### PR TITLE
fix: hardcoded lp index in ui

### DIFF
--- a/internal/adapters/entrypoints/rest/assets/management.html
+++ b/internal/adapters/entrypoints/rest/assets/management.html
@@ -67,8 +67,10 @@
                 <div class="card">
                     <div class="card-header">Provider</div>
                     <div class="card-body">
-                        <h5 class="card-title">Provider Address</h5>
-                        <p class="card-text" id="providerAddress"></p>
+                        <h5 class="card-title">Provider RSK Address</h5>
+                        <p class="card-text" id="providerRskAddress"></p>
+                        <h5 class="card-title">Provider BTC Address</h5>
+                        <p class="card-text" id="providerBtcAddress"></p>
                         <h5 class="card-title">Operational Status</h5>
                         <p class="card-text" id="isOperational"></p>
                     </div>
@@ -198,11 +200,11 @@
 
             const fetchData = async (url, elementId) => {
                 try {
-                    const response = await fetch(url, { 
-                        method: 'GET', 
-                        headers: { 
-                            'Content-Type': 'application/json', 
-                            'X-CSRF-Token': data.CsrfToken 
+                    const response = await fetch(url, {
+                        method: 'GET',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRF-Token': data.CsrfToken
                         }
                     });
                     const responseData = await response.json();
@@ -212,21 +214,10 @@
                 }
             };
 
-            const fetchProviderData = async () => {
-                try {
-                    const response = await fetch('/getProviders', { 
-                        method: 'GET', 
-                        headers: { 
-                            'Content-Type': 'application/json'
-                        }
-                    });
-                    const providers = await response.json();
-                    const provider = providers[0];
-                    setTextContent('providerAddress', provider.provider);
-                    setTextContent('isOperational', provider.status ? "Operational" : "Not Operational");
-                } catch (error) {
-                    console.error('Failed to fetch provider data:', error);
-                }
+            const populateProviderData = (providerData, rskAddress, btcAddress) => {
+                setTextContent('providerRskAddress', rskAddress);
+                setTextContent('providerBtcAddress', btcAddress);
+                setTextContent('isOperational', providerData.status ? "Operational" : "Not Operational");
             };
 
             const createLabel = text => {
@@ -494,7 +485,7 @@
                 const loadingBar = document.getElementById(loadingBarId);
                 const button = document.getElementById(buttonId);
                 loadingBar.style.display = 'block';
-                button.disabled = true; 
+                button.disabled = true;
                 try {
                     const amountInWei = Number(etherToWei(amountInEther));
                     const response = await fetch(endpoint, {
@@ -522,9 +513,9 @@
             populateConfigSection('generalConfig', data.Configuration.general);
             populateConfigSection('peginConfig', data.Configuration.pegin);
             populateConfigSection('pegoutConfig', data.Configuration.pegout);
+            populateProviderData(data.ProviderData, data.RskAddress, data.BtcAddress);
             fetchData('/pegin/collateral', 'peginCollateral');
             fetchData('/pegout/collateral', 'pegoutCollateral');
-            fetchProviderData();
         });
     </script>
 </body>

--- a/internal/configuration/registry/usecase.go
+++ b/internal/configuration/registry/usecase.go
@@ -216,6 +216,7 @@ func NewUseCaseRegistry(
 			liquidityProvider,
 			liquidityProvider,
 			liquidityProvider,
+			rskRegistry.Contracts,
 			env.Provider.ApiBaseUrl,
 		),
 		bridgePegoutUseCase: pegout.NewBridgePegoutUseCase(

--- a/internal/usecases/liquidity_provider/management_ui.go
+++ b/internal/usecases/liquidity_provider/management_ui.go
@@ -2,8 +2,11 @@ package liquidity_provider
 
 import (
 	"context"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
+	"slices"
+	"strings"
 )
 
 type ManagementTemplateId string
@@ -19,6 +22,7 @@ type GetManagementUiDataUseCase struct {
 	lp                          liquidity_provider.LiquidityProvider
 	peginLp                     liquidity_provider.PeginLiquidityProvider
 	pegoutLp                    liquidity_provider.PegoutLiquidityProvider
+	contracts                   blockchain.RskContracts
 	baseUrl                     string
 }
 
@@ -27,6 +31,7 @@ func NewGetManagementUiDataUseCase(
 	lp liquidity_provider.LiquidityProvider,
 	peginLp liquidity_provider.PeginLiquidityProvider,
 	pegoutLp liquidity_provider.PegoutLiquidityProvider,
+	contracts blockchain.RskContracts,
 	baseUrl string,
 ) *GetManagementUiDataUseCase {
 	return &GetManagementUiDataUseCase{
@@ -34,6 +39,7 @@ func NewGetManagementUiDataUseCase(
 		lp:                          lp,
 		peginLp:                     peginLp,
 		pegoutLp:                    pegoutLp,
+		contracts:                   contracts,
 		baseUrl:                     baseUrl,
 	}
 }
@@ -46,6 +52,9 @@ type ManagementTemplate struct {
 type ManagementTemplateData struct {
 	CredentialsSet bool
 	BaseUrl        string
+	BtcAddress     string
+	RskAddress     string
+	ProviderData   liquidity_provider.RegisteredLiquidityProvider
 	Configuration  FullConfiguration
 }
 
@@ -53,7 +62,7 @@ func (useCase *GetManagementUiDataUseCase) Run(ctx context.Context, loggedIn boo
 	if !loggedIn {
 		return useCase.getLoginTemplateData(ctx)
 	}
-	return useCase.getManagementTemplateData(ctx), nil
+	return useCase.getManagementTemplateData(ctx)
 }
 
 func (useCase *GetManagementUiDataUseCase) getLoginTemplateData(ctx context.Context) (*ManagementTemplate, error) {
@@ -71,21 +80,38 @@ func (useCase *GetManagementUiDataUseCase) getLoginTemplateData(ctx context.Cont
 	}, nil
 }
 
-func (useCase *GetManagementUiDataUseCase) getManagementTemplateData(ctx context.Context) *ManagementTemplate {
+func (useCase *GetManagementUiDataUseCase) getManagementTemplateData(ctx context.Context) (*ManagementTemplate, error) {
 	generalConfiguration := useCase.lp.GeneralConfiguration(ctx)
 	peginConfiguration := useCase.peginLp.PeginConfiguration(ctx)
 	pegoutConfiguration := useCase.pegoutLp.PegoutConfiguration(ctx)
+
+	rskAddress := useCase.lp.RskAddress()
+	// TODO change to getProvider in 2.1.0
+	providers, err := useCase.contracts.Lbc.GetProviders()
+	if err != nil {
+		return nil, usecases.WrapUseCaseError(usecases.GetManagementUiId, err)
+	}
+
+	index := slices.IndexFunc(providers, func(providerInfo liquidity_provider.RegisteredLiquidityProvider) bool {
+		return strings.EqualFold(providerInfo.Address, rskAddress)
+	})
+	if index == -1 {
+		return nil, usecases.WrapUseCaseError(usecases.GetManagementUiId, usecases.ProviderNotFoundError)
+	}
 
 	return &ManagementTemplate{
 		Name: ManagementUiTemplate,
 		Data: ManagementTemplateData{
 			CredentialsSet: true,
 			BaseUrl:        useCase.baseUrl,
+			BtcAddress:     useCase.lp.BtcAddress(),
+			RskAddress:     rskAddress,
+			ProviderData:   providers[index],
 			Configuration: FullConfiguration{
 				General: generalConfiguration,
 				Pegin:   peginConfiguration,
 				Pegout:  pegoutConfiguration,
 			},
 		},
-	}
+	}, nil
 }

--- a/internal/usecases/liquidity_provider/management_ui_test.go
+++ b/internal/usecases/liquidity_provider/management_ui_test.go
@@ -2,7 +2,9 @@ package liquidity_provider_test
 
 import (
 	"context"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	lp "github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/test"
 	"github.com/rsksmart/liquidity-provider-server/test/mocks"
@@ -11,37 +13,53 @@ import (
 	"testing"
 )
 
+// nolint:funlen
 func TestGetManagementUiDataUseCase_Run(t *testing.T) {
 	const testUrl = "http://localhost:8080"
 	t.Run("Return correct data when not logged in and credentials not set", func(t *testing.T) {
 		lpMock := &mocks.ProviderMock{}
 		lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+		lbcMock := &mocks.LbcMock{}
 		lpRepository.On("GetCredentials", test.AnyCtx).Return(nil, nil).Once()
-		useCase := liquidity_provider.NewGetManagementUiDataUseCase(lpRepository, lpMock, lpMock, lpMock, testUrl)
+		useCase := liquidity_provider.NewGetManagementUiDataUseCase(lpRepository, lpMock, lpMock, lpMock, blockchain.RskContracts{Lbc: lbcMock}, testUrl)
 		result, err := useCase.Run(context.Background(), false)
 		require.NoError(t, err)
 		assert.Equal(t, liquidity_provider.ManagementLoginTemplate, result.Name)
 		assert.False(t, result.Data.CredentialsSet)
 		assert.Equal(t, testUrl, result.Data.BaseUrl)
 		assert.Empty(t, result.Data.Configuration)
+		assert.Empty(t, result.Data.ProviderData)
+		assert.Empty(t, result.Data.BtcAddress)
+		assert.Empty(t, result.Data.RskAddress)
 		lpRepository.AssertExpectations(t)
 		lpMock.AssertExpectations(t)
+		lbcMock.AssertNotCalled(t, "GetProviders")
 	})
 	t.Run("Return correct data when not logged in and credentials set", func(t *testing.T) {
 		lpMock := &mocks.ProviderMock{}
+		lbcMock := &mocks.LbcMock{}
 		lpRepository := &mocks.LiquidityProviderRepositoryMock{}
 		lpRepository.On("GetCredentials", test.AnyCtx).Return(storedCredentials, nil).Once()
-		useCase := liquidity_provider.NewGetManagementUiDataUseCase(lpRepository, lpMock, lpMock, lpMock, testUrl)
+		useCase := liquidity_provider.NewGetManagementUiDataUseCase(lpRepository, lpMock, lpMock, lpMock, blockchain.RskContracts{Lbc: lbcMock}, testUrl)
 		result, err := useCase.Run(context.Background(), false)
 		require.NoError(t, err)
 		assert.Equal(t, liquidity_provider.ManagementLoginTemplate, result.Name)
 		assert.True(t, result.Data.CredentialsSet)
 		assert.Equal(t, testUrl, result.Data.BaseUrl)
 		assert.Empty(t, result.Data.Configuration)
+		assert.Empty(t, result.Data.ProviderData)
+		assert.Empty(t, result.Data.BtcAddress)
+		assert.Empty(t, result.Data.RskAddress)
 		lpRepository.AssertExpectations(t)
 		lpMock.AssertExpectations(t)
+		lbcMock.AssertNotCalled(t, "GetProviders")
 	})
 	t.Run("Return correct data when logged in", func(t *testing.T) {
+		const (
+			btcAddress = test.AnyAddress
+			rskAddress = test.AnyHash
+		)
+		lbcMock := &mocks.LbcMock{}
 		lpMock := &mocks.ProviderMock{}
 		lpRepository := &mocks.LiquidityProviderRepositoryMock{}
 		fullConfig := liquidity_provider.FullConfiguration{
@@ -49,26 +67,94 @@ func TestGetManagementUiDataUseCase_Run(t *testing.T) {
 			Pegin:   lp.DefaultPeginConfiguration(),
 			Pegout:  lp.DefaultPegoutConfiguration(),
 		}
+		providersInfo := []lp.RegisteredLiquidityProvider{
+			{
+				Id:           1,
+				Address:      "otherAddress",
+				Name:         "otherName",
+				ApiBaseUrl:   "otherUrl",
+				Status:       true,
+				ProviderType: lp.PeginProvider,
+			},
+			{
+				Id:           2,
+				Address:      rskAddress,
+				Name:         test.AnyString,
+				ApiBaseUrl:   test.AnyUrl,
+				Status:       true,
+				ProviderType: lp.FullProvider,
+			},
+		}
+		lbcMock.On("GetProviders").Return(providersInfo, nil).Once()
 		lpMock.On("GeneralConfiguration", test.AnyCtx).Return(fullConfig.General).Once()
 		lpMock.On("PeginConfiguration", test.AnyCtx).Return(fullConfig.Pegin).Once()
 		lpMock.On("PegoutConfiguration", test.AnyCtx).Return(fullConfig.Pegout).Once()
-		useCase := liquidity_provider.NewGetManagementUiDataUseCase(lpRepository, lpMock, lpMock, lpMock, testUrl)
+		lpMock.On("BtcAddress").Return(btcAddress).Once()
+		lpMock.On("RskAddress").Return(rskAddress).Once()
+		useCase := liquidity_provider.NewGetManagementUiDataUseCase(lpRepository, lpMock, lpMock, lpMock, blockchain.RskContracts{Lbc: lbcMock}, testUrl)
 		result, err := useCase.Run(context.Background(), true)
 		require.NoError(t, err)
 		assert.Equal(t, liquidity_provider.ManagementUiTemplate, result.Name)
 		assert.True(t, result.Data.CredentialsSet)
 		assert.Equal(t, testUrl, result.Data.BaseUrl)
 		assert.Equal(t, fullConfig, result.Data.Configuration)
+		assert.Equal(t, providersInfo[1], result.Data.ProviderData)
+		assert.Equal(t, btcAddress, result.Data.BtcAddress)
+		assert.Equal(t, rskAddress, result.Data.RskAddress)
 		lpRepository.AssertExpectations(t)
 		lpMock.AssertExpectations(t)
+		lbcMock.AssertExpectations(t)
 	})
 	t.Run("Return error when repository fails", func(t *testing.T) {
+		lbcMock := &mocks.LbcMock{}
 		lpMock := &mocks.ProviderMock{}
 		lpRepository := &mocks.LiquidityProviderRepositoryMock{}
 		lpRepository.On("GetCredentials", test.AnyCtx).Return(nil, assert.AnError).Once()
-		useCase := liquidity_provider.NewGetManagementUiDataUseCase(lpRepository, lpMock, lpMock, lpMock, testUrl)
+		useCase := liquidity_provider.NewGetManagementUiDataUseCase(lpRepository, lpMock, lpMock, lpMock, blockchain.RskContracts{Lbc: lbcMock}, testUrl)
 		result, err := useCase.Run(context.Background(), false)
 		require.Error(t, err)
 		assert.Empty(t, result)
+	})
+	t.Run("Return error when provider doesn't exists", func(t *testing.T) {
+		const rskAddress = test.AnyHash
+
+		lbcMock := &mocks.LbcMock{}
+		lpMock := &mocks.ProviderMock{}
+		lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+		fullConfig := liquidity_provider.FullConfiguration{
+			General: lp.DefaultGeneralConfiguration(),
+			Pegin:   lp.DefaultPeginConfiguration(),
+			Pegout:  lp.DefaultPegoutConfiguration(),
+		}
+		providersInfo := []lp.RegisteredLiquidityProvider{
+			{
+				Id:           1,
+				Address:      "otherAddress",
+				Name:         "otherName",
+				ApiBaseUrl:   "otherUrl",
+				Status:       true,
+				ProviderType: lp.PeginProvider,
+			},
+			{
+				Id:           2,
+				Address:      rskAddress,
+				Name:         test.AnyString,
+				ApiBaseUrl:   test.AnyUrl,
+				Status:       true,
+				ProviderType: lp.FullProvider,
+			},
+		}
+		lbcMock.On("GetProviders").Return(providersInfo, nil).Once()
+		lpMock.On("GeneralConfiguration", test.AnyCtx).Return(fullConfig.General).Once()
+		lpMock.On("PeginConfiguration", test.AnyCtx).Return(fullConfig.Pegin).Once()
+		lpMock.On("PegoutConfiguration", test.AnyCtx).Return(fullConfig.Pegout).Once()
+		lpMock.On("RskAddress").Return("nonExistingAddress").Once()
+		useCase := liquidity_provider.NewGetManagementUiDataUseCase(lpRepository, lpMock, lpMock, lpMock, blockchain.RskContracts{Lbc: lbcMock}, testUrl)
+		result, err := useCase.Run(context.Background(), true)
+		require.ErrorIs(t, err, usecases.ProviderNotFoundError)
+		assert.Empty(t, result)
+		lpRepository.AssertExpectations(t)
+		lpMock.AssertExpectations(t)
+		lbcMock.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
## What
- Remove hardcoded index in UI and replace by proper provider information
- Show also LP derivate BTC address in the management UI

## Why
- Because with the hardcoded index the new LP will see incorrect information in one of the management UI panels
- Because the derivate BTC address is a common question when setting up a LPS

## Task
https://rsklabs.atlassian.net/browse/GBI-2219