### PR TITLE
fix: get pegin quote minimum validation

### DIFF
--- a/internal/usecases/pegin/get_pegin_quote.go
+++ b/internal/usecases/pegin/get_pegin_quote.go
@@ -110,7 +110,7 @@ func (useCase *GetQuoteUseCase) Run(ctx context.Context, request QuoteRequest) (
 		return GetPeginQuoteResult{}, err
 	}
 
-	if err = usecases.ValidateMinLockValue(usecases.GetPeginQuoteId, useCase.contracts.Bridge, peginQuote.Total()); err != nil {
+	if err = usecases.ValidateMinLockValue(usecases.GetPeginQuoteId, useCase.contracts.Bridge, peginQuote.Value); err != nil {
 		return GetPeginQuoteResult{}, err
 	}
 

--- a/internal/usecases/pegin/get_pegin_quote_test.go
+++ b/internal/usecases/pegin/get_pegin_quote_test.go
@@ -150,6 +150,46 @@ func validateRequestTestCases() test.Table[func(btc *mocks.BtcRpcMock) pegin.Quo
 	}
 }
 
+func TestGetQuoteUseCase_Run_BridgeMinimum(t *testing.T) {
+	lp := new(mocks.ProviderMock)
+	peginQuoteRepository := new(mocks.PeginQuoteRepositoryMock)
+	rsk := new(mocks.RootstockRpcServerMock)
+	bridge := new(mocks.BridgeMock)
+	feeCollector := new(mocks.FeeCollectorMock)
+	btc := new(mocks.BtcRpcMock)
+	lbc := new(mocks.LbcMock)
+	contracts := blockchain.RskContracts{FeeCollector: feeCollector, Bridge: bridge, Lbc: lbc}
+	rpc := blockchain.Rpc{Rsk: rsk, Btc: btc}
+
+	lbc.On("GetAddress").Return(lbcAddress).Once()
+	btc.On("ValidateAddress", mock.Anything).Return(nil).Once()
+	bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(2000), nil).Once()
+	lp.On("PeginConfiguration", test.AnyCtx).Return(getPeginConfiguration()).Once()
+	lp.On("GeneralConfiguration", test.AnyCtx).Return(getGeneralConfiguration()).Once()
+	lp.On("RskAddress").Return(test.AnyAddress).Once()
+	lp.On("BtcAddress").Return(test.AnyAddress).Once()
+	rsk.EXPECT().EstimateGas(test.AnyCtx, mock.Anything, mock.Anything, mock.Anything).Return(entities.NewWei(100), nil).Once()
+	rsk.EXPECT().GasPrice(test.AnyCtx).Return(entities.NewWei(10), nil).Once()
+	feeCollector.On("DaoFeePercentage").Return(uint64(0), nil).Once()
+	bridge.On("GetFedAddress").Return(fedAddress, nil).Once()
+	useCase := pegin.NewGetQuoteUseCase(rpc, contracts, peginQuoteRepository, lp, lp, test.AnyAddress)
+	t.Run("Should compare bridge minimum against quote value", func(t *testing.T) {
+		// we compare 1999 of the quote value with the 2000 of the minimum, so the total is higher than the minimum due to the fees
+		quoteValue := entities.NewWei(1999)
+		request := pegin.NewQuoteRequest(test.AnyRskAddress, []byte{1}, quoteValue, test.AnyRskAddress, test.AnyBtcAddress)
+		result, err := useCase.Run(context.Background(), request)
+		assert.Empty(t, result)
+		require.ErrorIs(t, err, usecases.TxBelowMinimumError)
+	})
+
+	lp.AssertExpectations(t)
+	rsk.AssertExpectations(t)
+	bridge.AssertExpectations(t)
+	feeCollector.AssertExpectations(t)
+	btc.AssertExpectations(t)
+	peginQuoteRepository.AssertExpectations(t)
+}
+
 func TestGetQuoteUseCase_Run_ErrorHandling(t *testing.T) {
 	userRskAddress := "0x79568c2989232dCa1840087D73d403602364c0D4"
 	request := pegin.NewQuoteRequest(userRskAddress, []byte{1}, entities.NewWei(5000), userRskAddress, "mnYcQxCZBbmLzNfE9BhV7E8E2u7amdz5y6")

--- a/test/utils.go
+++ b/test/utils.go
@@ -24,12 +24,14 @@ var (
 )
 
 const (
-	AnyAddress  = "any address"
-	AnyString   = "any value"
-	AnyHash     = "any hash"
-	AnyUrl      = "url.com"
-	keyPath     = "../../docker-compose/localstack/local-key.json"
-	KeyPassword = "test"
+	AnyAddress    = "any address"
+	AnyRskAddress = "0x79568c2989232dCa1840087D73d403602364c0D4"
+	AnyBtcAddress = "mvL2bVzGUeC9oqVyQWJ4PxQspFzKgjzAqe"
+	AnyString     = "any value"
+	AnyHash       = "any hash"
+	AnyUrl        = "url.com"
+	keyPath       = "../../docker-compose/localstack/local-key.json"
+	KeyPassword   = "test"
 )
 
 type Case[V, R any] struct {


### PR DESCRIPTION
## What
Use `Value` field in the comparison against the bridge's minimum instead of the result of `Total()` function (which includes all the fees) in the `GetPeginQuoteUseCase`

## Why
This is a fix to the security finding VULN-555

## Task
https://rsklabs.atlassian.net/browse/GBI-2017
