### PR TITLE
fix: move min pegout validation to set config

### DIFF
--- a/internal/configuration/registry/usecase.go
+++ b/internal/configuration/registry/usecase.go
@@ -197,6 +197,7 @@ func NewUseCaseRegistry(
 			databaseRegistry.LiquidityProviderRepository,
 			rskRegistry.Wallet,
 			signingHashFunction,
+			rskRegistry.Contracts,
 		),
 		getConfigurationUseCase: liquidity_provider.NewGetConfigUseCase(liquidityProvider, liquidityProvider, liquidityProvider),
 		loginUseCase:            liquidity_provider.NewLoginUseCase(databaseRegistry.LiquidityProviderRepository, messaging.EventBus),

--- a/internal/usecases/liquidity_provider/set_pegout_config.go
+++ b/internal/usecases/liquidity_provider/set_pegout_config.go
@@ -3,6 +3,7 @@ package liquidity_provider
 import (
 	"context"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 )
@@ -11,17 +12,24 @@ type SetPegoutConfigUseCase struct {
 	lpRepository liquidity_provider.LiquidityProviderRepository
 	signer       entities.Signer
 	hashFunc     entities.HashFunction
+	contracts    blockchain.RskContracts
 }
 
 func NewSetPegoutConfigUseCase(
 	lpRepository liquidity_provider.LiquidityProviderRepository,
 	signer entities.Signer,
 	hashFunc entities.HashFunction,
+	contracts blockchain.RskContracts,
 ) *SetPegoutConfigUseCase {
-	return &SetPegoutConfigUseCase{lpRepository: lpRepository, signer: signer, hashFunc: hashFunc}
+	return &SetPegoutConfigUseCase{lpRepository: lpRepository, signer: signer, hashFunc: hashFunc, contracts: contracts}
 }
 
 func (useCase *SetPegoutConfigUseCase) Run(ctx context.Context, config liquidity_provider.PegoutConfiguration) error {
+	var err error
+	if err = usecases.ValidateMinLockValue(usecases.SetPegoutConfigId, useCase.contracts.Bridge, config.BridgeTransactionMin); err != nil {
+		return err
+	}
+
 	signedConfig, err := usecases.SignConfiguration(usecases.SetPegoutConfigId, useCase.signer, useCase.hashFunc, config)
 	if err != nil {
 		return err

--- a/internal/usecases/pegout/get_pegout_quote.go
+++ b/internal/usecases/pegout/get_pegout_quote.go
@@ -108,10 +108,6 @@ func (useCase *GetQuoteUseCase) Run(ctx context.Context, request QuoteRequest) (
 		return GetPegoutQuoteResult{}, err
 	}
 
-	if err = usecases.ValidateMinLockValue(usecases.GetPegoutQuoteId, useCase.contracts.Bridge, pegoutQuote.Total()); err != nil {
-		return GetPegoutQuoteResult{}, err
-	}
-
 	if hash, err = useCase.persistQuote(ctx, pegoutQuote); err != nil {
 		return GetPegoutQuoteResult{}, err
 	}

--- a/internal/usecases/pegout/get_pegout_quote_test.go
+++ b/internal/usecases/pegout/get_pegout_quote_test.go
@@ -23,7 +23,6 @@ func TestGetQuoteUseCase_Run(t *testing.T) {
 	feeCollector := new(mocks.FeeCollectorMock)
 	feeCollector.On("DaoFeePercentage").Return(uint64(0), nil)
 	bridge := new(mocks.BridgeMock)
-	bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000000), nil)
 	lbc := new(mocks.LbcMock)
 	lbc.On("GetAddress").Return("0x1234")
 	lbc.On("HashPegoutQuote", mock.Anything).Return("0x9876543210", nil)
@@ -242,17 +241,6 @@ func getQuoteUseCaseUnexpectedErrorSetups() test.Table[func(
 				rsk.On("GasPrice", test.AnyCtx).Return(entities.NewWei(50000000), nil)
 				rsk.On("GetHeight", test.AnyCtx).Return(uint64(100), nil)
 				feeCollector.On("DaoFeePercentage").Return(uint64(0), nil)
-				bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(0), assert.AnError)
-				btcWallet.On("EstimateTxFees", mock.Anything, mock.Anything).Return(entities.NewWei(1000), nil)
-			},
-		},
-		{
-			Value: func(rsk *mocks.RootstockRpcServerMock, feeCollector *mocks.FeeCollectorMock, bridge *mocks.BridgeMock,
-				lbc *mocks.LbcMock, lp *mocks.ProviderMock, btcWallet *mocks.BtcWalletMock, pegoutQuoteRepository *mocks.PegoutQuoteRepositoryMock) {
-				rsk.On("GasPrice", test.AnyCtx).Return(entities.NewWei(50000000), nil)
-				rsk.On("GetHeight", test.AnyCtx).Return(uint64(100), nil)
-				feeCollector.On("DaoFeePercentage").Return(uint64(0), nil)
-				bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000000), nil)
 				lbc.On("GetAddress").Return("0x1234")
 				lbc.On("HashPegoutQuote", mock.Anything).Return("0x9876543210", nil)
 				pegoutQuoteRepository.On("InsertQuote", test.AnyCtx, mock.Anything, mock.Anything).Return(assert.AnError)
@@ -265,7 +253,6 @@ func getQuoteUseCaseUnexpectedErrorSetups() test.Table[func(
 				rsk.On("GasPrice", test.AnyCtx).Return(entities.NewWei(50000000), nil)
 				rsk.On("GetHeight", test.AnyCtx).Return(uint64(100), nil)
 				feeCollector.On("DaoFeePercentage").Return(uint64(0), nil)
-				bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000000), nil)
 				lbc.On("GetAddress").Return("0x1234")
 				lbc.On("HashPegoutQuote", mock.Anything).Return("", assert.AnError)
 				pegoutQuoteRepository.On("InsertQuote", test.AnyCtx, mock.Anything, mock.Anything).Return(nil)
@@ -287,7 +274,6 @@ func getQuoteUseCaseUnexpectedErrorSetups() test.Table[func(
 				rsk.On("GasPrice", test.AnyCtx).Return(entities.NewWei(50000000), nil)
 				rsk.On("GetHeight", test.AnyCtx).Return(uint64(100), nil)
 				feeCollector.On("DaoFeePercentage").Return(uint64(0), nil)
-				bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000000), nil)
 				lbc.On("GetAddress").Return("0x1234")
 				lbc.On("HashPegoutQuote", mock.Anything).Return("0x2134", nil)
 				pegoutQuoteRepository.On("InsertQuote", test.AnyCtx, mock.Anything, mock.Anything).Return(nil)
@@ -311,7 +297,6 @@ func getQuoteUseCaseUnexpectedErrorSetups() test.Table[func(
 				rsk.On("EstimateGas", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(entities.NewWei(0), assert.AnError)
 				feeCollector.On("DaoFeePercentage").Return(uint64(12), nil)
-				bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000000), nil)
 				lbc.On("GetAddress").Return("0x1234")
 				lbc.On("HashPegoutQuote", mock.Anything).Return("0x4321", nil)
 				pegoutQuoteRepository.On("InsertQuote", test.AnyCtx, mock.Anything, mock.Anything).Return(nil)


### PR DESCRIPTION
## What
Move the validation of the minimum pegout from the `pegout.GetQuoteUseCase` to `liquidity_provider.SetPegoutConfigUseCase`

## Why
Because now the native pegout is done in a separated process so it is not related to the amount of one quote. 

P.S.
This was noticed by QA when playing with different configurations of the LP tool