### PR TITLE
fix missing LP btc address in parseQuote

### DIFF
--- a/connectors/rsk.go
+++ b/connectors/rsk.go
@@ -273,6 +273,9 @@ func parseQuote(q *types.Quote) (bindings.LiquidityBridgeContractQuote, error) {
 	if err := copyBtcAddr(q.BTCRefundAddr, pq.BtcRefundAddress[:]); err != nil {
 		return bindings.LiquidityBridgeContractQuote{}, fmt.Errorf("error parsing bitcoin refund address: %v", err)
 	}
+	if err := copyBtcAddr(q.LPBTCAddr, pq.LiquidityProviderBtcAddress[:]); err != nil {
+		return bindings.LiquidityBridgeContractQuote{}, fmt.Errorf("error parsing bitcoin liquidity provider address: %v", err)
+	}
 	if err := copyHex(q.LBCAddr, pq.LbcAddress[:]); err != nil {
 		return bindings.LiquidityBridgeContractQuote{}, fmt.Errorf("error parsing LBC address: %v", err)
 	}


### PR DESCRIPTION
I think the liquidity provider btc address was not being parsed when creating the struct **LiquidityBridgeContractQuote** that was then used to call the LBC function **hashQuote**.