### PR TITLE
fix: bson typo

### DIFF
--- a/internal/entities/quote/pegin_quote.go
+++ b/internal/entities/quote/pegin_quote.go
@@ -46,7 +46,7 @@ type CreatedPeginQuote struct {
 
 type PeginCreationData struct {
 	GasPrice      *entities.Wei   `json:"gasPrice" bson:"gas_price" validate:"required"`
-	FeePercentage *utils.BigFloat `json:"feePercentage" bson:"gte=0,lt=100,max_decimal_places=2" validate:"required"`
+	FeePercentage *utils.BigFloat `json:"feePercentage" bson:"fee_percentage" validate:"required"`
 	FixedFee      *entities.Wei   `json:"fixedFee" bson:"fixed_fee" validate:"required"`
 }
 

--- a/internal/entities/quote/pegout_quote.go
+++ b/internal/entities/quote/pegout_quote.go
@@ -53,7 +53,7 @@ type CreatedPegoutQuote struct {
 
 type PegoutCreationData struct {
 	FeeRate       *utils.BigFloat `json:"feeRate" bson:"fee_rate" validate:"required"`
-	FeePercentage *utils.BigFloat `json:"feePercentage" bson:"gte=0,lt=100,max_decimal_places=2" validate:"required"`
+	FeePercentage *utils.BigFloat `json:"feePercentage" bson:"fee_percentage" validate:"required"`
 	GasPrice      *entities.Wei   `json:"gasPrice" bson:"gas_price" validate:"required"`
 	FixedFee      *entities.Wei   `json:"fixedFee" bson:"fixed_fee" validate:"required"`
 }


### PR DESCRIPTION
## What
Fix typo introduced in 2222e24eb6904b9293262cff9b1c009510674c42 

## Why
Because this typo is making the server serialize the document with the wrong name
