### PR TITLE
Update sed usage based on OS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @Luisfc68 @MaximStanciu8 @gsoares85 @Dominikkq @AndresQuijano

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Building LPS environment...
         run: cd docker-compose/local/ && LPS_STAGE=regtest sh lps-env.sh up
+        shell: bash
 
       - name: Checking LPS health...
         run: curl -X GET http://localhost:8080/health

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,11 +27,11 @@ jobs:
         run: cd docker-compose/local/ && ./gh-action-env.sh $GITHUB_TOKEN
 
       - name: Building LPS environment...
-        run: cd docker-compose/local/ && LPS_STAGE=regtest sh lps-env.sh up
+        run: cd docker-compose/local/ && LPS_STAGE=regtest ./lps-env.sh up
         shell: bash
 
       - name: Checking LPS health...
         run: curl -X GET http://localhost:8080/health
 
       - name: Shutting LPS environment down...
-        run: cd docker-compose/local/ && LPS_STAGE=regtest sh lps-env.sh down
+        run: cd docker-compose/local/ && LPS_STAGE=regtest ./lps-env.sh down

--- a/docker-compose/local/lps-env.sh
+++ b/docker-compose/local/lps-env.sh
@@ -7,6 +7,22 @@ COMMIT_TAG=$(git describe --exact-match --tags || echo "")
 export COMMIT_HASH
 export COMMIT_TAG
 
+# Detect OS
+OS_TYPE="$(uname)"
+
+if [[ "$OS_TYPE" == "Darwin" ]]; then
+    # macOS
+    echo "Running on macOS"
+    SED_INPLACE=("sed" "-i" "")
+elif [[ "$OS_TYPE" == "Linux" ]]; then
+    # Assume Ubuntu or other Linux
+    echo "Running on Linux"
+    SED_INPLACE=("sed" "-i")
+else
+    echo "Unsupported OS: $OS_TYPE"
+    exit 1
+fi
+
 if [ -z "${LPS_STAGE}" ]; then
   echo "LPS_STAGE is not set. Exit 1"
   exit 1
@@ -33,7 +49,7 @@ echo "LPS_STAGE: $LPS_STAGE; ENV_FILE: $ENV_FILE; LPS_UID: $LPS_UID"
 
 # Force Management API to be enabled
 if [ -f "$ENV_FILE" ]; then
-  sed -i 's/^ENABLE_MANAGEMENT_API=.*/ENABLE_MANAGEMENT_API=true/' "$ENV_FILE"
+  "${SED_INPLACE[@]}" 's/^ENABLE_MANAGEMENT_API=.*/ENABLE_MANAGEMENT_API=true/' "$ENV_FILE"
 fi
 
 SCRIPT_CMD=$1


### PR DESCRIPTION
## What
- Add CODEOWNERS file
- Update local script to be usable both in the pipeline and in the Mac local environment without modifying it manually

## Why
Since `sed` command has a different behavior in MacOS and Ubuntu the local script required some manual modifications in order to run in the local env