### PR TITLE
fix: add missing captcha header

### DIFF
--- a/internal/adapters/entrypoints/rest/common.go
+++ b/internal/adapters/entrypoints/rest/common.go
@@ -10,6 +10,11 @@ import (
 	"time"
 )
 
+const (
+	ContentTypeJson = "application/json"
+	ContentTypeForm = "application/x-www-form-urlencoded"
+)
+
 var RequestValidator = validator.New(validator.WithRequiredStructEnabled())
 
 type ErrorDetails = map[string]any
@@ -45,7 +50,7 @@ func JsonErrorResponse(w http.ResponseWriter, code int, response *ErrorResponse)
 
 func JsonResponseWithBody[T any](w http.ResponseWriter, statusCode int, body *T) {
 	var err error
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", ContentTypeJson)
 	w.WriteHeader(statusCode)
 	if body == nil {
 		return


### PR DESCRIPTION
## What 
Add `Content-Type` header in captcha validation request and polish captcha error handling

## Why
Because if we sent the form without the content type header the captcha service won't know how are we providing the token and will return an error.

P.S.
The layer where this bug was originated is the only layer that remains without unit test [(GBI-1874)](https://rsklabs.atlassian.net/browse/GBI-1874)