### PR TITLE
Feat/GBI-2485/Add rsk-monitor as a Docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,10 @@ utils-docker:
 	mkdir -p utils
 	docker build -f docker-compose/utils/Dockerfile --output=utils .
 
+MONITOR_PORT ?= 8090
 monitoring:
 	docker build -f docker-compose/monitoring/Dockerfile -t monitoring .
 	docker run \
-		-p 8080:8080 \
+		-p $(MONITOR_PORT):$(MONITOR_PORT) \
+		-e MONITOR_PORT=$(MONITOR_PORT) \
 		monitoring

--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,9 @@ utils-docker:
 	rm -rf utils
 	mkdir -p utils
 	docker build -f docker-compose/utils/Dockerfile --output=utils .
+
+monitoring:
+	docker build -f docker-compose/monitoring/Dockerfile -t monitoring .
+	docker run \
+		-p 8080:8080 \
+		monitoring

--- a/README.md
+++ b/README.md
@@ -70,22 +70,13 @@ make monitoring
 ```
 The service is configured in `docker-compose/monitoring/src/config.ts` and supports both testnet and mainnet monitoring:
 
-- **Testnet monitoring** (enabled by default):
-  - Monitors 3 testnet addresses with 10-second polling interval
-  - The preconfigured addresses are:
-    - mwEceC31MwWmF6hc5SSQ8FmbgdsSoBSnbm (testnet1)
-    - mvL2bVzGUeC9oqVyQWJ4PxQspFzKgjzAqe (testnet2)
-    - tb1q7hec37mcmfk6hmqn67echzdf8zwg5n5pqnfzma (testnet3)
-
-- **Mainnet monitoring** (commented out by default):
-  - Can be enabled by uncommenting the mainnet configuration in config.ts
-  - The preconfigured addresses were taken randomly from mainnet and are:
-    - bc1qv7l4jgnzxyjgn598ee04l72lanudx50fqpdq0t (mainnet1)
-    - 3DGxAYYUA61WrrdbBac8Ra9eA9peAQwTJF (mainnet2)
+- MONITORED_ADDRESSES: The set of addresses to be monitored. Each address should have an alias that will be used in the metrics.
+- MONITOR_CONFIG: The configuration for the monitoring service.
+  - pollingIntervalSeconds: How often the service will check the bitcoin balance of the monitored addresses in seconds.
+  - monitorName: The name of the monitoring service.
+  - network: The network to monitor (mainnet or testnet).
 
 The service can be configured to monitor other addresses by modifying the `MONITORED_ADDRESSES` array in `docker-compose/monitoring/src/config.ts`.
-
-The metrics endpoint provides balance information for the monitored addresses.
 
 
 ### More information

--- a/README.md
+++ b/README.md
@@ -64,10 +64,16 @@ on special cases. This script requires an input file whose structure can be foun
 ### Monitoring Service
 The project includes a Bitcoin balance monitoring service that tracks specified BTC addresses and exposes metrics at `http://<host>:8080/metrics` using Prometheus `https://prometheus.io/`.
 
-To run the monitoring service:
+To run the monitoring service with the default port (8090):
 ```bash
 make monitoring
 ```
+
+To run the monitoring service with a custom port (e.g., 8091):
+```bash
+make monitoring MONITOR_PORT=8091
+```
+
 The service is configured in `docker-compose/monitoring/src/config.ts` and supports both testnet and mainnet monitoring:
 
 - MONITORED_ADDRESSES: The set of addresses to be monitored. Each address should have an alias that will be used in the metrics.
@@ -75,6 +81,7 @@ The service is configured in `docker-compose/monitoring/src/config.ts` and suppo
   - pollingIntervalSeconds: How often the service will check the bitcoin balance of the monitored addresses in seconds.
   - monitorName: The name of the monitoring service.
   - network: The network to monitor (mainnet or testnet).
+  - port: The port where the service will be exposed.
 
 The service can be configured to monitor other addresses by modifying the `MONITORED_ADDRESSES` array in `docker-compose/monitoring/src/config.ts`.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,33 @@ on special cases. This script requires an input file whose structure can be foun
 - **refund_user_pegout**: executes a refund for a user's peg-out operation through the Liquidity Bridge Contract. This is used when a peg-out operation needs to be refunded back to the user's RSK address. The script requires the quote hash of the operation to refund.
 - **key_conversion**: shows the corresponding BTC and RSK address for a given private key and encrypts it into a keystore, accepts the key either in WIF or hex format. The key can be provided through the terminal, a file or an existing keystore.
 
+### Monitoring Service
+The project includes a Bitcoin balance monitoring service that tracks specified BTC addresses and exposes metrics at `http://<host>:8080/metrics` using Prometheus `https://prometheus.io/`.
+
+To run the monitoring service:
+```bash
+make monitoring
+```
+The service is configured in `docker-compose/monitoring/src/config.ts` and supports both testnet and mainnet monitoring:
+
+- **Testnet monitoring** (enabled by default):
+  - Monitors 3 testnet addresses with 10-second polling interval
+  - The preconfigured addresses are:
+    - mwEceC31MwWmF6hc5SSQ8FmbgdsSoBSnbm (testnet1)
+    - mvL2bVzGUeC9oqVyQWJ4PxQspFzKgjzAqe (testnet2)
+    - tb1q7hec37mcmfk6hmqn67echzdf8zwg5n5pqnfzma (testnet3)
+
+- **Mainnet monitoring** (commented out by default):
+  - Can be enabled by uncommenting the mainnet configuration in config.ts
+  - The preconfigured addresses were taken randomly from mainnet and are:
+    - bc1qv7l4jgnzxyjgn598ee04l72lanudx50fqpdq0t (mainnet1)
+    - 3DGxAYYUA61WrrdbBac8Ra9eA9peAQwTJF (mainnet2)
+
+The service can be configured to monitor other addresses by modifying the `MONITORED_ADDRESSES` array in `docker-compose/monitoring/src/config.ts`.
+
+The metrics endpoint provides balance information for the monitored addresses.
+
+
 ### More information
 If you're looking forward to integrate with Flyover Protocol then you can check the [Flyover SDK repository](https://github.com/rsksmart/unified-bridges-sdk/tree/main/packages/flyover-sdk).
 

--- a/docker-compose/monitoring/.dockerignore
+++ b/docker-compose/monitoring/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+**/node_modules
+npm-debug.log
+dist
+lib 

--- a/docker-compose/monitoring/Dockerfile
+++ b/docker-compose/monitoring/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:18-alpine
+
+# Set working directory to monitoring project
+WORKDIR /app/monitoring
+
+# Copy only the monitoring project files
+COPY docker-compose/monitoring ./
+
+# Install dependencies and build
+RUN npm install && npm run build
+
+# Expose port 8080 for metrics
+EXPOSE 8080
+
+# Run the monitoring service
+CMD ["npx", "ts-node", "src/index.ts"] 

--- a/docker-compose/monitoring/Dockerfile
+++ b/docker-compose/monitoring/Dockerfile
@@ -9,8 +9,5 @@ COPY docker-compose/monitoring ./
 # Install dependencies and build
 RUN npm install && npm run build
 
-# Expose port 8080 for metrics
-EXPOSE 8080
-
 # Run the monitoring service
 CMD ["npx", "ts-node", "src/index.ts"] 

--- a/docker-compose/monitoring/package.json
+++ b/docker-compose/monitoring/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "bitcoin",
+  "version": "1.0.0",
+  "description": "Bitcoin balance monitor sample",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "ts-node src/index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@mempool/mempool.js": "^2.3.0",
+    "@types/node": "^20.11.19",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3",
+    "@rsksmart/rsk-monitor": "^0.1.0"
+  }
+}

--- a/docker-compose/monitoring/src/config.ts
+++ b/docker-compose/monitoring/src/config.ts
@@ -1,13 +1,9 @@
 import { type BitcoinAddress } from '@rsksmart/rsk-monitor'
 
-
-/**
- * Uncomment this to monitor testnet addresses
- */
 export const MONITORED_ADDRESSES: BitcoinAddress[] = [
-  { address: 'mwEceC31MwWmF6hc5SSQ8FmbgdsSoBSnbm', alias: 'testnet1' },
-  { address: 'mvL2bVzGUeC9oqVyQWJ4PxQspFzKgjzAqe', alias: 'testnet2' },
-  { address: 'tb1q7hec37mcmfk6hmqn67echzdf8zwg5n5pqnfzma', alias: 'testnet3' }
+  { address: 'mwEc...', alias: 'testnet1' },
+  { address: 'mvL2...', alias: 'testnet2' },
+  { address: 'tb1q7...', alias: 'testnet3' }
 ]
 
 export const MONITOR_CONFIG = {
@@ -15,18 +11,3 @@ export const MONITOR_CONFIG = {
   monitorName: 'bitcoin-balance-monitor',
   network: 'testnet' as 'mainnet' | 'testnet'
 } 
-
-
-/**
- * Uncomment this to monitor mainnet addresses
- */
-// export const MONITORED_ADDRESSES: BitcoinAddress[] = [
-//   { address: 'bc1qv7l4jgnzxyjgn598ee04l72lanudx50fqpdq0t', alias: 'mainnet1' },
-//   { address: '3DGxAYYUA61WrrdbBac8Ra9eA9peAQwTJF', alias: 'mainnet2' }
-// ]
-
-// export const MONITOR_CONFIG = {
-//   pollingIntervalSeconds: 2 * 60,
-//   monitorName: 'bitcoin-balance-monitor',
-//   network: 'mainnet' as 'mainnet' | 'testnet'
-// } 

--- a/docker-compose/monitoring/src/config.ts
+++ b/docker-compose/monitoring/src/config.ts
@@ -1,0 +1,32 @@
+import { type BitcoinAddress } from '@rsksmart/rsk-monitor'
+
+
+/**
+ * Uncomment this to monitor testnet addresses
+ */
+export const MONITORED_ADDRESSES: BitcoinAddress[] = [
+  { address: 'mwEceC31MwWmF6hc5SSQ8FmbgdsSoBSnbm', alias: 'testnet1' },
+  { address: 'mvL2bVzGUeC9oqVyQWJ4PxQspFzKgjzAqe', alias: 'testnet2' },
+  { address: 'tb1q7hec37mcmfk6hmqn67echzdf8zwg5n5pqnfzma', alias: 'testnet3' }
+]
+
+export const MONITOR_CONFIG = {
+  pollingIntervalSeconds: 10,
+  monitorName: 'bitcoin-balance-monitor',
+  network: 'testnet' as 'mainnet' | 'testnet'
+} 
+
+
+/**
+ * Uncomment this to monitor mainnet addresses
+ */
+// export const MONITORED_ADDRESSES: BitcoinAddress[] = [
+//   { address: 'bc1qv7l4jgnzxyjgn598ee04l72lanudx50fqpdq0t', alias: 'mainnet1' },
+//   { address: '3DGxAYYUA61WrrdbBac8Ra9eA9peAQwTJF', alias: 'mainnet2' }
+// ]
+
+// export const MONITOR_CONFIG = {
+//   pollingIntervalSeconds: 2 * 60,
+//   monitorName: 'bitcoin-balance-monitor',
+//   network: 'mainnet' as 'mainnet' | 'testnet'
+// } 

--- a/docker-compose/monitoring/src/config.ts
+++ b/docker-compose/monitoring/src/config.ts
@@ -9,5 +9,6 @@ export const MONITORED_ADDRESSES: BitcoinAddress[] = [
 export const MONITOR_CONFIG = {
   pollingIntervalSeconds: 10,
   monitorName: 'bitcoin-balance-monitor',
-  network: 'testnet' as 'mainnet' | 'testnet'
+  network: 'testnet' as 'mainnet' | 'testnet',
+  port: parseInt(process.env.MONITOR_PORT || '8090', 10)
 } 

--- a/docker-compose/monitoring/src/index.ts
+++ b/docker-compose/monitoring/src/index.ts
@@ -8,7 +8,7 @@ async function main (): Promise<void> {
     network: MONITOR_CONFIG.network
   } as MonitorConfig, MONITORED_ADDRESSES)
     .withBalanceMetric()
-    .withExporters(new ConsoleExporter(), new PrometheusExporter(8080, 'bitcoinbalancemonitor'))
+    .withExporters(new ConsoleExporter(), new PrometheusExporter(MONITOR_CONFIG.port, 'bitcoinbalancemonitor'))
     .build()
     .run()
 

--- a/docker-compose/monitoring/src/index.ts
+++ b/docker-compose/monitoring/src/index.ts
@@ -1,0 +1,24 @@
+import { BitcoinMempoolMonitorBuilder, ConsoleExporter, MonitorConfig, PrometheusExporter } from '@rsksmart/rsk-monitor'
+import { MONITORED_ADDRESSES, MONITOR_CONFIG } from './config'
+
+async function main (): Promise<void> {
+  await BitcoinMempoolMonitorBuilder.create({
+    pollingIntervalSeconds: MONITOR_CONFIG.pollingIntervalSeconds,
+    monitorName: MONITOR_CONFIG.monitorName,
+    network: MONITOR_CONFIG.network
+  } as MonitorConfig, MONITORED_ADDRESSES)
+    .withBalanceMetric()
+    .withExporters(new ConsoleExporter(), new PrometheusExporter(8080, 'bitcoinbalancemonitor'))
+    .build()
+    .run()
+
+  console.log('Starting Bitcoin balance monitor...')
+  console.log('Monitoring addresses:', MONITORED_ADDRESSES)
+
+  process.on('SIGINT', () => {
+    console.log('Stopping monitor...')
+    process.exit(0)
+  })
+}
+
+main().catch(console.error)

--- a/docker-compose/monitoring/tsconfig.json
+++ b/docker-compose/monitoring/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+} 


### PR DESCRIPTION
## What
-Add a Docker container to use [rsk-monitor](https://github.com/rsksmart/rsk-monitor) and give metrics about BTC addresses.
-Add a command in the Makefile to easily run the container.

## Why
This is part of the delivery strategy of the monitor for Systema

[Jira tk](https://rsklabs.atlassian.net/browse/GBI-2485)