### PR TITLE
fix: pegout btc watcher mutex lock order

### DIFF
--- a/internal/adapters/entrypoints/watcher/pegout_btc_watcher.go
+++ b/internal/adapters/entrypoints/watcher/pegout_btc_watcher.go
@@ -80,8 +80,8 @@ watcherLoop:
 	for {
 		select {
 		case <-watcher.ticker.C():
-			watcher.quotesMutex.Lock()
 			watcher.currentBlockMutex.Lock()
+			watcher.quotesMutex.Lock()
 			if height, err := watcher.rpc.Btc.GetHeight(); err == nil && height.Cmp(watcher.currentBlock) > 0 {
 				watcher.checkQuotes()
 				watcher.currentBlock = height


### PR DESCRIPTION
## What
- Change mutex lock order in pegout btc watcher
- Add a test to prevent this scenario in the future

## Why
To fix vulnerability LP-019, a potential deadlock if `Prepare` and `Start` are called at the same time. This wasn't found because the LPS calls these functions sequentially for all the watchers.

This fix is being included in this version (2.1.0) and not in the patch that we're making for the current version because this vulnerability exists only in this version.

## Task
https://rsklabs.atlassian.net/browse/GBI-2174