### PR TITLE
feat: remove btcRefundAddress from pegin request

### DIFF
--- a/internal/adapters/dataproviders/bitcoin/rpc.go
+++ b/internal/adapters/dataproviders/bitcoin/rpc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	merkle "github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcutil"
+	"strings"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -244,6 +245,10 @@ func (rpc *bitcoindRpc) GetCoinbaseInformation(txHash string) (blockchain.BtcCoi
 		WitnessMerkleRoot:    ToSwappedBytes32(merkle.CalcMerkleRoot(txs, true)),
 		WitnessReservedValue: ToSwappedBytes32(witnessReservedValue),
 	}, nil
+}
+
+func (rpc *bitcoindRpc) NetworkName() string {
+	return strings.ToLower(rpc.conn.NetworkParams.Name)
 }
 
 func (rpc *bitcoindRpc) getTxBlock(txHash string) (*wire.MsgBlock, *chainhash.Hash, error) {

--- a/internal/adapters/dataproviders/bitcoin/rpc_test.go
+++ b/internal/adapters/dataproviders/bitcoin/rpc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/dataproviders/bitcoin"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
+	"github.com/rsksmart/liquidity-provider-server/test"
 	"github.com/rsksmart/liquidity-provider-server/test/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -685,4 +686,17 @@ func getTestBlock(t *testing.T, filename string) *btcutil.Block {
 	block, err := btcutil.NewBlockFromBytes(blockBytes)
 	require.NoError(t, err)
 	return block
+}
+
+func TestBitcoindRpc_NetworkName(t *testing.T) {
+	table := test.Table[*chaincfg.Params, string]{
+		{Value: &chaincfg.MainNetParams, Result: "mainnet"},
+		{Value: &chaincfg.TestNet3Params, Result: "testnet3"},
+		{Value: &chaincfg.RegressionNetParams, Result: "regtest"},
+		{Value: &chaincfg.SimNetParams, Result: "simnet"},
+	}
+	test.RunTable(t, table, func(p *chaincfg.Params) string {
+		rpc := bitcoin.NewBitcoindRpc(bitcoin.NewConnection(p, &mocks.ClientAdapterMock{}))
+		return rpc.NetworkName()
+	})
 }

--- a/internal/adapters/entrypoints/rest/common_test.go
+++ b/internal/adapters/entrypoints/rest/common_test.go
@@ -168,7 +168,7 @@ func TestValidateRequest(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&response))
 		assert.Contains(t, response.Message, "validation error")
-		assert.Len(t, response.Details, 3)
+		assert.Len(t, response.Details, 2)
 		for key := range response.Details {
 			assert.Contains(t, response.Details[key], "validation failed")
 		}

--- a/internal/adapters/entrypoints/rest/handlers/get_pegin_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/get_pegin_quote.go
@@ -41,7 +41,6 @@ func NewGetPeginQuoteHandler(useCase *pegin.GetQuoteUseCase) http.HandlerFunc {
 			callArgument,
 			entities.NewUWei(quoteRequest.ValueToTransfer),
 			quoteRequest.RskRefundAddress,
-			quoteRequest.BitcoinRefundAddress,
 		)
 
 		result, err = useCase.Run(req.Context(), peginRequest)

--- a/internal/entities/blockchain/bitcoin.go
+++ b/internal/entities/blockchain/bitcoin.go
@@ -34,6 +34,11 @@ const (
 	BtcTxInfoErrorTemplate      = "error getting Bitcoin transaction information (%s): %v"
 )
 
+const (
+	BitcoinMainnetP2PKHZeroAddress = "1111111111111111111114oLvT2"
+	BitcoinTestnetP2PKHZeroAddress = "mfWxJ45yp2SFn7UciZyNpvDKrzbhyfKrY8"
+)
+
 // IsSupportedBtcAddress checks if flyover protocol supports the given address
 func IsSupportedBtcAddress(address string) bool {
 	return IsTestnetBtcAddress(address) || IsMainnetBtcAddress(address) || IsRegtestBtcAddress(address)
@@ -106,6 +111,7 @@ type BitcoinNetwork interface {
 	GetTransactionBlockInfo(txHash string) (BitcoinBlockInformation, error)
 	// GetCoinbaseInformation returns the coinbase transaction information of the block that includes txHash
 	GetCoinbaseInformation(txHash string) (BtcCoinbaseTransactionInformation, error)
+	NetworkName() string
 }
 
 type BitcoinTransactionInformation struct {

--- a/internal/entities/blockchain/bitcoin_test.go
+++ b/internal/entities/blockchain/bitcoin_test.go
@@ -1,10 +1,12 @@
 package blockchain_test
 
 import (
+	"github.com/btcsuite/btcd/btcutil/base58"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -620,4 +622,19 @@ func TestIsTaprootAddress(t *testing.T) {
 	for _, address := range others {
 		assert.Falsef(t, blockchain.IsBtcP2TRAddress(address), "IsTaprootAddress should return false for address %s", address)
 	}
+}
+
+func TestZeroAddresses(t *testing.T) {
+	t.Run("Mainnet zero address should be an array of zeros", func(t *testing.T) {
+		result, version, err := base58.CheckDecode(blockchain.BitcoinMainnetP2PKHZeroAddress)
+		require.NoError(t, err)
+		assert.Equal(t, make([]byte, 20), result)
+		assert.Equal(t, uint8(0x00), version)
+	})
+	t.Run("Testnet zero address should be an array of zeros", func(t *testing.T) {
+		result, version, err := base58.CheckDecode(blockchain.BitcoinTestnetP2PKHZeroAddress)
+		require.NoError(t, err)
+		assert.Equal(t, make([]byte, 20), result)
+		assert.Equal(t, uint8(0x6f), version)
+	})
 }

--- a/pkg/pegin.go
+++ b/pkg/pegin.go
@@ -10,7 +10,6 @@ type PeginQuoteRequest struct {
 	CallContractArguments    string `json:"callContractArguments" required:"" validate:"" example:"0x0" description:"Contract data"`
 	ValueToTransfer          uint64 `json:"valueToTransfer" required:"" validate:"required" example:"0x0" description:"Value to send in the call"`
 	RskRefundAddress         string `json:"rskRefundAddress" required:"" validate:"required,eth_addr" example:"0x0" description:"User RSK refund address"`
-	BitcoinRefundAddress     string `json:"bitcoinRefundAddress" required:"" validate:"required" example:"0x0" description:"User Bitcoin refund address. Note: Must be a legacy address, segwit addresses are not accepted"`
 }
 
 type PeginQuoteDTO struct {

--- a/test/integration/pegin_test.go
+++ b/test/integration/pegin_test.go
@@ -74,7 +74,6 @@ func getPeginQuoteTest(s *IntegrationTestSuite, url string, quoteResponse *pkg.G
 		CallContractArguments:    "",
 		ValueToTransfer:          600000000000000000,
 		RskRefundAddress:         "0x79568c2989232dCa1840087D73d403602364c0D4",
-		BitcoinRefundAddress:     "n1zjV3WxJgA4dBfS5aMiEHtZsjTUvAL7p7",
 	}
 
 	result, err := execute[[]pkg.GetPeginQuoteResponse](Execution{

--- a/test/mocks/btc_rpc_mock.go
+++ b/test/mocks/btc_rpc_mock.go
@@ -64,3 +64,8 @@ func (m *BtcRpcMock) GetCoinbaseInformation(txHash string) (blockchain.BtcCoinba
 	args := m.Called(txHash)
 	return args.Get(0).(blockchain.BtcCoinbaseTransactionInformation), args.Error(1)
 }
+
+func (m *BtcRpcMock) NetworkName() string {
+	args := m.Called()
+	return args.String(0)
+}


### PR DESCRIPTION
## What
Remove `btcRefundAddress` field from pegin request and replace it internally with network corresponding zero address

## Why
To remove an unnecessary BTC address field from the request and reduce the friction with the user

## Task
https://rsklabs.atlassian.net/browse/GBI-1907