### PR TITLE
fix derivation address construction for segwit refund address

### DIFF
--- a/connectors/bitcoin.go
+++ b/connectors/bitcoin.go
@@ -368,7 +368,7 @@ func DecodeBTCAddressWithVersion(address string) ([]byte, error) {
 		}
 		log.Debug("decoded btc address data", addressBts)
 		log.Debug("decoded version address data", data)
-		bts.Write(addressBts)
+		bts.Write(data)
 		return bts.Bytes(), nil
 	}
 	log.Debug("decoded btc address data", addressBts)


### PR DESCRIPTION
https://rsklabs.atlassian.net/browse/GBI-1432 
Important: this fixes the validation, but bridge still doesn’t support this kind of address