### PR TITLE
update fee calculation

### DIFF
--- a/connectors/bitcoin.go
+++ b/connectors/bitcoin.go
@@ -90,8 +90,9 @@ type BTCClient interface {
 }
 
 type BTC struct {
-	c      BTCClient
-	params chaincfg.Params
+	c            BTCClient
+	params       chaincfg.Params
+	TxDefaultFee int64
 }
 
 func NewBTC(network string) (*BTC, error) {
@@ -141,6 +142,7 @@ func (btc *BTC) Connect(btcConfig BtcConfig) error {
 	}
 
 	btc.c = c
+	btc.TxDefaultFee = btcConfig.TxFee
 	return nil
 }
 
@@ -1036,6 +1038,9 @@ func (btc *BTC) SendBtcWithOpReturn(address string, amount uint64, opReturnConte
 		return "", err
 	}
 	tx.AddTxOut(wire.NewTxOut(0, opReturnScript))
+
+	fee := btc.TxDefaultFee * int64(tx.SerializeSize())
+	tx.TxOut[0].Value -= fee
 
 	signedTx, _, err := btc.c.SignRawTransactionWithWallet(tx)
 	if err != nil {


### PR DESCRIPTION
Hey guys I was doing more test and found this issue too.  Since we're not using send_to_address the value set with set_tx_fee is not used so some Tx are rejected because they don't have enough fee value, this doesn't happen on every pegout because in some cases the value of the spent tx input its bigger than the output value and that diff is used as fee but in this way that problem is solved for all txs