### PR TITLE
feat: add min validation per utxo

### DIFF
--- a/internal/entities/blockchain/bitcoin.go
+++ b/internal/entities/blockchain/bitcoin.go
@@ -97,6 +97,14 @@ func (tx *BitcoinTransactionInformation) AmountToAddress(address string) *entiti
 	return total
 }
 
+func (tx *BitcoinTransactionInformation) UTXOsToAddress(address string) []*entities.Wei {
+	utxos, ok := tx.Outputs[address]
+	if !ok {
+		return []*entities.Wei{}
+	}
+	return utxos
+}
+
 type BitcoinBlockInformation struct {
 	Hash   [32]byte
 	Height *big.Int

--- a/internal/entities/blockchain/bitcoin_test.go
+++ b/internal/entities/blockchain/bitcoin_test.go
@@ -302,6 +302,68 @@ func TestBitcoinTransactionInformation_AmountToAddress(t *testing.T) {
 	})
 }
 
+func TestBitcoinTransactionInformation_UTXOsToAddress(t *testing.T) {
+	address := "2N1DB2ZfVwWUSm8rxnDpo879awEvwFwtHL9"
+	cases := test.Table[blockchain.BitcoinTransactionInformation, []*entities.Wei]{
+		{Value: blockchain.BitcoinTransactionInformation{
+			Hash:          "0x1234",
+			Confirmations: 1,
+			Outputs:       map[string][]*entities.Wei{"2N1nBfGejU5iLEqAS42fBKJ1Dw6mw4su8eQ": {entities.NewWei(100)}},
+		},
+			Result: []*entities.Wei{},
+		},
+		{Value: blockchain.BitcoinTransactionInformation{
+			Hash:          "0x1234",
+			Confirmations: 1,
+			Outputs:       map[string][]*entities.Wei{address: {entities.NewWei(500), entities.NewWei(300)}},
+		},
+			Result: []*entities.Wei{entities.NewWei(500), entities.NewWei(300)},
+		},
+		{Value: blockchain.BitcoinTransactionInformation{
+			Hash:          "0x1234",
+			Confirmations: 1,
+			Outputs: map[string][]*entities.Wei{
+				"2MuqWCdj3sepKF4i7j8WvBgMoavTxavxj14": {entities.NewWei(100), entities.NewWei(500)},
+				address:                               {entities.NewWei(500)},
+			},
+		},
+			Result: []*entities.Wei{entities.NewWei(500)},
+		},
+		{Value: blockchain.BitcoinTransactionInformation{
+			Hash:          "0x1234",
+			Confirmations: 1,
+			Outputs: map[string][]*entities.Wei{
+				"2N991MLUtYHfHzLQgtNfK9NtUVUSEe9Ncaf": {entities.NewWei(400)},
+				address:                               {entities.NewWei(200), entities.NewWei(100)},
+				"mpZQG3z2iWoMAWKQdJBmAan8hS8q1Kd1ai":  {entities.NewWei(800), entities.NewWei(1000)},
+			},
+		},
+			Result: []*entities.Wei{entities.NewWei(200), entities.NewWei(100)},
+		},
+		{Value: blockchain.BitcoinTransactionInformation{
+			Hash:          "0x1234",
+			Confirmations: 1,
+			Outputs: map[string][]*entities.Wei{
+				"n3EanzRxjg2VyQRrnyetiVfNzjz7736RBD": {entities.NewWei(4000)},
+				address:                              {entities.NewWei(2000)},
+			},
+		},
+			Result: []*entities.Wei{entities.NewWei(2000)},
+		},
+		{Value: blockchain.BitcoinTransactionInformation{
+			Hash:          "0x1234",
+			Confirmations: 1,
+			Outputs:       map[string][]*entities.Wei{address: {entities.NewWei(3000)}},
+		},
+			Result: []*entities.Wei{entities.NewWei(3000)},
+		},
+	}
+
+	test.RunTable(t, cases, func(value blockchain.BitcoinTransactionInformation) []*entities.Wei {
+		return value.UTXOsToAddress(address)
+	})
+}
+
 func TestIsSupportedBtcAddress(t *testing.T) {
 	var notSuported []string
 	notSuported = append(notSuported, nativeSegwitTestnetAddresses...)

--- a/internal/usecases/common.go
+++ b/internal/usecases/common.go
@@ -173,3 +173,23 @@ func SignConfiguration[C liquidity_provider.ConfigurationType](
 	}
 	return signedConfig, nil
 }
+
+// ValidateBridgeUtxoMin checks that all the UTXOs to an address of a Bitcoin transaction are above the Rootstock Bridge minimum
+func ValidateBridgeUtxoMin(bridge blockchain.RootstockBridge, transaction blockchain.BitcoinTransactionInformation, address string) error {
+	minLockTxValueInWei, err := bridge.GetMinimumLockTxValue()
+	if err != nil {
+		return err
+	}
+	utxos := transaction.UTXOsToAddress(address)
+	if len(utxos) == 0 {
+		err = fmt.Errorf("no UTXO directed to address %s present in transaction", address)
+		return errors.Join(TxBelowMinimumError, err)
+	}
+	for _, utxo := range utxos {
+		if minLockTxValueInWei.Cmp(utxo) > 0 {
+			err = errors.New("not all the UTXOs are above the min lock value")
+			return errors.Join(TxBelowMinimumError, err)
+		}
+	}
+	return nil
+}

--- a/internal/usecases/common_test.go
+++ b/internal/usecases/common_test.go
@@ -142,3 +142,89 @@ func TestSignConfiguration_SignatureError(t *testing.T) {
 	require.Equal(t, entities.Signed[liquidity_provider.PeginConfiguration]{}, signed)
 	require.Error(t, err)
 }
+
+// nolint:funlen
+func TestValidateBridgeUtxoMin(t *testing.T) {
+	const (
+		address       = "2N991MLUtYHfHzLQgtNfK9NtUVUSEe9Ncaf"
+		txHash        = "9fa7040fbe1e442e970c231aaf830abf62c83b165fc436b1ce6e385b6ce40e59"
+		confirmations = 10
+	)
+	t.Run("should fail if one of the UTXO is under the bridge min", func(t *testing.T) {
+		bridge := &mocks.BridgeMock{}
+		bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000), nil).Once()
+		tx := blockchain.BitcoinTransactionInformation{
+			Hash: txHash, Confirmations: confirmations,
+			Outputs: map[string][]*entities.Wei{
+				address: {entities.NewWei(1000), entities.NewWei(999), entities.NewWei(3000)},
+			},
+		}
+		err := u.ValidateBridgeUtxoMin(bridge, tx, address)
+		require.ErrorContains(t, err, "not all the UTXOs are above the min lock value")
+		require.ErrorIs(t, err, u.TxBelowMinimumError)
+		bridge.AssertExpectations(t)
+	})
+	t.Run("should fail if all of the UTXO is under the bridge min", func(t *testing.T) {
+		bridge := &mocks.BridgeMock{}
+		bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000), nil).Once()
+		tx := blockchain.BitcoinTransactionInformation{
+			Hash: txHash, Confirmations: confirmations,
+			Outputs: map[string][]*entities.Wei{
+				address: {entities.NewWei(1), entities.NewWei(999), entities.NewWei(100)},
+			},
+		}
+		err := u.ValidateBridgeUtxoMin(bridge, tx, address)
+		require.ErrorContains(t, err, "not all the UTXOs are above the min lock value")
+		require.ErrorIs(t, err, u.TxBelowMinimumError)
+		bridge.AssertExpectations(t)
+	})
+	t.Run("should not fail if all the UTXO is above the bridge min", func(t *testing.T) {
+		bridge := &mocks.BridgeMock{}
+		bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000), nil).Twice()
+		tx := blockchain.BitcoinTransactionInformation{
+			Hash: txHash, Confirmations: confirmations,
+			Outputs: map[string][]*entities.Wei{
+				address: {entities.NewWei(1000), entities.NewWei(1000), entities.NewWei(1001)},
+			},
+		}
+		err := u.ValidateBridgeUtxoMin(bridge, tx, address)
+		require.NoError(t, err)
+
+		tx = blockchain.BitcoinTransactionInformation{
+			Hash: txHash, Confirmations: confirmations,
+			Outputs: map[string][]*entities.Wei{address: {entities.NewWei(1000)}},
+		}
+		err = u.ValidateBridgeUtxoMin(bridge, tx, address)
+		require.NoError(t, err)
+
+		bridge.AssertExpectations(t)
+	})
+	t.Run("should return error if call to the bridge fails", func(t *testing.T) {
+		bridge := &mocks.BridgeMock{}
+		bridge.On("GetMinimumLockTxValue").Return(nil, assert.AnError).Once()
+		tx := blockchain.BitcoinTransactionInformation{
+			Hash: txHash, Confirmations: confirmations,
+			Outputs: map[string][]*entities.Wei{
+				address: {entities.NewWei(1000), entities.NewWei(1000), entities.NewWei(1001)},
+			},
+		}
+		err := u.ValidateBridgeUtxoMin(bridge, tx, address)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, u.TxBelowMinimumError)
+		bridge.AssertExpectations(t)
+	})
+	t.Run("should fail if there is no UTXO for a given address", func(t *testing.T) {
+		bridge := &mocks.BridgeMock{}
+		bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000), nil).Once()
+		tx := blockchain.BitcoinTransactionInformation{
+			Hash: txHash, Confirmations: confirmations,
+			Outputs: map[string][]*entities.Wei{
+				"other-address": {entities.NewWei(1000), entities.NewWei(1000), entities.NewWei(1001)},
+			},
+		}
+		err := u.ValidateBridgeUtxoMin(bridge, tx, address)
+		require.ErrorContains(t, err, "no UTXO directed to address 2N991MLUtYHfHzLQgtNfK9NtUVUSEe9Ncaf present in transaction")
+		require.ErrorIs(t, err, u.TxBelowMinimumError)
+		bridge.AssertExpectations(t)
+	})
+}

--- a/internal/usecases/pegin/call_for_user.go
+++ b/internal/usecases/pegin/call_for_user.go
@@ -191,5 +191,9 @@ func (useCase *CallForUserUseCase) validateBitcoinTx(
 			false,
 		)
 	}
+
+	if err = usecases.ValidateBridgeUtxoMin(useCase.contracts.Bridge, txInfo, retainedQuote.DepositAddress); err != nil {
+		return useCase.publishErrorEvent(ctx, retainedQuote, *peginQuote, err, !errors.Is(err, usecases.TxBelowMinimumError))
+	}
 	return nil
 }

--- a/internal/usecases/pegin/call_for_user_test.go
+++ b/internal/usecases/pegin/call_for_user_test.go
@@ -31,6 +31,8 @@ func TestCallForUserUseCase_Run(t *testing.T) {
 	expectedRetainedQuote := retainedPeginQuote
 	expectedRetainedQuote.State = quote.PeginStateCallForUserSucceeded
 	expectedRetainedQuote.CallForUserTxHash = callForUser
+	bridge := new(mocks.BridgeMock)
+	bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000), nil).Once()
 
 	lp := new(mocks.ProviderMock)
 	lp.On("RskAddress").Return(lpRskAddress).Once()
@@ -41,9 +43,8 @@ func TestCallForUserUseCase_Run(t *testing.T) {
 
 	btc := new(mocks.BtcRpcMock)
 	btc.On("GetTransactionInfo", retainedPeginQuote.UserBtcTxHash).Return(blockchain.BitcoinTransactionInformation{
-		Hash:          retainedPeginQuote.UserBtcTxHash,
-		Confirmations: 10,
-		Outputs:       map[string][]*entities.Wei{retainedPeginQuote.DepositAddress: {entities.NewWei(30012)}},
+		Hash: retainedPeginQuote.UserBtcTxHash, Confirmations: 10,
+		Outputs: map[string][]*entities.Wei{retainedPeginQuote.DepositAddress: {entities.NewWei(30012)}},
 	}, nil).Once()
 	btc.On("GetTransactionBlockInfo", retainedPeginQuote.UserBtcTxHash).Return(blockchain.BitcoinBlockInformation{Hash: [32]byte{1, 2, 3}, Height: big.NewInt(5), Time: time.Now()}, nil).Once()
 
@@ -65,7 +66,7 @@ func TestCallForUserUseCase_Run(t *testing.T) {
 	})).Return(nil).Once()
 	rsk := new(mocks.RootstockRpcServerMock)
 
-	contracts := blockchain.RskContracts{Lbc: lbc}
+	contracts := blockchain.RskContracts{Lbc: lbc, Bridge: bridge}
 	rpc := blockchain.Rpc{Rsk: rsk, Btc: btc}
 	useCase := pegin.NewCallForUserUseCase(contracts, quoteRepository, rpc, lp, eventBus, mutex)
 	err := useCase.Run(context.Background(), retainedPeginQuote)
@@ -76,6 +77,7 @@ func TestCallForUserUseCase_Run(t *testing.T) {
 	quoteRepository.AssertExpectations(t)
 	eventBus.AssertExpectations(t)
 	mutex.AssertExpectations(t)
+	bridge.AssertExpectations(t)
 }
 
 func TestCallForUserUseCase_Run_AddExtraAmountDuringCall(t *testing.T) {
@@ -93,13 +95,14 @@ func TestCallForUserUseCase_Run_AddExtraAmountDuringCall(t *testing.T) {
 	expectedRetainedQuote.State = quote.PeginStateCallForUserSucceeded
 	expectedRetainedQuote.CallForUserTxHash = callForUser
 
+	bridge := new(mocks.BridgeMock)
+	bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000), nil).Once()
 	lp := new(mocks.ProviderMock)
 	lp.On("RskAddress").Return(lpRskAddress).Twice()
 	lbc := new(mocks.LbcMock)
 	lbc.On("GetBalance", testPeginQuote.LpRskAddress).Return(entities.NewWei(600), nil).Once()
 	txConfig := blockchain.NewTransactionConfig(entities.NewWei(29400), uint64(testPeginQuote.GasLimit+pegin.CallForUserExtraGas), nil)
 	lbc.On("CallForUser", txConfig, testPeginQuote).Return(callForUser, nil).Once()
-
 	btc := new(mocks.BtcRpcMock)
 	btc.On("GetTransactionInfo", retainedPeginQuote.UserBtcTxHash).Return(blockchain.BitcoinTransactionInformation{
 		Hash:          retainedPeginQuote.UserBtcTxHash,
@@ -107,7 +110,6 @@ func TestCallForUserUseCase_Run_AddExtraAmountDuringCall(t *testing.T) {
 		Outputs:       map[string][]*entities.Wei{retainedPeginQuote.DepositAddress: {entities.NewWei(30012)}},
 	}, nil).Once()
 	btc.On("GetTransactionBlockInfo", retainedPeginQuote.UserBtcTxHash).Return(blockchain.BitcoinBlockInformation{Hash: [32]byte{1, 2, 3}, Height: big.NewInt(5), Time: time.Now()}, nil).Once()
-
 	eventBus := new(mocks.EventBusMock)
 	eventBus.On("Publish", mock.MatchedBy(func(event quote.CallForUserCompletedEvent) bool {
 		require.NoError(t, event.Error)
@@ -126,7 +128,7 @@ func TestCallForUserUseCase_Run_AddExtraAmountDuringCall(t *testing.T) {
 	rsk := new(mocks.RootstockRpcServerMock)
 	rsk.On("GetBalance", test.AnyCtx, lpRskAddress).Return(entities.NewWei(80000), nil).Once()
 
-	contracts := blockchain.RskContracts{Lbc: lbc}
+	contracts := blockchain.RskContracts{Lbc: lbc, Bridge: bridge}
 	rpc := blockchain.Rpc{Rsk: rsk, Btc: btc}
 	useCase := pegin.NewCallForUserUseCase(contracts, quoteRepository, rpc, lp, eventBus, mutex)
 	err := useCase.Run(context.Background(), retainedPeginQuote)
@@ -138,6 +140,7 @@ func TestCallForUserUseCase_Run_AddExtraAmountDuringCall(t *testing.T) {
 	quoteRepository.AssertExpectations(t)
 	eventBus.AssertExpectations(t)
 	mutex.AssertExpectations(t)
+	bridge.AssertExpectations(t)
 }
 
 func TestCallForUserUseCase_Run_DontPublishRecoverableErrors(t *testing.T) {
@@ -162,10 +165,11 @@ func TestCallForUserUseCase_Run_DontPublishRecoverableErrors(t *testing.T) {
 		mutex.On("Lock").Return().Once()
 		mutex.On("Unlock").Return().Once()
 		quoteRepository := new(mocks.PeginQuoteRepositoryMock)
+		bridge := new(mocks.BridgeMock)
 		caseRetainedQuote := retainedPeginQuote
-		setup(&caseRetainedQuote, rsk, lbc, btc, quoteRepository)
+		setup(&caseRetainedQuote, rsk, lbc, btc, quoteRepository, bridge)
 
-		contracts := blockchain.RskContracts{Lbc: lbc}
+		contracts := blockchain.RskContracts{Lbc: lbc, Bridge: bridge}
 		rpc := blockchain.Rpc{Rsk: rsk, Btc: btc}
 		useCase := pegin.NewCallForUserUseCase(contracts, quoteRepository, rpc, lp, eventBus, mutex)
 		err := useCase.Run(context.Background(), caseRetainedQuote)
@@ -175,7 +179,7 @@ func TestCallForUserUseCase_Run_DontPublishRecoverableErrors(t *testing.T) {
 }
 
 // nolint:funlen
-func callForUserRecoverableErrorSetups() []func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock) {
+func callForUserRecoverableErrorSetups() []func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock, bridge *mocks.BridgeMock) {
 	now := uint32(time.Now().Unix())
 	peginQuote := quote.PeginQuote{
 		FedBtcAddress:      "fed address",
@@ -199,19 +203,19 @@ func callForUserRecoverableErrorSetups() []func(caseRetainedQuote *quote.Retaine
 		GasFee:             entities.NewWei(500),
 		ProductFeeAmount:   100,
 	}
-	return []func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock){
-		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock) {
+	return []func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock, bridge *mocks.BridgeMock){
+		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock, bridge *mocks.BridgeMock) {
 			caseRetainedQuote.State = quote.PeginStateCallForUserSucceeded
 		},
-		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock) {
+		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock, bridge *mocks.BridgeMock) {
 			quoteRepository.On("GetQuote", test.AnyCtx, mock.Anything).Return(nil, assert.AnError).Once()
 		},
-		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock) {
+		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock, bridge *mocks.BridgeMock) {
 			quoteRepository.On("GetQuote", test.AnyCtx, mock.Anything).
 				Return(&peginQuote, nil).Once()
 			btc.On("GetTransactionInfo", mock.Anything).Return(blockchain.BitcoinTransactionInformation{}, assert.AnError).Once()
 		},
-		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock) {
+		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock, bridge *mocks.BridgeMock) {
 			quoteRepository.On("GetQuote", test.AnyCtx, mock.Anything).
 				Return(&peginQuote, nil).Once()
 			btc.On("GetTransactionInfo", mock.Anything).Return(blockchain.BitcoinTransactionInformation{
@@ -221,7 +225,7 @@ func callForUserRecoverableErrorSetups() []func(caseRetainedQuote *quote.Retaine
 			}, nil).Once()
 			btc.On("GetTransactionBlockInfo", mock.Anything).Return(blockchain.BitcoinBlockInformation{}, assert.AnError).Once()
 		},
-		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock) {
+		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock, bridge *mocks.BridgeMock) {
 			quoteRepository.On("GetQuote", test.AnyCtx, mock.Anything).
 				Return(&peginQuote, nil).Once()
 			btc.On("GetTransactionInfo", mock.Anything).Return(blockchain.BitcoinTransactionInformation{
@@ -234,9 +238,25 @@ func callForUserRecoverableErrorSetups() []func(caseRetainedQuote *quote.Retaine
 				Height: big.NewInt(5),
 				Time:   time.Now(),
 			}, nil).Once()
+			bridge.On("GetMinimumLockTxValue").Return(nil, assert.AnError).Once()
+		},
+		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock, bridge *mocks.BridgeMock) {
+			quoteRepository.On("GetQuote", test.AnyCtx, mock.Anything).
+				Return(&peginQuote, nil).Once()
+			btc.On("GetTransactionInfo", mock.Anything).Return(blockchain.BitcoinTransactionInformation{
+				Hash:          "0x1d1e",
+				Confirmations: 10,
+				Outputs:       map[string][]*entities.Wei{test.AnyAddress: {entities.NewWei(1700)}},
+			}, nil).Once()
+			btc.On("GetTransactionBlockInfo", mock.Anything).Return(blockchain.BitcoinBlockInformation{
+				Hash:   [32]byte{1, 2, 3},
+				Height: big.NewInt(5),
+				Time:   time.Now(),
+			}, nil).Once()
+			bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000), nil).Once()
 			lbc.On("GetBalance", mock.Anything).Return(nil, assert.AnError).Once()
 		},
-		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock) {
+		func(caseRetainedQuote *quote.RetainedPeginQuote, rsk *mocks.RootstockRpcServerMock, lbc *mocks.LbcMock, btc *mocks.BtcRpcMock, quoteRepository *mocks.PeginQuoteRepositoryMock, bridge *mocks.BridgeMock) {
 			quoteRepository.On("GetQuote", test.AnyCtx, mock.Anything).
 				Return(&peginQuote, nil).Once()
 			btc.On("GetTransactionInfo", mock.Anything).Return(blockchain.BitcoinTransactionInformation{
@@ -249,6 +269,7 @@ func callForUserRecoverableErrorSetups() []func(caseRetainedQuote *quote.Retaine
 				Height: big.NewInt(5),
 				Time:   time.Now(),
 			}, nil).Once()
+			bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000), nil).Once()
 			lbc.On("GetBalance", mock.Anything).Return(entities.NewWei(500), nil).Once()
 			rsk.On("GetBalance", mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
 		},
@@ -500,13 +521,16 @@ func TestCallForUserUseCase_Run_NoLiquidity(t *testing.T) {
 	mutex.On("Lock").Return().Once()
 	mutex.On("Unlock").Return().Once()
 
+	bridge := new(mocks.BridgeMock)
+	bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000), nil).Once()
+
 	quoteRepository := new(mocks.PeginQuoteRepositoryMock)
 	quoteRepository.On("GetQuote", test.AnyCtx, retainedPeginQuote.QuoteHash).Return(&testPeginQuote, nil).Once()
 
 	rsk := new(mocks.RootstockRpcServerMock)
 	rsk.On("GetBalance", test.AnyCtx, lpRskAddress).Return(entities.NewWei(20000), nil).Once()
 
-	contracts := blockchain.RskContracts{Lbc: lbc}
+	contracts := blockchain.RskContracts{Lbc: lbc, Bridge: bridge}
 	rpc := blockchain.Rpc{Rsk: rsk, Btc: btc}
 	useCase := pegin.NewCallForUserUseCase(contracts, quoteRepository, rpc, lp, eventBus, mutex)
 	err := useCase.Run(context.Background(), retainedPeginQuote)
@@ -518,6 +542,7 @@ func TestCallForUserUseCase_Run_NoLiquidity(t *testing.T) {
 	quoteRepository.AssertExpectations(t)
 	eventBus.AssertNotCalled(t, "Publish")
 	mutex.AssertExpectations(t)
+	bridge.AssertExpectations(t)
 }
 
 func TestCallForUserUseCase_Run_CallForUserFail(t *testing.T) {
@@ -537,12 +562,12 @@ func TestCallForUserUseCase_Run_CallForUserFail(t *testing.T) {
 
 	lp := new(mocks.ProviderMock)
 	lp.On("RskAddress").Return(lpRskAddress).Twice()
-
+	bridge := new(mocks.BridgeMock)
+	bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000), nil).Once()
 	lbc := new(mocks.LbcMock)
 	lbc.On("GetBalance", testPeginQuote.LpRskAddress).Return(entities.NewWei(600), nil).Once()
 	txConfig := blockchain.NewTransactionConfig(entities.NewWei(29400), uint64(testPeginQuote.GasLimit+pegin.CallForUserExtraGas), nil)
 	lbc.On("CallForUser", txConfig, testPeginQuote).Return(callForUser, assert.AnError).Once()
-
 	btc := new(mocks.BtcRpcMock)
 	btc.On("GetTransactionInfo", retainedPeginQuote.UserBtcTxHash).Return(blockchain.BitcoinTransactionInformation{
 		Hash:          retainedPeginQuote.UserBtcTxHash,
@@ -568,7 +593,7 @@ func TestCallForUserUseCase_Run_CallForUserFail(t *testing.T) {
 
 	rsk := new(mocks.RootstockRpcServerMock)
 	rsk.On("GetBalance", test.AnyCtx, lpRskAddress).Return(entities.NewWei(80000), nil).Once()
-	contracts := blockchain.RskContracts{Lbc: lbc}
+	contracts := blockchain.RskContracts{Lbc: lbc, Bridge: bridge}
 	rpc := blockchain.Rpc{Rsk: rsk, Btc: btc}
 	useCase := pegin.NewCallForUserUseCase(contracts, quoteRepository, rpc, lp, eventBus, mutex)
 	err := useCase.Run(context.Background(), retainedPeginQuote)
@@ -580,4 +605,63 @@ func TestCallForUserUseCase_Run_CallForUserFail(t *testing.T) {
 	quoteRepository.AssertExpectations(t)
 	eventBus.AssertExpectations(t)
 	mutex.AssertExpectations(t)
+	bridge.AssertExpectations(t)
+}
+
+func TestCallForUserUseCase_Run_InvalidUTXOs(t *testing.T) {
+	retainedPeginQuote := quote.RetainedPeginQuote{
+		QuoteHash:         "abcdef",
+		DepositAddress:    test.AnyAddress,
+		Signature:         "signature",
+		RequiredLiquidity: entities.NewWei(1500),
+		State:             quote.PeginStateWaitingForDepositConfirmations,
+		UserBtcTxHash:     "0x3c2b1a",
+	}
+	expectedRetainedQuote := retainedPeginQuote
+	expectedRetainedQuote.State = quote.PeginStateCallForUserFailed
+
+	lp := new(mocks.ProviderMock)
+	lbc := new(mocks.LbcMock)
+
+	bridge := new(mocks.BridgeMock)
+	bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1000), nil).Once()
+
+	btc := new(mocks.BtcRpcMock)
+	btc.On("GetTransactionInfo", retainedPeginQuote.UserBtcTxHash).Return(blockchain.BitcoinTransactionInformation{
+		Hash:          retainedPeginQuote.UserBtcTxHash,
+		Confirmations: 20,
+		Outputs:       map[string][]*entities.Wei{retainedPeginQuote.DepositAddress: {entities.NewWei(30000), entities.NewWei(999)}},
+	}, nil).Once()
+	btc.On("GetTransactionBlockInfo", retainedPeginQuote.UserBtcTxHash).Return(blockchain.BitcoinBlockInformation{Hash: [32]byte{1, 2, 3}, Height: big.NewInt(5), Time: time.Now()}, nil).Once()
+
+	eventBus := new(mocks.EventBusMock)
+	eventBus.On("Publish", mock.MatchedBy(func(event quote.CallForUserCompletedEvent) bool {
+		require.Error(t, event.Error)
+		return assert.Equal(t, testPeginQuote, event.PeginQuote) && assert.Equal(t, expectedRetainedQuote, event.RetainedQuote) &&
+			assert.Equal(t, quote.CallForUserCompletedEventId, event.Event.Id())
+	})).Return().Once()
+
+	mutex := new(mocks.MutexMock)
+
+	quoteRepository := new(mocks.PeginQuoteRepositoryMock)
+	quoteRepository.On("GetQuote", test.AnyCtx, retainedPeginQuote.QuoteHash).Return(&testPeginQuote, nil).Once()
+	quoteRepository.On("UpdateRetainedQuote", test.AnyCtx, mock.MatchedBy(func(q quote.RetainedPeginQuote) bool {
+		return assert.Equal(t, expectedRetainedQuote, q)
+	})).Return(nil).Once()
+	rsk := new(mocks.RootstockRpcServerMock)
+
+	contracts := blockchain.RskContracts{Lbc: lbc, Bridge: bridge}
+	rpc := blockchain.Rpc{Rsk: rsk, Btc: btc}
+	useCase := pegin.NewCallForUserUseCase(contracts, quoteRepository, rpc, lp, eventBus, mutex)
+	err := useCase.Run(context.Background(), retainedPeginQuote)
+	require.ErrorContains(t, err, "not all the UTXOs are above the min lock value")
+	btc.AssertExpectations(t)
+	quoteRepository.AssertExpectations(t)
+	eventBus.AssertExpectations(t)
+	bridge.AssertExpectations(t)
+	mutex.AssertNotCalled(t, "Lock")
+	mutex.AssertNotCalled(t, "Unlock")
+	lbc.AssertNotCalled(t, "CallForUser")
+	lbc.AssertNotCalled(t, "GetBalance")
+	lp.AssertNotCalled(t, "RskAddress")
 }


### PR DESCRIPTION
## What
Add a validation to ensure each output of the pegin deposit transaction is above the RSK bridge minimum

## Why
To avoid considering transactions with multiple utxo that sum the total value of the quote as valid transactions

## Task
https://rsklabs.atlassian.net/browse/GBI-2236