### PR TITLE
fix: assignment in watcher

### DIFF
--- a/internal/adapters/entrypoints/watcher/pegin_btc_deposit_watcher.go
+++ b/internal/adapters/entrypoints/watcher/pegin_btc_deposit_watcher.go
@@ -137,8 +137,9 @@ func (watcher *PeginDepositAddressWatcher) handleQuote(ctx context.Context, watc
 	quoteHash := watchedQuote.RetainedQuote.QuoteHash
 
 	if watchedQuote.RetainedQuote.State == quote.PeginStateWaitingForDeposit {
-		if err = watcher.handleNotDepositedQuote(ctx, watchedQuote); err != nil {
+		if watchedQuote, err = watcher.handleNotDepositedQuote(ctx, watchedQuote); err != nil {
 			log.Error(peginBtcDepositWatcherLog(callForUserErrorTemplate, quoteHash, err))
+			return
 		}
 	}
 
@@ -160,7 +161,7 @@ func (watcher *PeginDepositAddressWatcher) handleQuote(ctx context.Context, watc
 	}
 }
 
-func (watcher *PeginDepositAddressWatcher) handleNotDepositedQuote(ctx context.Context, watchedQuote quote.WatchedPeginQuote) error {
+func (watcher *PeginDepositAddressWatcher) handleNotDepositedQuote(ctx context.Context, watchedQuote quote.WatchedPeginQuote) (quote.WatchedPeginQuote, error) {
 	var err error
 	var block blockchain.BitcoinBlockInformation
 	var txs []blockchain.BitcoinTransactionInformation
@@ -168,28 +169,28 @@ func (watcher *PeginDepositAddressWatcher) handleNotDepositedQuote(ctx context.C
 
 	depositAddress := watchedQuote.RetainedQuote.DepositAddress
 	if txs, err = watcher.btcWallet.GetTransactions(depositAddress); err != nil {
-		return err
+		return quote.WatchedPeginQuote{}, err
 	}
 
 	for _, tx := range txs {
 		log.Info(peginBtcDepositWatcherLog("Checking transaction %s for quote %s", tx.Hash, watchedQuote.RetainedQuote.QuoteHash))
 		if block, err = watcher.rpc.Btc.GetTransactionBlockInfo(tx.Hash); err != nil {
-			return err
+			return quote.WatchedPeginQuote{}, err
 		}
 		onTime := watchedQuote.PeginQuote.ExpireTime().After(block.Time)
 		correctAmount := tx.AmountToAddress(watchedQuote.RetainedQuote.DepositAddress).Cmp(watchedQuote.PeginQuote.Total()) >= 0
 		if watchedQuote.RetainedQuote.State == quote.PeginStateWaitingForDeposit && onTime && correctAmount {
 			if updatedQuote, err = watcher.updatePeginDepositUseCase.Run(ctx, watchedQuote, block, tx); err != nil {
-				return err
+				return quote.WatchedPeginQuote{}, err
 			} else {
 				watcher.quotes[watchedQuote.RetainedQuote.QuoteHash] = updatedQuote
-				return nil
+				return updatedQuote, nil
 			}
 		} else {
 			watcher.logRejectReason(block, tx, watchedQuote)
 		}
 	}
-	return nil
+	return watchedQuote, nil
 }
 
 func (watcher *PeginDepositAddressWatcher) handleDepositedQuote(ctx context.Context, watchedQuote quote.WatchedPeginQuote) error {


### PR DESCRIPTION
## What
Return the updated quote in `handleNotDepositedQuote` function. If there is an error, return an empty quote

## Why
Because in one of the changes of the 2.0.2 patch, the expiration check was moved below the deposit check to address the cases where the check is being done over a expired quote whose first confirmation was before the expiration. This can happen, for example, if the server goes down before the first confirmation of the deposit and starts again after the expiration. 

In that change, the quote object inside `handleQuote` was not updated, so even if the deposit is processed it would still be marked as expired later. To fix this, the return value of the `handleNotDepositedQuote` function was modified so it will return:
- Empty quote and error if there is an error during the check
- The same quote and nil if the deposit wasn't done or was invalid and there wasn't an error during the check
- The updated quote and nil if the check was successful and the quote was paid

If there's an error, the`handleQuote` function will return, otherwise the check will continue with the quote updated to its new state.

This was spotted during the development of the tests for this feature, it was done separately because the tests for the watchers are introduced in the 2.1 version: https://github.com/rsksmart/liquidity-provider-server/pull/563/commits/bac10cf96d7648f7323787d9b9fa93a28cf2f90f 
