### PR TITLE
feat: add new state for pegin

### DIFF
--- a/internal/configuration/registry/usecase.go
+++ b/internal/configuration/registry/usecase.go
@@ -56,6 +56,7 @@ type UseCaseRegistry struct {
 	peginStatusUseCase            *pegin.StatusUseCase
 	pegoutStatusUseCase           *pegout.StatusUseCase
 	availableLiquidityUseCase     *liquidity_provider.GetAvailableLiquidityUseCase
+	updatePeginDepositUseCase     *watcher.UpdatePeginDepositUseCase
 }
 
 // NewUseCaseRegistry
@@ -226,6 +227,7 @@ func NewUseCaseRegistry(
 		peginStatusUseCase:        pegin.NewStatusUseCase(databaseRegistry.PeginRepository),
 		pegoutStatusUseCase:       pegout.NewStatusUseCase(databaseRegistry.PegoutRepository),
 		availableLiquidityUseCase: liquidity_provider.NewGetAvailableLiquidityUseCase(liquidityProvider, liquidityProvider, liquidityProvider),
+		updatePeginDepositUseCase: watcher.NewUpdatePeginDepositUseCase(databaseRegistry.PeginRepository),
 	}
 }
 

--- a/internal/configuration/registry/watcher.go
+++ b/internal/configuration/registry/watcher.go
@@ -29,6 +29,7 @@ func NewWatcherRegistry(
 		PeginDepositAddressWatcher: watcher.NewPeginDepositAddressWatcher(
 			useCaseRegistry.callForUserUseCase,
 			useCaseRegistry.getWatchedPeginQuoteUseCase,
+			useCaseRegistry.updatePeginDepositUseCase,
 			useCaseRegistry.expiredPeginQuoteUseCase,
 			btcRegistry.MonitoringWallet,
 			messaging.Rpc,

--- a/internal/entities/quote/pegin_quote.go
+++ b/internal/entities/quote/pegin_quote.go
@@ -15,12 +15,13 @@ const (
 type PeginState string
 
 const (
-	PeginStateWaitingForDeposit      PeginState = "WaitingForDeposit"
-	PeginStateTimeForDepositElapsed  PeginState = "TimeForDepositElapsed"
-	PeginStateCallForUserSucceeded   PeginState = "CallForUserSucceeded"
-	PeginStateCallForUserFailed      PeginState = "CallForUserFailed"
-	PeginStateRegisterPegInSucceeded PeginState = "RegisterPegInSucceeded"
-	PeginStateRegisterPegInFailed    PeginState = "RegisterPegInFailed"
+	PeginStateWaitingForDeposit              PeginState = "WaitingForDeposit"
+	PeginStateWaitingForDepositConfirmations PeginState = "WaitingForDepositConfirmations"
+	PeginStateTimeForDepositElapsed          PeginState = "TimeForDepositElapsed"
+	PeginStateCallForUserSucceeded           PeginState = "CallForUserSucceeded"
+	PeginStateCallForUserFailed              PeginState = "CallForUserFailed"
+	PeginStateRegisterPegInSucceeded         PeginState = "RegisterPegInSucceeded"
+	PeginStateRegisterPegInFailed            PeginState = "RegisterPegInFailed"
 )
 
 type PeginQuoteRepository interface {

--- a/internal/usecases/common.go
+++ b/internal/usecases/common.go
@@ -56,6 +56,7 @@ const (
 	PeginQuoteStatusId         UseCaseId = "PeginQuoteStatus"
 	PegoutQuoteStatusId        UseCaseId = "PegoutQuoteStatus"
 	GetAvailableLiquidityId    UseCaseId = "GetAvailableLiquidity"
+	UpdatePeginDepositId       UseCaseId = "UpdatePeginDeposit"
 )
 
 var (
@@ -73,6 +74,7 @@ var (
 	InsufficientAmountError     = errors.New("insufficient amount")
 	AlreadyRegisteredError      = errors.New("liquidity provider already registered")
 	ProviderNotResignedError    = errors.New("provided hasn't completed resignation process")
+	IllegalQuoteStateError      = errors.New("illegal quote state")
 )
 
 type ErrorArgs map[string]string

--- a/internal/usecases/pegout/send_pegout.go
+++ b/internal/usecases/pegout/send_pegout.go
@@ -91,6 +91,7 @@ func (useCase *SendPegoutUseCase) publishErrorEvent(
 	wrappedError := usecases.WrapUseCaseErrorArgs(usecases.SendPegoutId, err, usecases.ErrorArg("quoteHash", retainedQuote.QuoteHash))
 	if !recoverable {
 		retainedQuote.State = quote.PegoutStateSendPegoutFailed
+		wrappedError = errors.Join(wrappedError, usecases.NonRecoverableError)
 		if err = useCase.quoteRepository.UpdateRetainedQuote(ctx, retainedQuote); err != nil {
 			wrappedError = errors.Join(wrappedError, err)
 		}

--- a/internal/usecases/watcher/get_watched_pegin_quote_test.go
+++ b/internal/usecases/watcher/get_watched_pegin_quote_test.go
@@ -15,9 +15,11 @@ import (
 
 var retainedQuotes = []quote.RetainedPeginQuote{
 	{QuoteHash: "01", State: quote.PeginStateWaitingForDeposit},
+	{QuoteHash: "02", State: quote.PeginStateCallForUserSucceeded},
 	{QuoteHash: "04", State: quote.PeginStateCallForUserSucceeded},
 	{QuoteHash: "03", State: quote.PeginStateWaitingForDeposit},
 	{QuoteHash: "05", State: quote.PeginStateCallForUserFailed},
+	{QuoteHash: "07", State: quote.PeginStateWaitingForDepositConfirmations},
 }
 
 var peginQuotes = []quote.PeginQuote{
@@ -26,14 +28,16 @@ var peginQuotes = []quote.PeginQuote{
 	{Nonce: 3},
 	{Nonce: 4},
 	{Nonce: 5},
+	{Nonce: 7},
+	{Nonce: 8},
 }
 
 func TestGetWatchedPeginQuoteUseCase_Run_WaitingForDeposit(t *testing.T) {
 	quoteRepository := new(mocks.PeginQuoteRepositoryMock)
 	quoteRepository.On("GetRetainedQuoteByState", test.AnyCtx, quote.PeginStateWaitingForDeposit).
-		Return([]quote.RetainedPeginQuote{retainedQuotes[0], retainedQuotes[2]}, nil)
+		Return([]quote.RetainedPeginQuote{retainedQuotes[0], retainedQuotes[3]}, nil)
 	quoteRepository.On("GetQuote", test.AnyCtx, retainedQuotes[0].QuoteHash).Return(&peginQuotes[0], nil)
-	quoteRepository.On("GetQuote", test.AnyCtx, retainedQuotes[2].QuoteHash).Return(&peginQuotes[2], nil)
+	quoteRepository.On("GetQuote", test.AnyCtx, retainedQuotes[3].QuoteHash).Return(&peginQuotes[2], nil)
 	useCase := watcher.NewGetWatchedPeginQuoteUseCase(quoteRepository)
 	watchedQuotes, err := useCase.Run(context.Background(), quote.PeginStateWaitingForDeposit)
 	quoteRepository.AssertExpectations(t)
@@ -48,11 +52,53 @@ func TestGetWatchedPeginQuoteUseCase_Run_WaitingForDeposit(t *testing.T) {
 	}
 }
 
+func TestGetWatchedPeginQuoteUseCase_Run_WaitingForDepositConfirmations(t *testing.T) {
+	quoteRepository := new(mocks.PeginQuoteRepositoryMock)
+	quoteRepository.On("GetRetainedQuoteByState", test.AnyCtx, quote.PeginStateWaitingForDepositConfirmations).
+		Return([]quote.RetainedPeginQuote{retainedQuotes[1], retainedQuotes[5]}, nil)
+	quoteRepository.On("GetQuote", test.AnyCtx, retainedQuotes[1].QuoteHash).Return(&peginQuotes[1], nil)
+	quoteRepository.On("GetQuote", test.AnyCtx, retainedQuotes[5].QuoteHash).Return(&peginQuotes[5], nil)
+	useCase := watcher.NewGetWatchedPeginQuoteUseCase(quoteRepository)
+	watchedQuotes, err := useCase.Run(context.Background(), quote.PeginStateWaitingForDepositConfirmations)
+	quoteRepository.AssertExpectations(t)
+	assert.Len(t, watchedQuotes, 2)
+	require.NoError(t, err)
+	var parsedHash big.Int
+	for _, watchedQuote := range watchedQuotes {
+		parsedHash.SetString(watchedQuote.RetainedQuote.QuoteHash, 16)
+		// this is just to validate that the watched quotes are built with the correct pairs,
+		// the nonce is not related to the hash in the business logic
+		assert.Equal(t, parsedHash.Int64(), watchedQuote.PeginQuote.Nonce)
+	}
+}
+
+func TestGetWatchedPeginQuoteUseCase_Run_MoreThanOneState(t *testing.T) {
+	quoteRepository := new(mocks.PeginQuoteRepositoryMock)
+	quoteRepository.On("GetRetainedQuoteByState", test.AnyCtx, quote.PeginStateWaitingForDeposit).
+		Return([]quote.RetainedPeginQuote{retainedQuotes[0], retainedQuotes[3]}, nil)
+	quoteRepository.On("GetRetainedQuoteByState", test.AnyCtx, quote.PeginStateWaitingForDepositConfirmations).
+		Return([]quote.RetainedPeginQuote{retainedQuotes[1], retainedQuotes[5]}, nil)
+	quoteRepository.On("GetQuote", test.AnyCtx, retainedQuotes[1].QuoteHash).Return(&peginQuotes[1], nil)
+	quoteRepository.On("GetQuote", test.AnyCtx, retainedQuotes[5].QuoteHash).Return(&peginQuotes[5], nil)
+	quoteRepository.On("GetQuote", test.AnyCtx, retainedQuotes[0].QuoteHash).Return(&peginQuotes[0], nil)
+	quoteRepository.On("GetQuote", test.AnyCtx, retainedQuotes[3].QuoteHash).Return(&peginQuotes[2], nil)
+	useCase := watcher.NewGetWatchedPeginQuoteUseCase(quoteRepository)
+	watchedQuotes, err := useCase.Run(context.Background(), quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations)
+	quoteRepository.AssertExpectations(t)
+	assert.Len(t, watchedQuotes, 4)
+	require.NoError(t, err)
+	var parsedHash big.Int
+	for _, watchedQuote := range watchedQuotes {
+		parsedHash.SetString(watchedQuote.RetainedQuote.QuoteHash, 16)
+		assert.Equal(t, parsedHash.Int64(), watchedQuote.PeginQuote.Nonce)
+	}
+}
+
 func TestGetWatchedPeginQuoteUseCase_Run_CallForUserSucceed(t *testing.T) {
 	quoteRepository := new(mocks.PeginQuoteRepositoryMock)
 	quoteRepository.On("GetRetainedQuoteByState", test.AnyCtx, quote.PeginStateCallForUserSucceeded).
-		Return([]quote.RetainedPeginQuote{retainedQuotes[1]}, nil)
-	quoteRepository.On("GetQuote", test.AnyCtx, retainedQuotes[1].QuoteHash).Return(&peginQuotes[3], nil)
+		Return([]quote.RetainedPeginQuote{retainedQuotes[2]}, nil)
+	quoteRepository.On("GetQuote", test.AnyCtx, retainedQuotes[2].QuoteHash).Return(&peginQuotes[3], nil)
 	useCase := watcher.NewGetWatchedPeginQuoteUseCase(quoteRepository)
 	watchedQuotes, err := useCase.Run(context.Background(), quote.PeginStateCallForUserSucceeded)
 	quoteRepository.AssertExpectations(t)

--- a/internal/usecases/watcher/update_pegin_deposit.go
+++ b/internal/usecases/watcher/update_pegin_deposit.go
@@ -1,0 +1,42 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
+)
+
+type UpdatePeginDepositUseCase struct {
+	peginRepository quote.PeginQuoteRepository
+}
+
+func NewUpdatePeginDepositUseCase(peginRepository quote.PeginQuoteRepository) *UpdatePeginDepositUseCase {
+	return &UpdatePeginDepositUseCase{peginRepository: peginRepository}
+}
+
+func (useCase *UpdatePeginDepositUseCase) Run(
+	ctx context.Context,
+	watchedQuote quote.WatchedPeginQuote,
+	block blockchain.BitcoinBlockInformation,
+	deposit blockchain.BitcoinTransactionInformation,
+) (quote.WatchedPeginQuote, error) {
+	sentAmount := deposit.AmountToAddress(watchedQuote.RetainedQuote.DepositAddress)
+	enoughAmount := sentAmount.Cmp(watchedQuote.PeginQuote.Total()) >= 0
+	sentBeforeExpire := block.Time.Before(watchedQuote.PeginQuote.ExpireTime())
+
+	if !enoughAmount || !sentBeforeExpire {
+		return quote.WatchedPeginQuote{}, usecases.WrapUseCaseError(usecases.UpdatePeginDepositId, errors.New("invalid bitcoin transaction for quote"))
+	} else if watchedQuote.RetainedQuote.State != quote.PeginStateWaitingForDeposit {
+		return quote.WatchedPeginQuote{}, usecases.WrapUseCaseError(usecases.UpdatePeginDepositId, usecases.IllegalQuoteStateError)
+	}
+
+	watchedQuote.RetainedQuote.State = quote.PeginStateWaitingForDepositConfirmations
+	watchedQuote.RetainedQuote.UserBtcTxHash = deposit.Hash
+
+	if err := useCase.peginRepository.UpdateRetainedQuote(ctx, watchedQuote.RetainedQuote); err != nil {
+		return quote.WatchedPeginQuote{}, usecases.WrapUseCaseError(usecases.UpdatePeginDepositId, err)
+	}
+	return watchedQuote, nil
+}

--- a/internal/usecases/watcher/update_pegin_deposit_test.go
+++ b/internal/usecases/watcher/update_pegin_deposit_test.go
@@ -1,0 +1,122 @@
+package watcher_test
+
+import (
+	"context"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases/watcher"
+	"github.com/rsksmart/liquidity-provider-server/test"
+	"github.com/rsksmart/liquidity-provider-server/test/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestUpdatePeginDepositUseCase_Run(t *testing.T) {
+	peginQuote := quote.PeginQuote{
+		Value:              entities.NewWei(5000),
+		CallFee:            entities.NewWei(100),
+		ProductFeeAmount:   1,
+		GasFee:             entities.NewWei(150),
+		AgreementTimestamp: 900,
+		TimeForDeposit:     200,
+	}
+	retainedQuote := quote.RetainedPeginQuote{
+		State:          quote.PeginStateWaitingForDeposit,
+		DepositAddress: test.AnyAddress,
+	}
+	quoteRepository := new(mocks.PeginQuoteRepositoryMock)
+	block := blockchain.BitcoinBlockInformation{
+		Hash:   [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+		Height: big.NewInt(500),
+		Time:   time.Unix(1000, 0),
+	}
+	tx := blockchain.BitcoinTransactionInformation{
+		Hash:          test.AnyString,
+		Confirmations: 5,
+		Outputs: map[string][]*entities.Wei{
+			test.AnyAddress: {entities.NewWei(5251)},
+		},
+	}
+	quoteRepository.On(
+		"UpdateRetainedQuote",
+		test.AnyCtx,
+		mock.MatchedBy(func(q quote.RetainedPeginQuote) bool {
+			return q.UserBtcTxHash == test.AnyString && q.State == quote.PeginStateWaitingForDepositConfirmations
+		}),
+	).Return(nil)
+	useCase := watcher.NewUpdatePeginDepositUseCase(quoteRepository)
+	watchedPeginQuote, err := useCase.Run(context.Background(), quote.NewWatchedPeginQuote(peginQuote, retainedQuote), block, tx)
+	quoteRepository.AssertExpectations(t)
+	require.NoError(t, err)
+	assert.Equal(t, quote.PeginStateWaitingForDepositConfirmations, watchedPeginQuote.RetainedQuote.State)
+	assert.Equal(t, tx.Hash, watchedPeginQuote.RetainedQuote.UserBtcTxHash)
+}
+
+func TestUpdatePeginDepositUseCase_Run_ErrorHandling(t *testing.T) {
+	const bitcoinTxErrorMsg = "invalid bitcoin transaction for quote"
+	peginQuote := quote.PeginQuote{
+		Value:              entities.NewWei(1),
+		CallFee:            entities.NewWei(2),
+		ProductFeeAmount:   3,
+		GasFee:             entities.NewWei(4),
+		AgreementTimestamp: 500,
+		TimeForDeposit:     50,
+	}
+	t.Run("Fail by illegal quote state", func(t *testing.T) {
+		states := []quote.PeginState{
+			quote.PeginStateWaitingForDepositConfirmations,
+			quote.PeginStateTimeForDepositElapsed,
+			quote.PeginStateCallForUserSucceeded,
+			quote.PeginStateCallForUserFailed,
+			quote.PeginStateRegisterPegInSucceeded,
+			quote.PeginStateRegisterPegInFailed,
+		}
+		quoteRepository := new(mocks.PeginQuoteRepositoryMock)
+		block := blockchain.BitcoinBlockInformation{Time: time.Unix(510, 0)}
+		tx := blockchain.BitcoinTransactionInformation{Outputs: map[string][]*entities.Wei{test.AnyAddress: {entities.NewWei(10)}}}
+		for _, state := range states {
+			retainedQuote := quote.RetainedPeginQuote{State: state, DepositAddress: test.AnyAddress}
+			useCase := watcher.NewUpdatePeginDepositUseCase(quoteRepository)
+			watchedPeginQuote, err := useCase.Run(context.Background(), quote.NewWatchedPeginQuote(peginQuote, retainedQuote), block, tx)
+			require.ErrorIs(t, err, usecases.IllegalQuoteStateError)
+			assert.Empty(t, watchedPeginQuote)
+		}
+	})
+	t.Run("Fail by bitcoin transaction amount", func(t *testing.T) {
+		quoteRepository := new(mocks.PeginQuoteRepositoryMock)
+		block := blockchain.BitcoinBlockInformation{Time: time.Unix(510, 0)}
+		tx := blockchain.BitcoinTransactionInformation{Outputs: map[string][]*entities.Wei{test.AnyAddress: {entities.NewWei(5)}}}
+		retainedQuote := quote.RetainedPeginQuote{State: quote.PeginStateWaitingForDeposit, DepositAddress: test.AnyAddress}
+		useCase := watcher.NewUpdatePeginDepositUseCase(quoteRepository)
+		watchedPeginQuote, err := useCase.Run(context.Background(), quote.NewWatchedPeginQuote(peginQuote, retainedQuote), block, tx)
+		require.ErrorContains(t, err, bitcoinTxErrorMsg)
+		assert.Empty(t, watchedPeginQuote)
+	})
+	t.Run("Fail by bitcoin transaction timestamp", func(t *testing.T) {
+		quoteRepository := new(mocks.PeginQuoteRepositoryMock)
+		block := blockchain.BitcoinBlockInformation{Time: time.Unix(2000, 0)}
+		tx := blockchain.BitcoinTransactionInformation{Outputs: map[string][]*entities.Wei{test.AnyAddress: {entities.NewWei(10)}}}
+		retainedQuote := quote.RetainedPeginQuote{State: quote.PeginStateWaitingForDeposit, DepositAddress: test.AnyAddress}
+		useCase := watcher.NewUpdatePeginDepositUseCase(quoteRepository)
+		watchedPeginQuote, err := useCase.Run(context.Background(), quote.NewWatchedPeginQuote(peginQuote, retainedQuote), block, tx)
+		require.ErrorContains(t, err, bitcoinTxErrorMsg)
+		assert.Empty(t, watchedPeginQuote)
+	})
+	t.Run("Fail to update retained quote", func(t *testing.T) {
+		quoteRepository := new(mocks.PeginQuoteRepositoryMock)
+		quoteRepository.On("UpdateRetainedQuote", test.AnyCtx, mock.Anything).Return(assert.AnError)
+		block := blockchain.BitcoinBlockInformation{Time: time.Unix(510, 0)}
+		tx := blockchain.BitcoinTransactionInformation{Outputs: map[string][]*entities.Wei{test.AnyAddress: {entities.NewWei(10)}}}
+		retainedQuote := quote.RetainedPeginQuote{State: quote.PeginStateWaitingForDeposit, DepositAddress: test.AnyAddress}
+		useCase := watcher.NewUpdatePeginDepositUseCase(quoteRepository)
+		watchedPeginQuote, err := useCase.Run(context.Background(), quote.NewWatchedPeginQuote(peginQuote, retainedQuote), block, tx)
+		require.Error(t, err)
+		assert.Empty(t, watchedPeginQuote)
+	})
+}

--- a/internal/usecases/watcher/update_pegout_deposit.go
+++ b/internal/usecases/watcher/update_pegout_deposit.go
@@ -20,7 +20,7 @@ func (useCase *UpdatePegoutQuoteDepositUseCase) Run(ctx context.Context, watched
 	if !deposit.IsValidForQuote(watchedQuote.PegoutQuote) {
 		return quote.WatchedPegoutQuote{}, usecases.WrapUseCaseError(usecases.UpdatePegoutDepositId, errors.New("deposit not valid for quote"))
 	} else if watchedQuote.RetainedQuote.State != quote.PegoutStateWaitingForDeposit {
-		return quote.WatchedPegoutQuote{}, usecases.WrapUseCaseError(usecases.UpdatePegoutDepositId, errors.New("illegal quote state"))
+		return quote.WatchedPegoutQuote{}, usecases.WrapUseCaseError(usecases.UpdatePegoutDepositId, usecases.IllegalQuoteStateError)
 	}
 	watchedQuote.RetainedQuote.State = quote.PegoutStateWaitingForDepositConfirmations
 	watchedQuote.RetainedQuote.UserRskTxHash = deposit.TxHash

--- a/internal/usecases/watcher/update_pegout_deposit_test.go
+++ b/internal/usecases/watcher/update_pegout_deposit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases/watcher"
 	"github.com/rsksmart/liquidity-provider-server/test"
 	"github.com/rsksmart/liquidity-provider-server/test/mocks"
@@ -153,7 +154,7 @@ func TestUpdatePegoutQuoteDepositUseCase_Run_IllegalState(t *testing.T) {
 		quoteReporitory.AssertNotCalled(t, "UpsertPegoutDeposit")
 		assert.Equal(t, quote.WatchedPegoutQuote{}, watchedPegoutQuote)
 		require.Error(t, err)
-		assert.True(t, strings.Contains(err.Error(), "illegal quote state"))
+		require.ErrorIs(t, err, usecases.IllegalQuoteStateError)
 	}
 }
 


### PR DESCRIPTION
## What
Add the `WaitingForDepositConfirmations` state in the pegin

## Why
Because of two reasons:
- The states in the pegin and pegout weren't consistent because pegout had both `WaitingForDeposit` and `WaitingForDepositConfirmations` but pegin only had `WaitingForDeposit`
- It is useful to differentiate between the state where the tx has been done but doesn't have enough confirmations yet and the state where the tx hasn't been done at all

## Task
https://rsklabs.atlassian.net/browse/GBI-1860