### PR TITLE
Added btc watcher improvements

### DIFF
--- a/connectors/testmocks/addresswatcher_mock.go
+++ b/connectors/testmocks/addresswatcher_mock.go
@@ -1,0 +1,23 @@
+package testmocks
+
+import (
+	"github.com/btcsuite/btcutil"
+	"github.com/stretchr/testify/mock"
+)
+
+type AddressWatcherMock struct {
+	mock.Mock
+}
+
+func (a *AddressWatcherMock) OnNewConfirmation(txHash string, confirmations int64, amount btcutil.Amount) {
+	a.Called(txHash, confirmations, amount)
+}
+
+func (a *AddressWatcherMock) OnExpire() {
+	a.Called()
+}
+
+func (a *AddressWatcherMock) Done() <-chan struct{} {
+	args := a.Called()
+	return args.Get(0).(<-chan struct{})
+}

--- a/connectors/testmocks/btcclient_mock.go
+++ b/connectors/testmocks/btcclient_mock.go
@@ -1,0 +1,47 @@
+package testmocks
+
+import (
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/stretchr/testify/mock"
+)
+
+type BTCClientMock struct {
+	mock.Mock
+}
+
+func (B *BTCClientMock) ImportAddressRescan(address string, account string, rescan bool) error {
+	args := B.Called(address, account, rescan)
+	return args.Error(0)
+}
+
+func (B *BTCClientMock) GetTransaction(txHash *chainhash.Hash) (*btcjson.GetTransactionResult, error) {
+	args := B.Called(txHash)
+	return args.Get(0).(*btcjson.GetTransactionResult), args.Error(1)
+}
+
+func (B *BTCClientMock) GetBlockVerbose(blockHash *chainhash.Hash) (*btcjson.GetBlockVerboseResult, error) {
+	B.Called(blockHash)
+	return new(btcjson.GetBlockVerboseResult), nil
+}
+
+func (B *BTCClientMock) ListUnspentMinMaxAddresses(minConf, maxConf int, addrs []btcutil.Address) ([]btcjson.ListUnspentResult, error) {
+	args := B.Called(minConf, maxConf, addrs)
+	return args.Get(0).([]btcjson.ListUnspentResult), args.Error(1)
+}
+
+func (B *BTCClientMock) GetBlock(blockHash *chainhash.Hash) (*wire.MsgBlock, error) {
+	B.Called(blockHash)
+	return new(wire.MsgBlock), nil
+}
+
+func (B *BTCClientMock) GetRawTransaction(txHash *chainhash.Hash) (*btcutil.Tx, error) {
+	B.Called(txHash)
+	return new(btcutil.Tx), nil
+}
+
+func (B *BTCClientMock) Disconnect() {
+	B.Called()
+}

--- a/http/testmocks/btc_mock.go
+++ b/http/testmocks/btc_mock.go
@@ -2,6 +2,7 @@ package testmocks
 
 import (
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcutil"
 	"github.com/rsksmart/liquidity-provider-server/connectors"
 	"github.com/stretchr/testify/mock"
 	"time"
@@ -11,8 +12,8 @@ type BtcMock struct {
 	mock.Mock
 }
 
-func (b *BtcMock) AddAddressWatcher(address string, interval time.Duration, w connectors.AddressWatcher) error {
-	b.Called(address, interval, w)
+func (b *BtcMock) AddAddressWatcher(address string, minAmount btcutil.Amount, interval time.Duration, exp time.Time, w connectors.AddressWatcher) error {
+	b.Called(address, minAmount, interval, exp, w)
 	return nil
 }
 


### PR DESCRIPTION
- change how the address watcher monitors addresses to NOT stop monitoring right after the first deposit.
- address watcher should check that the deposit must have at least the negotiated amount (funds to advance + fees). Anything below that will be ignored.
- the address watcher should stop monitoring only after the time for deposit has elapsed, or the expected deposit deposit happens