### PR TITLE
feat: disable quote cleaner watcher

### DIFF
--- a/cmd/application/lps/application.go
+++ b/cmd/application/lps/application.go
@@ -146,7 +146,6 @@ func (app *Application) prepareWatchers() ([]watcher.Watcher, error) {
 	watchers := []watcher.Watcher{
 		app.watcherRegistry.PeginDepositAddressWatcher,
 		app.watcherRegistry.PeginBridgeWatcher,
-		app.watcherRegistry.QuoteCleanerWatcher,
 		app.watcherRegistry.PegoutRskDepositWatcher,
 		app.watcherRegistry.PegoutBtcTransferWatcher,
 		app.watcherRegistry.LiquidityCheckWatcher,


### PR DESCRIPTION
## What
Disable quote cleaner watcher

## Why
This has proven to not be useful because it adds friction to recover the info for the refunds

## Task
https://rsklabs.atlassian.net/browse/GBI-2204