### PR TITLE
feat: change pegout liquidity unit in liquidity endpoint

### DIFF
--- a/pkg/liquidity_provider.go
+++ b/pkg/liquidity_provider.go
@@ -79,7 +79,7 @@ type CredentialsUpdateRequest struct {
 
 type AvailableLiquidityDTO struct {
 	PeginLiquidityAmount  *big.Int `json:"peginLiquidityAmount" example:"5000000000000000000" description:"Available liquidity for PegIn operations in wei"  required:""`
-	PegoutLiquidityAmount *big.Int `json:"pegoutLiquidityAmount" example:"500000000" description:"Available liquidity for PegOut operations in satoshi" required:""`
+	PegoutLiquidityAmount *big.Int `json:"pegoutLiquidityAmount" example:"5000000000000000000" description:"Available liquidity for PegOut operations in wei" required:""`
 }
 
 type ServerInfoDTO struct {
@@ -88,10 +88,9 @@ type ServerInfoDTO struct {
 }
 
 func ToAvailableLiquidityDTO(entity liquidity_provider.AvailableLiquidity) AvailableLiquidityDTO {
-	satoshis, _ := entity.PegoutLiquidity.ToSatoshi().Int(nil)
 	return AvailableLiquidityDTO{
 		PeginLiquidityAmount:  entity.PeginLiquidity.AsBigInt(),
-		PegoutLiquidityAmount: satoshis,
+		PegoutLiquidityAmount: entity.PegoutLiquidity.AsBigInt(),
 	}
 }
 

--- a/pkg/liquidity_provider_test.go
+++ b/pkg/liquidity_provider_test.go
@@ -21,7 +21,7 @@ func TestToAvailableLiquidityDTO(t *testing.T) {
 	}
 	dto := pkg.ToAvailableLiquidityDTO(liquidity)
 	assert.Equal(t, "1234567890987654321", dto.PeginLiquidityAmount.String())
-	assert.Equal(t, "987654322", dto.PegoutLiquidityAmount.String())
+	assert.Equal(t, "9876543210123456789", dto.PegoutLiquidityAmount.String())
 }
 
 func TestFromPeginConfigurationDTO(t *testing.T) {


### PR DESCRIPTION
## What
Modify liquidity endpoint to return pegout liquidity expressed in wei

## Why
Change decided after the conversation started by @jd-iov in the task [GBI-2333](https://rsklabs.atlassian.net/browse/GBI-2333)