### PR TITLE
Fix extra gas for call for user

### DIFF
--- a/docker-compose/powpeg/pegin/Dockerfile
+++ b/docker-compose/powpeg/pegin/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update -y && \
 
 WORKDIR /code/powpeg
 
-ARG POWPEG_RELEASE="HOP"
-ARG POWPEG_VERSION="4.3.0.1"
+ARG POWPEG_RELEASE="FINGERROOT"
+ARG POWPEG_VERSION="5.0.0.0"
 
 RUN gitrev="${POWPEG_RELEASE}-${POWPEG_VERSION}" && \
     git init && \

--- a/docker-compose/powpeg/pegout/Dockerfile
+++ b/docker-compose/powpeg/pegout/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update -y && \
 
 WORKDIR /code/powpeg
 
-ARG POWPEG_RELEASE="HOP"
-ARG POWPEG_VERSION="4.3.0.1"
+ARG POWPEG_RELEASE="FINGERROOT"
+ARG POWPEG_VERSION="5.0.0.0"
 
 RUN gitrev="${POWPEG_RELEASE}-${POWPEG_VERSION}" && \
     git init && \

--- a/docker-compose/rskj/Dockerfile
+++ b/docker-compose/rskj/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update -y && \
 
 WORKDIR /code/rskj
 
-ARG RSKJ_RELEASE="HOP"
-ARG RSKJ_VERSION="4.4.0"
+ARG RSKJ_RELEASE="FINGERROOT"
+ARG RSKJ_VERSION="5.0.0"
 
 RUN gitrev="${RSKJ_RELEASE}-${RSKJ_VERSION}" && \
     git init && \

--- a/http/watcher.go
+++ b/http/watcher.go
@@ -58,7 +58,7 @@ type BTCAddressPegOutWatcher struct {
 
 const (
 	pegInGasLim           = 1500000
-	CFUExtraGas           = 150000
+	CFUExtraGas           = 180000
 	WatcherClosedError    = "watcher is closed; cannot handle OnNewConfirmation; hash: %v"
 	WatcherOnExpireError  = "watcher is closed; cannot handle OnExpire; hash: %v"
 	TimeExpiredError      = "time has expired for quote: %v"
@@ -295,7 +295,7 @@ func (w *BTCAddressWatcher) performRegisterPegIn(txHash string) error {
 
 	err = w.rsk.RegisterPegInWithoutTx(q, w.signature, rawTx, pmt, big.NewInt(bh))
 	if err != nil {
-		if strings.Contains(err.Error(), "Failed to validate BTC transaction") {
+		if strings.Contains(err.Error(), "LBC031") {
 			log.Debugf("bridge failed to validate BTC transaction. retrying on next confirmation. tx: %v", txHash)
 			return nil // allow retrying in case the bridge didn't acknowledge all required confirmations have occurred
 		}


### PR DESCRIPTION
https://rsklabs.atlassian.net/browse/GBI-1323

Bug cause: at some point the gas required for the call for user became more and we needed to increase that extra value. At first I thought this was related to RSKj version 5 update, but I did some test in v5.0.0 and v4.4.0 and the results were the same so my guess is that this increase in the cost of the call for user appeared in one of the recent changes in LBC and we didn't noticed.