### PR TITLE
feat: add btc wallet reconnection

### DIFF
--- a/internal/adapters/dataproviders/bitcoin/common_test.go
+++ b/internal/adapters/dataproviders/bitcoin/common_test.go
@@ -1,8 +1,12 @@
 package bitcoin_test
 
 import (
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/dataproviders/bitcoin"
+	"github.com/rsksmart/liquidity-provider-server/test"
+	"github.com/rsksmart/liquidity-provider-server/test/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -132,4 +136,38 @@ func TestToSwappedBytes32(t *testing.T) {
 	assert.Equal(t, [32]byte{0x20, 0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x0F, 0x0E, 0x0D, 0x0C, 0x0B, 0x0A, 0x09, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01}, swappedBytes)
 	assert.Equal(t, [32]byte{0x40, 0x3F, 0x3E, 0x3D, 0x3C, 0x3B, 0x3A, 0x39, 0x38, 0x37, 0x36, 0x35, 0x34, 0x33, 0x32, 0x31, 0x30, 0x2F, 0x2E, 0x2D, 0x2C, 0x2B, 0x2A, 0x29, 0x28, 0x27, 0x26, 0x25, 0x24, 0x23, 0x22, 0x21}, swappedHash)
 	assert.Equal(t, [32]byte{0x60, 0x5F, 0x5E, 0x5D, 0x5C, 0x5B, 0x5A, 0x59, 0x58, 0x57, 0x56, 0x55, 0x54, 0x53, 0x52, 0x51, 0x50, 0x4F, 0x4E, 0x4D, 0x4C, 0x4B, 0x4A, 0x49, 0x48, 0x47, 0x46, 0x45, 0x44, 0x43, 0x42, 0x41}, swappedHashPointer)
+}
+
+func TestEnsureLoadedBtcWallet(t *testing.T) {
+	t.Run("Should return error if connection is not a wallet connection", func(t *testing.T) {
+		conn := bitcoin.NewConnection(&chaincfg.TestNet3Params, new(mocks.ClientAdapterMock))
+		err := bitcoin.EnsureLoadedBtcWallet(conn)
+		require.ErrorContains(t, err, "connection is not a wallet connection")
+	})
+	t.Run("Shouldn't return error if wallet is loaded and responding", func(t *testing.T) {
+		clientMock := new(mocks.ClientAdapterMock)
+		clientMock.EXPECT().GetWalletInfo().Return(&btcjson.GetWalletInfoResult{WalletName: test.AnyString}, nil)
+		conn := bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, clientMock, test.AnyString)
+		err := bitcoin.EnsureLoadedBtcWallet(conn)
+		require.NoError(t, err)
+		clientMock.AssertExpectations(t)
+	})
+	t.Run("Should load wallet if wallet is not loaded", func(t *testing.T) {
+		clientMock := new(mocks.ClientAdapterMock)
+		clientMock.EXPECT().GetWalletInfo().Return(nil, assert.AnError)
+		clientMock.EXPECT().LoadWallet(test.AnyString).Return(&btcjson.LoadWalletResult{Name: test.AnyString}, nil)
+		conn := bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, clientMock, test.AnyString)
+		err := bitcoin.EnsureLoadedBtcWallet(conn)
+		require.NoError(t, err)
+		clientMock.AssertExpectations(t)
+	})
+	t.Run("Should return error loading wallet if it fails", func(t *testing.T) {
+		clientMock := new(mocks.ClientAdapterMock)
+		clientMock.EXPECT().GetWalletInfo().Return(nil, assert.AnError)
+		clientMock.EXPECT().LoadWallet(test.AnyString).Return(nil, assert.AnError)
+		conn := bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, clientMock, test.AnyString)
+		err := bitcoin.EnsureLoadedBtcWallet(conn)
+		require.Error(t, err)
+		clientMock.AssertExpectations(t)
+	})
 }

--- a/internal/adapters/dataproviders/bitcoin/derivative_wallet_test.go
+++ b/internal/adapters/dataproviders/bitcoin/derivative_wallet_test.go
@@ -212,7 +212,7 @@ func TestDerivativeWallet(t *testing.T) {
 			cases := derivativeWalletEstimateTxFeesErrorSetups(rskAccount)
 			for _, testCase := range cases {
 				client := &mocks.ClientAdapterMock{}
-				client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Once()
+				client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Twice()
 				client.On("GetAddressInfo", btcAddress).Return(existingAddressInfo, nil).Once()
 				t.Run(testCase.description, func(t *testing.T) {
 					testCase.setup(t, client)
@@ -227,7 +227,7 @@ func TestDerivativeWallet(t *testing.T) {
 			cases := derivativeWalletSendWithOpReturnErrorSetups(rskAccount)
 			for _, testCase := range cases {
 				client := &mocks.ClientAdapterMock{}
-				client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Once()
+				client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Twice()
 				client.On("GetAddressInfo", btcAddress).Return(existingAddressInfo, nil).Once()
 				t.Run(testCase.description, func(t *testing.T) {
 					testCase.setup(t, client)
@@ -282,7 +282,7 @@ func testAddress(t *testing.T, rskAccount *account.RskAccount, addressInfo *btcj
 
 func testGetBalance(t *testing.T, rskAccount *account.RskAccount, addressInfo *btcjson.GetAddressInfoResult) {
 	client := &mocks.ClientAdapterMock{}
-	client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Once()
+	client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Twice()
 	client.On("GetAddressInfo", btcAddress).Return(addressInfo, nil).Once()
 	parsedAddress, err := btcutil.DecodeAddress(btcAddress, &chaincfg.TestNet3Params)
 	require.NoError(t, err)
@@ -334,7 +334,7 @@ func testGetTransactions(t *testing.T, rskAccount *account.RskAccount, addressIn
 	client.EXPECT().GetRawTransactionVerbose(mock.Anything).RunAndReturn(func(hash *chainhash.Hash) (*btcjson.TxRawResult, error) {
 		return mockedTxs[*hash], nil
 	})
-	client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Once()
+	client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Twice()
 	client.On("GetAddressInfo", btcAddress).Return(addressInfo, nil).Once()
 	parsedAddress, err := btcutil.DecodeAddress(testnetAddress, &chaincfg.TestNet3Params)
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func testEstimateFees(t *testing.T, rskAccount *account.RskAccount, addressInfo 
 	client := &mocks.ClientAdapterMock{}
 	amount := entities.NewWei(5000000000000000)
 	floatAmount, _ := amount.ToRbtc().Float64()
-	client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Once()
+	client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Twice()
 	client.On("GetAddressInfo", btcAddress).Return(addressInfo, nil).Once()
 	client.On("EstimateSmartFee", int64(1), &btcjson.EstimateModeEconomical).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 1}, nil).Once()
 	client.On("WalletCreateFundedPsbt",
@@ -422,7 +422,7 @@ func testEstimateFees(t *testing.T, rskAccount *account.RskAccount, addressInfo 
 func testEstimateFeesExtra(t *testing.T, rskAccount *account.RskAccount, addressInfo *btcjson.GetAddressInfoResult) {
 	client := &mocks.ClientAdapterMock{}
 	amount := entities.NewWei(5000000000000000)
-	client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Once()
+	client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Twice()
 	client.On("GetAddressInfo", btcAddress).Return(addressInfo, nil).Once()
 	client.On("EstimateSmartFee", int64(1), &btcjson.EstimateModeEconomical).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 3}, nil).Once()
 	client.On("WalletCreateFundedPsbt",
@@ -451,7 +451,7 @@ func testSendWithOpReturn(t *testing.T, rskAccount *account.RskAccount, addressI
 	satoshis, _ := value.ToSatoshi().Float64()
 	address, err := btcutil.DecodeAddress(testnetAddress, &chaincfg.TestNet3Params)
 	require.NoError(t, err)
-	client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Once()
+	client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Twice()
 	client.On("GetAddressInfo", btcAddress).Return(addressInfo, nil).Once()
 	client.On("CreateRawTransaction",
 		([]btcjson.TransactionInput)(nil),
@@ -512,6 +512,9 @@ func derivativeWalletSendWithOpReturnErrorSetups(rskAccount *account.RskAccount)
 		{
 			description: "error parsing address",
 			setup: func(t *testing.T, client *mocks.ClientAdapterMock) {
+				// overwrite this expectation because if it fails to parse the address, it will not verify the wallet is loaded
+				client.EXPECT().GetWalletInfo().Unset()
+				client.EXPECT().GetWalletInfo().Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Once()
 				wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
 				require.NoError(t, err)
 				result, err := wallet.SendWithOpReturn(test.AnyString, entities.NewWei(1), []byte{0xf1})
@@ -648,6 +651,8 @@ func derivativeWalletEstimateTxFeesErrorSetups(rskAccount *account.RskAccount) [
 		{
 			description: "estimate for invalid address",
 			setup: func(t *testing.T, client *mocks.ClientAdapterMock) {
+				client.EXPECT().GetWalletInfo().Unset() // overwrite this expectation because if it fails to parse the address, it will not verify the wallet is loaded
+				client.EXPECT().GetWalletInfo().Return(&btcjson.GetWalletInfoResult{WalletName: bitcoin.DerivativeWalletId, Scanning: btcjson.ScanningOrFalse{Value: false}}, nil).Once()
 				wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
 				require.NoError(t, err)
 				result, err := wallet.EstimateTxFees(test.AnyString, entities.NewWei(1))

--- a/internal/adapters/dataproviders/bitcoin/watchonly_wallet.go
+++ b/internal/adapters/dataproviders/bitcoin/watchonly_wallet.go
@@ -70,10 +70,16 @@ func (wallet *WatchOnlyWallet) ImportAddress(address string) error {
 	if err != nil {
 		return err
 	}
+	if err = EnsureLoadedBtcWallet(wallet.conn); err != nil {
+		return err
+	}
 	return wallet.conn.client.ImportAddressRescan(address, "", false)
 }
 
 func (wallet *WatchOnlyWallet) GetTransactions(address string) ([]blockchain.BitcoinTransactionInformation, error) {
+	if err := EnsureLoadedBtcWallet(wallet.conn); err != nil {
+		return nil, err
+	}
 	return getTransactionsToAddress(address, wallet.conn.NetworkParams, wallet.conn.client)
 }
 

--- a/internal/adapters/dataproviders/bitcoin/watchonly_wallet_test.go
+++ b/internal/adapters/dataproviders/bitcoin/watchonly_wallet_test.go
@@ -204,7 +204,7 @@ func TestWatchOnlyWallet_GetTransactions(t *testing.T) {
 
 		parsedAddress, err := btcutil.DecodeAddress(testnetAddress, &chaincfg.TestNet3Params)
 		require.NoError(t, err)
-		client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{PrivateKeysEnabled: false}, nil).Once()
+		client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{PrivateKeysEnabled: false}, nil).Twice()
 		client.On("ListUnspentMinMaxAddresses", 0, 9999999, []btcutil.Address{parsedAddress}).Return(result, nil).Once()
 		wallet, err := bitcoin.NewWatchOnlyWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.PeginWalletId))
 		require.NoError(t, err)
@@ -218,7 +218,7 @@ func TestWatchOnlyWallet_GetTransactions(t *testing.T) {
 	})
 	t.Run("Error on RPC call", func(t *testing.T) {
 		client := &mocks.ClientAdapterMock{}
-		client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{PrivateKeysEnabled: false}, nil).Once()
+		client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{PrivateKeysEnabled: false}, nil).Times(5)
 		wallet, err := bitcoin.NewWatchOnlyWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.PeginWalletId))
 		require.NoError(t, err)
 		transactions, err := wallet.GetTransactions("invalidAddress")
@@ -255,7 +255,7 @@ func TestWatchOnlyWallet_ImportAddress(t *testing.T) {
 	t.Run("valid address", func(t *testing.T) {
 		client := &mocks.ClientAdapterMock{}
 		client.On("ImportAddressRescan", testnetAddress, "", false).Return(nil).Once()
-		client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{PrivateKeysEnabled: false}, nil).Once()
+		client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{PrivateKeysEnabled: false}, nil).Twice()
 		wallet, err := bitcoin.NewWatchOnlyWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.PeginWalletId))
 		require.NoError(t, err)
 		err = wallet.ImportAddress(testnetAddress)
@@ -264,7 +264,7 @@ func TestWatchOnlyWallet_ImportAddress(t *testing.T) {
 
 		client = &mocks.ClientAdapterMock{}
 		client.On("ImportAddressRescan", mainnetAddress, "", false).Return(nil).Once()
-		client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{PrivateKeysEnabled: false}, nil).Once()
+		client.On("GetWalletInfo").Return(&btcjson.GetWalletInfoResult{PrivateKeysEnabled: false}, nil).Twice()
 		wallet, err = bitcoin.NewWatchOnlyWallet(bitcoin.NewWalletConnection(&chaincfg.MainNetParams, client, bitcoin.PeginWalletId))
 		require.NoError(t, err)
 		err = wallet.ImportAddress(mainnetAddress)


### PR DESCRIPTION
## What
Added a check to ensure wallet is loaded before every interaction with a BTC wallet within the LPS and load the wallet if it isn't

## Why
To avoid the need of restarting the LPS if the BTC node is restarted

## Task
https://rsklabs.atlassian.net/browse/GBI-2152