### PR TITLE
feat: add functionality to accept pegout quote without CAPTCHA 

### DIFF
--- a/OpenApi.yml
+++ b/OpenApi.yml
@@ -534,6 +534,7 @@ components:
     ProviderDetail:
       properties:
         fee:
+          deprecated: true
           type: integer
         feePercentage:
           type: number

--- a/OpenApi.yml
+++ b/OpenApi.yml
@@ -534,7 +534,6 @@ components:
     ProviderDetail:
       properties:
         fee:
-          deprecated: true
           type: integer
         feePercentage:
           type: number
@@ -708,6 +707,20 @@ components:
           type: string
         rbtcLockingCap:
           $ref: '#/components/schemas/'
+      type: object
+    pkg.AcceptAuthenticatedQuoteRequest:
+      properties:
+        quoteHash:
+          description: QuoteHash
+          example: "0x0"
+          type: string
+        signature:
+          description: Signature from a trusted account
+          example: "0x0"
+          type: string
+      required:
+      - quoteHash
+      - signature
       type: object
     pkg.AcceptPeginRespose:
       properties:
@@ -1001,6 +1014,23 @@ paths:
                 $ref: '#/components/schemas/PeginQuoteStatusDTO'
           description: Object containing the quote itself and its status
       summary: GetPeginStatus
+  /pegout/acceptAuthenticatedQuote:
+    post:
+      description: ' Accepts Quote with trusted account signature'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AcceptAuthenticatedQuoteRequest'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/'
+          description: ""
+      summary: Accept authenticated quote
   /pegout/acceptQuote:
     post:
       description: ' Accepts Quote Pegout'

--- a/OpenApi.yml
+++ b/OpenApi.yml
@@ -736,6 +736,20 @@ components:
       - signature
       - bitcoinDepositAddressHash
       type: object
+    pkg.AcceptPegoutResponse:
+      properties:
+        lbcAddress:
+          description: LBC address to execute depositPegout function
+          example: "0x0"
+          type: string
+        signature:
+          description: Signature of the quote
+          example: "0x0"
+          type: string
+      required:
+      - signature
+      - lbcAddress
+      type: object
     pkg.AcceptQuoteRequest:
       properties:
         quoteHash:
@@ -1028,7 +1042,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/'
+                $ref: '#/components/schemas/AcceptPegoutResponse'
           description: ""
       summary: Accept authenticated quote
   /pegout/acceptQuote:

--- a/internal/adapters/dataproviders/database/mongo/pegout_test.go
+++ b/internal/adapters/dataproviders/database/mongo/pegout_test.go
@@ -2,6 +2,10 @@ package mongo_test
 
 import (
 	"context"
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/dataproviders/database/mongo"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
@@ -18,9 +22,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	mongoDb "go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"reflect"
-	"testing"
-	"time"
 )
 
 var testPegoutQuote = quote.PegoutQuote{
@@ -46,15 +47,16 @@ var testPegoutQuote = quote.PegoutQuote{
 }
 
 var testRetainedPegoutQuote = quote.RetainedPegoutQuote{
-	QuoteHash:          "27d70ec2bc2c3154dc9a5b53b118a755441b22bc1c8ccde967ed33609970c25f",
-	DepositAddress:     "mkE1WWdiu5VgjfugomDk8GxV6JdEEEJR9s",
-	Signature:          "5c9eab91c753355f87c19d09ea88b2fd02773981e513bc2821fed5ceba0d452a0a3d21e2252cb35348ce5c6803117e3abb62837beb8f5866a375ce66587d004b1c",
-	RequiredLiquidity:  entities.NewWei(55),
-	State:              quote.PegoutStateWaitingForDepositConfirmations,
-	UserRskTxHash:      "0x6b2e1e4daf8cf00c5c3534b72cdeec3526e8a38f70c11e44888b6e4ae1ee7d38",
-	LpBtcTxHash:        "6ac3779dc33ad52f3409cbb909bcd458745995496a2a3954406206f6e5d4cb0e",
-	RefundPegoutTxHash: "0x8e773a2826e73f8e5792304379a7e46dff38f17089c6d344335e03537b31c2bc",
-	BridgeRefundTxHash: "0x4f3f6f0664a732e4c907971e75c1e3fd8671461dcb53f566660432fc47255d8b",
+	QuoteHash:           "27d70ec2bc2c3154dc9a5b53b118a755441b22bc1c8ccde967ed33609970c25f",
+	DepositAddress:      "mkE1WWdiu5VgjfugomDk8GxV6JdEEEJR9s",
+	Signature:           "5c9eab91c753355f87c19d09ea88b2fd02773981e513bc2821fed5ceba0d452a0a3d21e2252cb35348ce5c6803117e3abb62837beb8f5866a375ce66587d004b1c",
+	RequiredLiquidity:   entities.NewWei(55),
+	State:               quote.PegoutStateWaitingForDepositConfirmations,
+	UserRskTxHash:       "0x6b2e1e4daf8cf00c5c3534b72cdeec3526e8a38f70c11e44888b6e4ae1ee7d38",
+	LpBtcTxHash:         "6ac3779dc33ad52f3409cbb909bcd458745995496a2a3954406206f6e5d4cb0e",
+	RefundPegoutTxHash:  "0x8e773a2826e73f8e5792304379a7e46dff38f17089c6d344335e03537b31c2bc",
+	BridgeRefundTxHash:  "0x4f3f6f0664a732e4c907971e75c1e3fd8671461dcb53f566660432fc47255d8b",
+	OwnerAccountAddress: "0x233845a26a4dA08E16218e7B401501D048670674",
 }
 
 var testPegoutDeposit = quote.PegoutDeposit{
@@ -181,7 +183,7 @@ func TestPegoutMongoRepository_GetRetainedQuote(t *testing.T) {
 	client, collection := getClientAndCollectionMocks(mongo.RetainedPegoutQuoteCollection)
 	log.SetLevel(log.DebugLevel)
 	t.Run("Get retained pegout quote successfully", func(t *testing.T) {
-		const expectedLog = "READ interaction with db: {QuoteHash:27d70ec2bc2c3154dc9a5b53b118a755441b22bc1c8ccde967ed33609970c25f DepositAddress:mkE1WWdiu5VgjfugomDk8GxV6JdEEEJR9s Signature:5c9eab91c753355f87c19d09ea88b2fd02773981e513bc2821fed5ceba0d452a0a3d21e2252cb35348ce5c6803117e3abb62837beb8f5866a375ce66587d004b1c RequiredLiquidity:55 State:WaitingForDepositConfirmations UserRskTxHash:0x6b2e1e4daf8cf00c5c3534b72cdeec3526e8a38f70c11e44888b6e4ae1ee7d38 LpBtcTxHash:6ac3779dc33ad52f3409cbb909bcd458745995496a2a3954406206f6e5d4cb0e RefundPegoutTxHash:0x8e773a2826e73f8e5792304379a7e46dff38f17089c6d344335e03537b31c2bc BridgeRefundTxHash:0x4f3f6f0664a732e4c907971e75c1e3fd8671461dcb53f566660432fc47255d8b}"
+		const expectedLog = "READ interaction with db: {QuoteHash:27d70ec2bc2c3154dc9a5b53b118a755441b22bc1c8ccde967ed33609970c25f DepositAddress:mkE1WWdiu5VgjfugomDk8GxV6JdEEEJR9s Signature:5c9eab91c753355f87c19d09ea88b2fd02773981e513bc2821fed5ceba0d452a0a3d21e2252cb35348ce5c6803117e3abb62837beb8f5866a375ce66587d004b1c RequiredLiquidity:55 State:WaitingForDepositConfirmations UserRskTxHash:0x6b2e1e4daf8cf00c5c3534b72cdeec3526e8a38f70c11e44888b6e4ae1ee7d38 LpBtcTxHash:6ac3779dc33ad52f3409cbb909bcd458745995496a2a3954406206f6e5d4cb0e RefundPegoutTxHash:0x8e773a2826e73f8e5792304379a7e46dff38f17089c6d344335e03537b31c2bc BridgeRefundTxHash:0x4f3f6f0664a732e4c907971e75c1e3fd8671461dcb53f566660432fc47255d8b OwnerAccountAddress:0x233845a26a4dA08E16218e7B401501D048670674}"
 		repo := mongo.NewPegoutMongoRepository(mongo.NewConnection(client, time.Duration(1)))
 		collection.On("FindOne", mock.Anything, bson.D{primitive.E{Key: "quote_hash", Value: test.AnyHash}}).
 			Return(mongoDb.NewSingleResultFromDocument(testRetainedPegoutQuote, nil, nil)).Once()
@@ -220,7 +222,7 @@ func TestPegoutMongoRepository_GetRetainedQuote(t *testing.T) {
 
 func TestPegoutMongoRepository_InsertRetainedQuote(t *testing.T) {
 	t.Run("Insert retained pegout quote successfully", func(t *testing.T) {
-		const expectedLog = "INSERT interaction with db: {QuoteHash:27d70ec2bc2c3154dc9a5b53b118a755441b22bc1c8ccde967ed33609970c25f DepositAddress:mkE1WWdiu5VgjfugomDk8GxV6JdEEEJR9s Signature:5c9eab91c753355f87c19d09ea88b2fd02773981e513bc2821fed5ceba0d452a0a3d21e2252cb35348ce5c6803117e3abb62837beb8f5866a375ce66587d004b1c RequiredLiquidity:55 State:WaitingForDepositConfirmations UserRskTxHash:0x6b2e1e4daf8cf00c5c3534b72cdeec3526e8a38f70c11e44888b6e4ae1ee7d38 LpBtcTxHash:6ac3779dc33ad52f3409cbb909bcd458745995496a2a3954406206f6e5d4cb0e RefundPegoutTxHash:0x8e773a2826e73f8e5792304379a7e46dff38f17089c6d344335e03537b31c2bc BridgeRefundTxHash:0x4f3f6f0664a732e4c907971e75c1e3fd8671461dcb53f566660432fc47255d8b}"
+		const expectedLog = "INSERT interaction with db: {QuoteHash:27d70ec2bc2c3154dc9a5b53b118a755441b22bc1c8ccde967ed33609970c25f DepositAddress:mkE1WWdiu5VgjfugomDk8GxV6JdEEEJR9s Signature:5c9eab91c753355f87c19d09ea88b2fd02773981e513bc2821fed5ceba0d452a0a3d21e2252cb35348ce5c6803117e3abb62837beb8f5866a375ce66587d004b1c RequiredLiquidity:55 State:WaitingForDepositConfirmations UserRskTxHash:0x6b2e1e4daf8cf00c5c3534b72cdeec3526e8a38f70c11e44888b6e4ae1ee7d38 LpBtcTxHash:6ac3779dc33ad52f3409cbb909bcd458745995496a2a3954406206f6e5d4cb0e RefundPegoutTxHash:0x8e773a2826e73f8e5792304379a7e46dff38f17089c6d344335e03537b31c2bc BridgeRefundTxHash:0x4f3f6f0664a732e4c907971e75c1e3fd8671461dcb53f566660432fc47255d8b OwnerAccountAddress:0x233845a26a4dA08E16218e7B401501D048670674}"
 		client, collection := getClientAndCollectionMocks(mongo.RetainedPegoutQuoteCollection)
 		collection.On("InsertOne", mock.Anything, mock.MatchedBy(func(q quote.RetainedPegoutQuote) bool {
 			return q.QuoteHash == testRetainedPegoutQuote.QuoteHash && reflect.TypeOf(quote.RetainedPegoutQuote{}).NumField() == test.CountNonZeroValues(q)
@@ -246,7 +248,7 @@ func TestPegoutMongoRepository_InsertRetainedQuote(t *testing.T) {
 func TestPegoutMongoRepository_UpdateRetainedQuote(t *testing.T) {
 	const updated = "updated value"
 	t.Run("Update retained pegout quote successfully", func(t *testing.T) {
-		const expectedLog = "UPDATE interaction with db: {QuoteHash:27d70ec2bc2c3154dc9a5b53b118a755441b22bc1c8ccde967ed33609970c25f DepositAddress:updated value Signature:updated value RequiredLiquidity:200 State:SendPegoutFailed UserRskTxHash:updated value LpBtcTxHash:updated value RefundPegoutTxHash:updated value BridgeRefundTxHash:updated value}"
+		const expectedLog = "UPDATE interaction with db: {QuoteHash:27d70ec2bc2c3154dc9a5b53b118a755441b22bc1c8ccde967ed33609970c25f DepositAddress:updated value Signature:updated value RequiredLiquidity:200 State:SendPegoutFailed UserRskTxHash:updated value LpBtcTxHash:updated value RefundPegoutTxHash:updated value BridgeRefundTxHash:updated value OwnerAccountAddress:0x233845a26a4dA08E16218e7B401501D048670674}"
 		client, collection := getClientAndCollectionMocks(mongo.RetainedPegoutQuoteCollection)
 		updatedQuote := testRetainedPegoutQuote
 		updatedQuote.State = quote.PegoutStateSendPegoutFailed
@@ -404,7 +406,7 @@ func TestPegoutMongoRepository_GetRetainedQuoteByState(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	states := []quote.PegoutState{quote.PegoutStateSendPegoutSucceeded, quote.PegoutStateSendPegoutFailed}
 	t.Run("Get retained pegout quotes by state successfully", func(t *testing.T) {
-		const expectedLog = "READ interaction with db: [{QuoteHash:27d70ec2bc2c3154dc9a5b53b118a755441b22bc1c8ccde967ed33609970c25f DepositAddress:mkE1WWdiu5VgjfugomDk8GxV6JdEEEJR9s Signature:5c9eab91c753355f87c19d09ea88b2fd02773981e513bc2821fed5ceba0d452a0a3d21e2252cb35348ce5c6803117e3abb62837beb8f5866a375ce66587d004b1c RequiredLiquidity:55 State:WaitingForDepositConfirmations UserRskTxHash:0x6b2e1e4daf8cf00c5c3534b72cdeec3526e8a38f70c11e44888b6e4ae1ee7d38 LpBtcTxHash:6ac3779dc33ad52f3409cbb909bcd458745995496a2a3954406206f6e5d4cb0e RefundPegoutTxHash:0x8e773a2826e73f8e5792304379a7e46dff38f17089c6d344335e03537b31c2bc BridgeRefundTxHash:0x4f3f6f0664a732e4c907971e75c1e3fd8671461dcb53f566660432fc47255d8b} {QuoteHash:other hash DepositAddress:mkE1WWdiu5VgjfugomDk8GxV6JdEEEJR9s Signature:456 RequiredLiquidity:777 State:WaitingForDepositConfirmations UserRskTxHash:0x6b2e1e4daf8cf00c5c3534b72cdeec3526e8a38f70c11e44888b6e4ae1ee7d38 LpBtcTxHash:6ac3779dc33ad52f3409cbb909bcd458745995496a2a3954406206f6e5d4cb0e RefundPegoutTxHash:0x8e773a2826e73f8e5792304379a7e46dff38f17089c6d344335e03537b31c2bc BridgeRefundTxHash:0x4f3f6f0664a732e4c907971e75c1e3fd8671461dcb53f566660432fc47255d8b}]"
+		const expectedLog = "READ interaction with db: [{QuoteHash:27d70ec2bc2c3154dc9a5b53b118a755441b22bc1c8ccde967ed33609970c25f DepositAddress:mkE1WWdiu5VgjfugomDk8GxV6JdEEEJR9s Signature:5c9eab91c753355f87c19d09ea88b2fd02773981e513bc2821fed5ceba0d452a0a3d21e2252cb35348ce5c6803117e3abb62837beb8f5866a375ce66587d004b1c RequiredLiquidity:55 State:WaitingForDepositConfirmations UserRskTxHash:0x6b2e1e4daf8cf00c5c3534b72cdeec3526e8a38f70c11e44888b6e4ae1ee7d38 LpBtcTxHash:6ac3779dc33ad52f3409cbb909bcd458745995496a2a3954406206f6e5d4cb0e RefundPegoutTxHash:0x8e773a2826e73f8e5792304379a7e46dff38f17089c6d344335e03537b31c2bc BridgeRefundTxHash:0x4f3f6f0664a732e4c907971e75c1e3fd8671461dcb53f566660432fc47255d8b OwnerAccountAddress:0x233845a26a4dA08E16218e7B401501D048670674} {QuoteHash:other hash DepositAddress:mkE1WWdiu5VgjfugomDk8GxV6JdEEEJR9s Signature:456 RequiredLiquidity:777 State:WaitingForDepositConfirmations UserRskTxHash:0x6b2e1e4daf8cf00c5c3534b72cdeec3526e8a38f70c11e44888b6e4ae1ee7d38 LpBtcTxHash:6ac3779dc33ad52f3409cbb909bcd458745995496a2a3954406206f6e5d4cb0e RefundPegoutTxHash:0x8e773a2826e73f8e5792304379a7e46dff38f17089c6d344335e03537b31c2bc BridgeRefundTxHash:0x4f3f6f0664a732e4c907971e75c1e3fd8671461dcb53f566660432fc47255d8b OwnerAccountAddress:0x233845a26a4dA08E16218e7B401501D048670674}]"
 		repo := mongo.NewPegoutMongoRepository(mongo.NewConnection(client, time.Duration(1)))
 		secondQuote := testRetainedPegoutQuote
 		secondQuote.QuoteHash = "other hash"
@@ -559,7 +561,7 @@ func TestPegoutMongoRepository_UpdateRetainedQuotes(t *testing.T) {
 		{QuoteHash: "quote2", DepositAddress: test.AnyAddress, Signature: test.AnyString, RequiredLiquidity: entities.NewWei(2000), State: quote.PegoutStateSendPegoutFailed},
 	}
 	t.Run("Update retained quotes successfully", func(t *testing.T) {
-		const expectedLog = "UPDATE interaction with db: [{QuoteHash:quote1 DepositAddress:any address Signature:any value RequiredLiquidity:1000 State:SendPegoutSucceeded UserRskTxHash: LpBtcTxHash: RefundPegoutTxHash: BridgeRefundTxHash:} {QuoteHash:quote2 DepositAddress:any address Signature:any value RequiredLiquidity:2000 State:SendPegoutFailed UserRskTxHash: LpBtcTxHash: RefundPegoutTxHash: BridgeRefundTxHash:}]"
+		const expectedLog = "UPDATE interaction with db: [{QuoteHash:quote1 DepositAddress:any address Signature:any value RequiredLiquidity:1000 State:SendPegoutSucceeded UserRskTxHash: LpBtcTxHash: RefundPegoutTxHash: BridgeRefundTxHash: OwnerAccountAddress:} {QuoteHash:quote2 DepositAddress:any address Signature:any value RequiredLiquidity:2000 State:SendPegoutFailed UserRskTxHash: LpBtcTxHash: RefundPegoutTxHash: BridgeRefundTxHash: OwnerAccountAddress:}]"
 		client, collection := getClientAndCollectionMocks(mongo.RetainedPegoutQuoteCollection)
 		session := &mocks.SessionBindingMock{}
 		client.On("StartSession").Return(session, nil).Once()

--- a/internal/adapters/dataproviders/liquidity_provider.go
+++ b/internal/adapters/dataproviders/liquidity_provider.go
@@ -163,7 +163,7 @@ func (lp *LocalLiquidityProvider) AvailablePeginLiquidity(ctx context.Context) (
 func (lp *LocalLiquidityProvider) GeneralConfiguration(ctx context.Context) liquidity_provider.GeneralConfiguration {
 	configuration, err := liquidity_provider.ValidateConfiguration(lp.signer, func() (*entities.Signed[liquidity_provider.GeneralConfiguration], error) {
 		return lp.lpRepository.GetGeneralConfiguration(ctx)
-	}, crypto.Keccak256)
+	})
 	if err != nil {
 		lp.logConfigError("general", err)
 		return liquidity_provider.DefaultGeneralConfiguration()
@@ -174,7 +174,7 @@ func (lp *LocalLiquidityProvider) GeneralConfiguration(ctx context.Context) liqu
 func (lp *LocalLiquidityProvider) PegoutConfiguration(ctx context.Context) liquidity_provider.PegoutConfiguration {
 	configuration, err := liquidity_provider.ValidateConfiguration(lp.signer, func() (*entities.Signed[liquidity_provider.PegoutConfiguration], error) {
 		return lp.lpRepository.GetPegoutConfiguration(ctx)
-	}, crypto.Keccak256)
+	})
 	if err != nil {
 		lp.logConfigError("pegout", err)
 		return liquidity_provider.DefaultPegoutConfiguration()
@@ -185,7 +185,7 @@ func (lp *LocalLiquidityProvider) PegoutConfiguration(ctx context.Context) liqui
 func (lp *LocalLiquidityProvider) PeginConfiguration(ctx context.Context) liquidity_provider.PeginConfiguration {
 	configuration, err := liquidity_provider.ValidateConfiguration(lp.signer, func() (*entities.Signed[liquidity_provider.PeginConfiguration], error) {
 		return lp.lpRepository.GetPeginConfiguration(ctx)
-	}, crypto.Keccak256)
+	})
 	if err != nil {
 		lp.logConfigError("pegin", err)
 		return liquidity_provider.DefaultPeginConfiguration()

--- a/internal/adapters/dataproviders/liquidity_provider.go
+++ b/internal/adapters/dataproviders/liquidity_provider.go
@@ -161,7 +161,7 @@ func (lp *LocalLiquidityProvider) AvailablePeginLiquidity(ctx context.Context) (
 }
 
 func (lp *LocalLiquidityProvider) GeneralConfiguration(ctx context.Context) liquidity_provider.GeneralConfiguration {
-	configuration, err := liquidity_provider.ValidateConfiguration(lp.signer, func() (*entities.Signed[liquidity_provider.GeneralConfiguration], error) {
+	configuration, err := liquidity_provider.ValidateConfiguration(lp.signer, crypto.Keccak256, func() (*entities.Signed[liquidity_provider.GeneralConfiguration], error) {
 		return lp.lpRepository.GetGeneralConfiguration(ctx)
 	})
 	if err != nil {
@@ -172,7 +172,7 @@ func (lp *LocalLiquidityProvider) GeneralConfiguration(ctx context.Context) liqu
 }
 
 func (lp *LocalLiquidityProvider) PegoutConfiguration(ctx context.Context) liquidity_provider.PegoutConfiguration {
-	configuration, err := liquidity_provider.ValidateConfiguration(lp.signer, func() (*entities.Signed[liquidity_provider.PegoutConfiguration], error) {
+	configuration, err := liquidity_provider.ValidateConfiguration(lp.signer, crypto.Keccak256, func() (*entities.Signed[liquidity_provider.PegoutConfiguration], error) {
 		return lp.lpRepository.GetPegoutConfiguration(ctx)
 	})
 	if err != nil {
@@ -183,7 +183,7 @@ func (lp *LocalLiquidityProvider) PegoutConfiguration(ctx context.Context) liqui
 }
 
 func (lp *LocalLiquidityProvider) PeginConfiguration(ctx context.Context) liquidity_provider.PeginConfiguration {
-	configuration, err := liquidity_provider.ValidateConfiguration(lp.signer, func() (*entities.Signed[liquidity_provider.PeginConfiguration], error) {
+	configuration, err := liquidity_provider.ValidateConfiguration(lp.signer, crypto.Keccak256, func() (*entities.Signed[liquidity_provider.PeginConfiguration], error) {
 		return lp.lpRepository.GetPeginConfiguration(ctx)
 	})
 	if err != nil {

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegin_authenticated_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegin_authenticated_quote.go
@@ -17,7 +17,7 @@ import (
 // @Param Request body pkg.AcceptAuthenticatedQuoteRequest true "Quote Hash and Signature"
 // @Success 200 object pkg.AcceptPeginRespose Interface that represents that the quote has been successfully accepted
 // @Route /pegin/acceptAuthenticatedQuote [post]
-func NewAcceptPeginAuthenticatedQuoteHandler(useCase AcceptQuoteUseCaseInterface) http.HandlerFunc {
+func NewAcceptPeginAuthenticatedQuoteHandler(useCase AcceptQuoteUseCase) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		var err error
 		acceptRequest := pkg.AcceptAuthenticatedQuoteRequest{}
@@ -35,7 +35,7 @@ func NewAcceptPeginAuthenticatedQuoteHandler(useCase AcceptQuoteUseCaseInterface
 
 		acceptedQuote, err := useCase.Run(req.Context(), acceptRequest.QuoteHash, acceptRequest.Signature)
 		if err != nil {
-			handleAcceptQuoteError(w, err)
+			HandleAcceptQuoteError(w, err)
 			return
 		}
 

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegin_authenticated_quote_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegin_authenticated_quote_test.go
@@ -58,8 +58,7 @@ func TestAcceptPeginAuthenticatedQuoteHandler(t *testing.T) {
 	mockUseCase.AssertExpectations(t)
 }
 
-// nolint:funlen,maintidx
-func TestAcceptPeginAuthenticatedQuoteHandlerErrorCases(t *testing.T) {
+func TestAcceptPeginAuthenticatedQuoteHandlerValidationErrors(t *testing.T) {
 	t.Run("should handle malformed JSON in request body", func(t *testing.T) {
 		// Create a request with malformed JSON (missing closing brace)
 		malformedJSON := []byte(`{"quoteHash": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "signature": "validSignature123"`)
@@ -116,7 +115,10 @@ func TestAcceptPeginAuthenticatedQuoteHandlerErrorCases(t *testing.T) {
 		assert.Contains(t, errorResponse, "message")
 		assert.Contains(t, errorResponse["message"], "validation error")
 	})
+}
 
+// nolint:funlen
+func TestAcceptPeginAuthenticatedQuoteHandlerErrorCases(t *testing.T) {
 	t.Run("should return 400 on invalid quote hash format", func(t *testing.T) {
 		reqBody := pkg.AcceptAuthenticatedQuoteRequest{
 			QuoteHash: "123456789XABCDEF", // Invalid - contains non-hex character 'X'

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegin_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegin_quote.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rsksmart/liquidity-provider-server/pkg"
 )
 
-type AcceptQuoteUseCaseInterface interface {
+type AcceptQuoteUseCase interface {
 	Run(ctx context.Context, quoteHash, signature string) (quote.AcceptedQuote, error)
 }
 
@@ -21,7 +21,7 @@ type AcceptQuoteUseCaseInterface interface {
 // @Param QuoteHash body pkg.AcceptQuoteRequest true "Quote Hash"
 // @Success 200  object pkg.AcceptPeginRespose Interface that represents that the quote has been successfully accepted
 // @Route /pegin/acceptQuote [post]
-func NewAcceptPeginQuoteHandler(useCase AcceptQuoteUseCaseInterface) http.HandlerFunc {
+func NewAcceptPeginQuoteHandler(useCase AcceptQuoteUseCase) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		var err error
 		acceptRequest := pkg.AcceptQuoteRequest{}

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote.go
@@ -13,7 +13,7 @@ import (
 // @Title Accept authenticated quote
 // @Description Accepts Quote with trusted account signature
 // @Param Request body pkg.AcceptAuthenticatedQuoteRequest true "Quote Hash and Signature"
-// @Success 200 object pkg.AcceptPeginRespose Interface that represents that the quote has been successfully accepted
+// @Success 200 object pkg.AcceptPegoutResponse Interface that represents that the quote has been successfully accepted
 // @Route /pegout/acceptAuthenticatedQuote [post]
 func NewAcceptPegoutAuthenticatedQuoteHandler(useCase AcceptQuoteUseCase) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
@@ -39,9 +39,9 @@ func NewAcceptPegoutAuthenticatedQuoteHandler(useCase AcceptQuoteUseCase) http.H
 			return
 		}
 
-		response := pkg.AcceptPeginRespose{
-			Signature:                 acceptedQuote.Signature,
-			BitcoinDepositAddressHash: acceptedQuote.DepositAddress,
+		response := pkg.AcceptPegoutResponse{
+			Signature:  acceptedQuote.Signature,
+			LbcAddress: acceptedQuote.DepositAddress,
 		}
 		rest.JsonResponseWithBody(w, http.StatusOK, &response)
 	}

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
+	"github.com/rsksmart/liquidity-provider-server/pkg"
+)
+
+// NewAcceptPegoutAuthenticatedQuoteHandler
+// @Title Accept authenticated quote
+// @Description Accepts Quote with trusted account signature
+// @Param Request body pkg.AcceptAuthenticatedQuoteRequest true "Quote Hash and Signature"
+// @Success 200 object pkg.AcceptPegoutRespose Interface that represents that the quote has been successfully accepted
+// @Route /pegout/acceptAuthenticatedQuote [post]
+func NewAcceptPegoutAuthenticatedQuoteHandler(useCase AcceptQuoteUseCase) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		var err error
+		acceptRequest := pkg.AcceptAuthenticatedQuoteRequest{}
+		if err = rest.DecodeRequest(w, req, &acceptRequest); err != nil {
+			return
+		} else if err = rest.ValidateRequest(w, &acceptRequest); err != nil {
+			return
+		}
+
+		if err = quote.ValidateQuoteHash(acceptRequest.QuoteHash); err != nil {
+			jsonErr := rest.NewErrorResponseWithDetails("invalid quote hash", rest.DetailsFromError(err), true)
+			rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
+			return
+		}
+
+		acceptedQuote, err := useCase.Run(req.Context(), acceptRequest.QuoteHash, acceptRequest.Signature)
+		if err != nil {
+			HandleAcceptQuoteError(w, err)
+			return
+		}
+
+		response := pkg.AcceptPeginRespose{
+			Signature:                 acceptedQuote.Signature,
+			BitcoinDepositAddressHash: acceptedQuote.DepositAddress,
+		}
+		rest.JsonResponseWithBody(w, http.StatusOK, &response)
+	}
+}

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
@@ -12,7 +13,7 @@ import (
 // @Title Accept authenticated quote
 // @Description Accepts Quote with trusted account signature
 // @Param Request body pkg.AcceptAuthenticatedQuoteRequest true "Quote Hash and Signature"
-// @Success 200 object pkg.AcceptPegoutRespose Interface that represents that the quote has been successfully accepted
+// @Success 200 object pkg.AcceptPeginRespose Interface that represents that the quote has been successfully accepted
 // @Route /pegout/acceptAuthenticatedQuote [post]
 func NewAcceptPegoutAuthenticatedQuoteHandler(useCase AcceptQuoteUseCase) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
@@ -29,6 +30,8 @@ func NewAcceptPegoutAuthenticatedQuoteHandler(useCase AcceptQuoteUseCase) http.H
 			rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
 			return
 		}
+
+		acceptRequest.Signature = strings.TrimPrefix(acceptRequest.Signature, "0x")
 
 		acceptedQuote, err := useCase.Run(req.Context(), acceptRequest.QuoteHash, acceptRequest.Signature)
 		if err != nil {

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote_test.go
@@ -1,0 +1,380 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest/handlers"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
+	"github.com/rsksmart/liquidity-provider-server/pkg"
+	"github.com/rsksmart/liquidity-provider-server/test/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcceptPegoutAuthenticatedQuoteHandler_Success(t *testing.T) {
+	quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	signature := "validSignature123"
+	acceptedQuote := quote.AcceptedQuote{
+		Signature:      "signedHash123",
+		DepositAddress: "depositAddress456",
+	}
+
+	reqBody := pkg.AcceptAuthenticatedQuoteRequest{
+		QuoteHash: quoteHash,
+		Signature: signature,
+	}
+	jsonBody, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	request := httptest.NewRequest(http.MethodPost, "/pegout/acceptAuthenticatedQuote", bytes.NewBuffer(jsonBody))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+	mockUseCase.On("Run", mock.Anything, quoteHash, signature).Return(acceptedQuote, nil)
+
+	handlerFunc := handlers.NewAcceptPegoutAuthenticatedQuoteHandler(mockUseCase)
+	handler := http.HandlerFunc(handlerFunc)
+
+	handler.ServeHTTP(recorder, request)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var responseBody pkg.AcceptPeginRespose
+	err = json.NewDecoder(recorder.Body).Decode(&responseBody)
+	require.NoError(t, err)
+
+	assert.Equal(t, acceptedQuote.Signature, responseBody.Signature)
+	assert.Equal(t, acceptedQuote.DepositAddress, responseBody.BitcoinDepositAddressHash)
+
+	mockUseCase.AssertExpectations(t)
+}
+
+// nolint:funlen
+func TestAcceptPegoutAuthenticatedQuoteHandler_RequestErrors(t *testing.T) {
+	t.Run("should handle malformed JSON in request body", func(t *testing.T) {
+		// Create a request with malformed JSON (missing closing brace)
+		malformedJSON := []byte(`{"quoteHash": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "signature": "validSignature123"`)
+		request := httptest.NewRequest(http.MethodPost, "/pegout/acceptAuthenticatedQuote", bytes.NewBuffer(malformedJSON))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+
+		handlerFunc := handlers.NewAcceptPegoutAuthenticatedQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		// Request decoding should fail with 400 Bad Request
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+		mockUseCase.AssertNotCalled(t, "Run")
+
+		var errorResponse map[string]interface{}
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Contains(t, errorResponse, "message")
+		assert.Contains(t, errorResponse["message"], "Error decoding request")
+	})
+
+	t.Run("should handle request validation failure - missing quote hash", func(t *testing.T) {
+		reqBody := pkg.AcceptAuthenticatedQuoteRequest{
+			QuoteHash: "", // Empty quote hash will fail validation
+			Signature: "validSignature123",
+		}
+		jsonBody, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/pegout/acceptAuthenticatedQuote", bytes.NewBuffer(jsonBody))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+
+		handlerFunc := handlers.NewAcceptPegoutAuthenticatedQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		// Validation should fail with 400 Bad Request
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+		mockUseCase.AssertNotCalled(t, "Run")
+
+		var errorResponse map[string]interface{}
+		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Contains(t, errorResponse, "message")
+		assert.Contains(t, errorResponse["message"], "validation error")
+	})
+
+	t.Run("should handle request validation failure - missing signature", func(t *testing.T) {
+		reqBody := pkg.AcceptAuthenticatedQuoteRequest{
+			QuoteHash: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			Signature: "", // Empty signature will fail validation
+		}
+		jsonBody, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/pegout/acceptAuthenticatedQuote", bytes.NewBuffer(jsonBody))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+
+		handlerFunc := handlers.NewAcceptPegoutAuthenticatedQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		// Validation should fail with 400 Bad Request
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+		mockUseCase.AssertNotCalled(t, "Run")
+
+		var errorResponse map[string]interface{}
+		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Contains(t, errorResponse, "message")
+		assert.Contains(t, errorResponse["message"], "validation error")
+	})
+}
+
+func TestAcceptPegoutAuthenticatedQuoteHandler_QuoteHashValidation(t *testing.T) {
+	t.Run("should return 400 on invalid quote hash format - too short", func(t *testing.T) {
+		reqBody := pkg.AcceptAuthenticatedQuoteRequest{
+			QuoteHash: "123456789abcdef", // Too short
+			Signature: "validSignature123",
+		}
+		jsonBody, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/pegout/acceptAuthenticatedQuote", bytes.NewBuffer(jsonBody))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+
+		handlerFunc := handlers.NewAcceptPegoutAuthenticatedQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+		mockUseCase.AssertNotCalled(t, "Run")
+
+		var errorResponse map[string]interface{}
+		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Contains(t, errorResponse, "message")
+		assert.Contains(t, errorResponse["message"], "invalid quote hash")
+	})
+
+	t.Run("should return 400 on invalid quote hash format - non-hex characters", func(t *testing.T) {
+		reqBody := pkg.AcceptAuthenticatedQuoteRequest{
+			QuoteHash: "123456789XABCDEF123456789XABCDEF123456789XABCDEF123456789XABCDEF", // Contains non-hex character 'X'
+			Signature: "validSignature123",
+		}
+		jsonBody, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/pegout/acceptAuthenticatedQuote", bytes.NewBuffer(jsonBody))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+
+		handlerFunc := handlers.NewAcceptPegoutAuthenticatedQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+		mockUseCase.AssertNotCalled(t, "Run")
+
+		var errorResponse map[string]interface{}
+		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Contains(t, errorResponse, "message")
+		assert.Contains(t, errorResponse["message"], "invalid quote hash")
+	})
+}
+
+// nolint:funlen
+func TestAcceptPegoutAuthenticatedQuoteHandler_UseCaseErrors(t *testing.T) {
+	testCases := []struct {
+		name           string
+		useCaseError   error
+		expectedStatus int
+		expectedMsg    string
+	}{
+		{
+			name:           "quote not found error",
+			useCaseError:   usecases.QuoteNotFoundError,
+			expectedStatus: http.StatusNotFound,
+			expectedMsg:    "quote not found",
+		},
+		{
+			name:           "expired quote error",
+			useCaseError:   usecases.ExpiredQuoteError,
+			expectedStatus: http.StatusGone,
+			expectedMsg:    "expired quote",
+		},
+		{
+			name:           "no liquidity error",
+			useCaseError:   usecases.NoLiquidityError,
+			expectedStatus: http.StatusConflict,
+			expectedMsg:    "not enough liquidity",
+		},
+		{
+			name:           "locking cap exceeded error",
+			useCaseError:   usecases.LockingCapExceededError,
+			expectedStatus: http.StatusConflict,
+			expectedMsg:    "locking cap exceeded",
+		},
+		{
+			name:           "tampered trusted account error",
+			useCaseError:   liquidity_provider.TamperedTrustedAccountError,
+			expectedStatus: http.StatusInternalServerError,
+			expectedMsg:    "error fetching trusted account",
+		},
+		{
+			name:           "unexpected error",
+			useCaseError:   errors.New("unexpected database error"),
+			expectedStatus: http.StatusInternalServerError,
+			expectedMsg:    "unknown error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+			signature := "validSignature123"
+
+			reqBody := pkg.AcceptAuthenticatedQuoteRequest{
+				QuoteHash: quoteHash,
+				Signature: signature,
+			}
+			jsonBody, err := json.Marshal(reqBody)
+			require.NoError(t, err)
+
+			request := httptest.NewRequest(http.MethodPost, "/pegout/acceptAuthenticatedQuote", bytes.NewBuffer(jsonBody))
+			request.Header.Set("Content-Type", "application/json")
+			recorder := httptest.NewRecorder()
+
+			mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+			mockUseCase.On("Run", mock.Anything, quoteHash, signature).Return(quote.AcceptedQuote{}, tc.useCaseError)
+
+			handlerFunc := handlers.NewAcceptPegoutAuthenticatedQuoteHandler(mockUseCase)
+			handler := http.HandlerFunc(handlerFunc)
+
+			handler.ServeHTTP(recorder, request)
+
+			// Verify the response status and message (this indirectly tests that HandleAcceptQuoteError is working correctly)
+			assert.Equal(t, tc.expectedStatus, recorder.Code)
+
+			var errorResponse map[string]interface{}
+			err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
+			require.NoError(t, err)
+			assert.Contains(t, errorResponse, "message")
+			assert.Equal(t, tc.expectedMsg, errorResponse["message"])
+
+			mockUseCase.AssertExpectations(t)
+		})
+	}
+}
+
+// nolint:funlen
+func TestAcceptPegoutAuthenticatedQuoteHandler_SignatureProcessing(t *testing.T) {
+	t.Run("should strip 0x prefix from signature", func(t *testing.T) {
+		quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+		signatureWithPrefix := "0xvalidSignature123"
+		signatureWithoutPrefix := "validSignature123"
+		acceptedQuote := quote.AcceptedQuote{
+			Signature:      "signedHash123",
+			DepositAddress: "depositAddress456",
+		}
+
+		reqBody := pkg.AcceptAuthenticatedQuoteRequest{
+			QuoteHash: quoteHash,
+			Signature: signatureWithPrefix,
+		}
+		jsonBody, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/pegout/acceptAuthenticatedQuote", bytes.NewBuffer(jsonBody))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+		// Verify that the use case receives the signature WITHOUT the "0x" prefix
+		mockUseCase.On("Run", mock.Anything, quoteHash, signatureWithoutPrefix).Return(acceptedQuote, nil)
+
+		handlerFunc := handlers.NewAcceptPegoutAuthenticatedQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		var responseBody pkg.AcceptPeginRespose
+		err = json.NewDecoder(recorder.Body).Decode(&responseBody)
+		require.NoError(t, err)
+
+		assert.Equal(t, acceptedQuote.Signature, responseBody.Signature)
+		assert.Equal(t, acceptedQuote.DepositAddress, responseBody.BitcoinDepositAddressHash)
+
+		mockUseCase.AssertExpectations(t)
+	})
+
+	t.Run("should leave signature unchanged when no 0x prefix", func(t *testing.T) {
+		quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+		signature := "validSignature123"
+		acceptedQuote := quote.AcceptedQuote{
+			Signature:      "signedHash123",
+			DepositAddress: "depositAddress456",
+		}
+
+		reqBody := pkg.AcceptAuthenticatedQuoteRequest{
+			QuoteHash: quoteHash,
+			Signature: signature,
+		}
+		jsonBody, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/pegout/acceptAuthenticatedQuote", bytes.NewBuffer(jsonBody))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+		// Verify that the use case receives the signature unchanged
+		mockUseCase.On("Run", mock.Anything, quoteHash, signature).Return(acceptedQuote, nil)
+
+		handlerFunc := handlers.NewAcceptPegoutAuthenticatedQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		var responseBody pkg.AcceptPeginRespose
+		err = json.NewDecoder(recorder.Body).Decode(&responseBody)
+		require.NoError(t, err)
+
+		assert.Equal(t, acceptedQuote.Signature, responseBody.Signature)
+		assert.Equal(t, acceptedQuote.DepositAddress, responseBody.BitcoinDepositAddressHash)
+
+		mockUseCase.AssertExpectations(t)
+	})
+}

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote_test.go
@@ -48,12 +48,12 @@ func TestAcceptPegoutAuthenticatedQuoteHandler_Success(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 
-	var responseBody pkg.AcceptPeginRespose
+	var responseBody pkg.AcceptPegoutResponse
 	err = json.NewDecoder(recorder.Body).Decode(&responseBody)
 	require.NoError(t, err)
 
 	assert.Equal(t, acceptedQuote.Signature, responseBody.Signature)
-	assert.Equal(t, acceptedQuote.DepositAddress, responseBody.BitcoinDepositAddressHash)
+	assert.Equal(t, acceptedQuote.DepositAddress, responseBody.LbcAddress)
 
 	mockUseCase.AssertExpectations(t)
 }
@@ -328,12 +328,12 @@ func TestAcceptPegoutAuthenticatedQuoteHandler_SignatureProcessing(t *testing.T)
 
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		var responseBody pkg.AcceptPeginRespose
+		var responseBody pkg.AcceptPegoutResponse
 		err = json.NewDecoder(recorder.Body).Decode(&responseBody)
 		require.NoError(t, err)
 
 		assert.Equal(t, acceptedQuote.Signature, responseBody.Signature)
-		assert.Equal(t, acceptedQuote.DepositAddress, responseBody.BitcoinDepositAddressHash)
+		assert.Equal(t, acceptedQuote.DepositAddress, responseBody.LbcAddress)
 
 		mockUseCase.AssertExpectations(t)
 	})
@@ -368,12 +368,12 @@ func TestAcceptPegoutAuthenticatedQuoteHandler_SignatureProcessing(t *testing.T)
 
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		var responseBody pkg.AcceptPeginRespose
+		var responseBody pkg.AcceptPegoutResponse
 		err = json.NewDecoder(recorder.Body).Decode(&responseBody)
 		require.NoError(t, err)
 
 		assert.Equal(t, acceptedQuote.Signature, responseBody.Signature)
-		assert.Equal(t, acceptedQuote.DepositAddress, responseBody.BitcoinDepositAddressHash)
+		assert.Equal(t, acceptedQuote.DepositAddress, responseBody.LbcAddress)
 
 		mockUseCase.AssertExpectations(t)
 	})

--- a/internal/adapters/entrypoints/rest/handlers/common.go
+++ b/internal/adapters/entrypoints/rest/handlers/common.go
@@ -1,10 +1,14 @@
 package handlers
 
 import (
+	"errors"
+	"net/http"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest/server/cookies"
 	"github.com/rsksmart/liquidity-provider-server/internal/configuration/environment"
-	"net/http"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 )
 
 const UnknownErrorMessage = "unknown error"
@@ -29,4 +33,27 @@ func closeManagementSession(req *http.Request, w http.ResponseWriter, env enviro
 		return err
 	}
 	return nil
+}
+
+func HandleAcceptQuoteError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, usecases.QuoteNotFoundError):
+		jsonErr := rest.NewErrorResponseWithDetails("quote not found", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusNotFound, jsonErr)
+	case errors.Is(err, usecases.ExpiredQuoteError):
+		jsonErr := rest.NewErrorResponseWithDetails("expired quote", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusGone, jsonErr)
+	case errors.Is(err, usecases.NoLiquidityError):
+		jsonErr := rest.NewErrorResponseWithDetails("not enough liquidity", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
+	case errors.Is(err, usecases.LockingCapExceededError):
+		jsonErr := rest.NewErrorResponseWithDetails("locking cap exceeded", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
+	case errors.Is(err, liquidity_provider.ErrTamperedTrustedAccount):
+		jsonErr := rest.NewErrorResponseWithDetails("error fetching trusted account", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
+	default:
+		jsonErr := rest.NewErrorResponseWithDetails(UnknownErrorMessage, rest.DetailsFromError(err), false)
+		rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
+	}
 }

--- a/internal/adapters/entrypoints/rest/handlers/common.go
+++ b/internal/adapters/entrypoints/rest/handlers/common.go
@@ -49,7 +49,7 @@ func HandleAcceptQuoteError(w http.ResponseWriter, err error) {
 	case errors.Is(err, usecases.LockingCapExceededError):
 		jsonErr := rest.NewErrorResponseWithDetails("locking cap exceeded", rest.DetailsFromError(err), true)
 		rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
-	case errors.Is(err, liquidity_provider.ErrTamperedTrustedAccount):
+	case errors.Is(err, liquidity_provider.TamperedTrustedAccountError):
 		jsonErr := rest.NewErrorResponseWithDetails("error fetching trusted account", rest.DetailsFromError(err), true)
 		rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
 	default:

--- a/internal/adapters/entrypoints/rest/handlers/common_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/common_test.go
@@ -1,0 +1,150 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
+	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest/handlers"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nolint:funlen
+func TestHandleAcceptQuoteError(t *testing.T) {
+	t.Run("should return 404 when quote not found", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		handlers.HandleAcceptQuoteError(recorder, usecases.QuoteNotFoundError)
+
+		assert.Equal(t, 404, recorder.Code)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, "quote not found", errorResponse.Message)
+		assert.True(t, errorResponse.Recoverable)
+		assert.Contains(t, errorResponse.Details, "error")
+		assert.Equal(t, usecases.QuoteNotFoundError.Error(), errorResponse.Details["error"])
+	})
+
+	t.Run("should return 410 when quote is expired", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		handlers.HandleAcceptQuoteError(recorder, usecases.ExpiredQuoteError)
+
+		assert.Equal(t, 410, recorder.Code)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, "expired quote", errorResponse.Message)
+		assert.True(t, errorResponse.Recoverable)
+		assert.Contains(t, errorResponse.Details, "error")
+		assert.Equal(t, usecases.ExpiredQuoteError.Error(), errorResponse.Details["error"])
+	})
+
+	t.Run("should return 409 when not enough liquidity", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		handlers.HandleAcceptQuoteError(recorder, usecases.NoLiquidityError)
+
+		assert.Equal(t, 409, recorder.Code)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, "not enough liquidity", errorResponse.Message)
+		assert.True(t, errorResponse.Recoverable)
+		assert.Contains(t, errorResponse.Details, "error")
+		assert.Equal(t, usecases.NoLiquidityError.Error(), errorResponse.Details["error"])
+	})
+
+	t.Run("should return 409 when locking cap exceeded", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		handlers.HandleAcceptQuoteError(recorder, usecases.LockingCapExceededError)
+
+		assert.Equal(t, 409, recorder.Code)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, "locking cap exceeded", errorResponse.Message)
+		assert.True(t, errorResponse.Recoverable)
+		assert.Contains(t, errorResponse.Details, "error")
+		assert.Equal(t, usecases.LockingCapExceededError.Error(), errorResponse.Details["error"])
+	})
+
+	t.Run("should return 500 when tampered trusted account error", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		handlers.HandleAcceptQuoteError(recorder, liquidity_provider.TamperedTrustedAccountError)
+
+		assert.Equal(t, 500, recorder.Code)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, "error fetching trusted account", errorResponse.Message)
+		assert.True(t, errorResponse.Recoverable)
+		assert.Contains(t, errorResponse.Details, "error")
+		assert.Equal(t, liquidity_provider.TamperedTrustedAccountError.Error(), errorResponse.Details["error"])
+	})
+
+	t.Run("should return 500 with unknown error message for unexpected errors", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		unexpectedError := errors.New("unexpected database connection error")
+
+		handlers.HandleAcceptQuoteError(recorder, unexpectedError)
+
+		assert.Equal(t, 500, recorder.Code)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, handlers.UnknownErrorMessage, errorResponse.Message)
+		assert.False(t, errorResponse.Recoverable)
+		assert.Contains(t, errorResponse.Details, "error")
+		assert.Equal(t, unexpectedError.Error(), errorResponse.Details["error"])
+	})
+
+	t.Run("should handle wrapped errors correctly", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		wrappedError := usecases.WrapUseCaseError(usecases.AcceptPeginQuoteId, usecases.ExpiredQuoteError)
+
+		handlers.HandleAcceptQuoteError(recorder, wrappedError)
+
+		assert.Equal(t, 410, recorder.Code)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, "expired quote", errorResponse.Message)
+		assert.True(t, errorResponse.Recoverable)
+		assert.Contains(t, errorResponse.Details, "error")
+	})
+
+	t.Run("should set correct content type header", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		handlers.HandleAcceptQuoteError(recorder, usecases.QuoteNotFoundError)
+
+		assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+	})
+
+	t.Run("should include timestamp in error response", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		handlers.HandleAcceptQuoteError(recorder, usecases.QuoteNotFoundError)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.NotZero(t, errorResponse.Timestamp)
+	})
+}

--- a/internal/adapters/entrypoints/rest/routes/public.go
+++ b/internal/adapters/entrypoints/rest/routes/public.go
@@ -68,6 +68,14 @@ func GetPublicEndpoints(useCaseRegistry registry.UseCaseRegistry) []PublicEndpoi
 		},
 		{
 			Endpoint: Endpoint{
+				Path:    "/pegout/acceptAuthenticatedQuote",
+				Method:  http.MethodPost,
+				Handler: handlers.NewAcceptPegoutAuthenticatedQuoteHandler(useCaseRegistry.GetAcceptPegoutQuoteUseCase()),
+			},
+			RequiresCaptcha: false,
+		},
+		{
+			Endpoint: Endpoint{
 				Path:    "/userQuotes",
 				Method:  http.MethodGet,
 				Handler: handlers.NewGetUserQuotesHandler(useCaseRegistry.GetUserDepositsUseCase()),

--- a/internal/adapters/entrypoints/rest/routes/public_test.go
+++ b/internal/adapters/entrypoints/rest/routes/public_test.go
@@ -41,7 +41,7 @@ func TestGetPublicEndpoints(t *testing.T) {
 	err := yaml.Unmarshal(specBytes, spec)
 	require.NoError(t, err)
 
-	assert.Len(t, endpoints, 13)
+	assert.Len(t, endpoints, 14)
 	for _, endpoint := range endpoints {
 		lowerCaseMethod := strings.ToLower(endpoint.Method)
 		assert.NotNilf(t, spec.Paths[endpoint.Path][lowerCaseMethod], "Handler not found for path %s and verb %s", endpoint.Path, endpoint.Method)

--- a/internal/configuration/registry/usecase.go
+++ b/internal/configuration/registry/usecase.go
@@ -161,6 +161,8 @@ func NewUseCaseRegistry(
 			liquidityProvider,
 			messaging.EventBus,
 			mutexes.PegoutLiquidityMutex(),
+			databaseRegistry.TrustedAccountRepository,
+			signingHashFunction,
 		),
 		sendPegoutUseCase: pegout.NewSendPegoutUseCase(
 			btcRegistry.PaymentWallet,

--- a/internal/entities/liquidity_provider/liquidity_provider.go
+++ b/internal/entities/liquidity_provider/liquidity_provider.go
@@ -124,8 +124,8 @@ type DefaultCredentialsSetEvent struct {
 
 func ValidateConfiguration[T ConfigurationType](
 	signer entities.Signer,
-	readFunction func() (*entities.Signed[T], error),
 	hashFunction entities.HashFunction,
+	readFunction func() (*entities.Signed[T], error),
 ) (*entities.Signed[T], error) {
 	configuration, err := readFunction()
 	if err != nil {

--- a/internal/entities/liquidity_provider/liquidity_provider_test.go
+++ b/internal/entities/liquidity_provider/liquidity_provider_test.go
@@ -117,8 +117,8 @@ func TestValidateConfiguration(t *testing.T) {
 
 		result, err := liquidity_provider.ValidateConfiguration(
 			mockSigner,
-			readFunction,
 			ethcrypto.Keccak256,
+			readFunction,
 		)
 
 		require.NoError(t, err)
@@ -142,8 +142,8 @@ func TestValidateConfiguration(t *testing.T) {
 
 		result, err := liquidity_provider.ValidateConfiguration(
 			mockSigner,
-			readFunction,
 			ethcrypto.Keccak256,
+			readFunction,
 		)
 
 		require.Error(t, err)
@@ -161,11 +161,65 @@ func TestValidateConfiguration(t *testing.T) {
 
 		result, err := liquidity_provider.ValidateConfiguration(
 			mockSigner,
-			readFunction,
 			ethcrypto.Keccak256,
+			readFunction,
 		)
 
 		require.ErrorIs(t, err, liquidity_provider.ConfigurationNotFoundError)
+		require.Nil(t, result)
+		mockSigner.AssertExpectations(t)
+	})
+
+	t.Run("tampered configuration", func(t *testing.T) {
+		mockSigner := new(mocks.SignerMock)
+
+		mockConfig := liquidity_provider.GeneralConfiguration{
+			RskConfirmations: liquidity_provider.ConfirmationsPerAmount{
+				10: 100,
+				20: 200,
+			},
+			BtcConfirmations: liquidity_provider.ConfirmationsPerAmount{
+				10: 5,
+				20: 10,
+			},
+			PublicLiquidityCheck: true,
+		}
+
+		// Calculate hash from the original config
+		correctConfigBytes := []byte(`{"rskConfirmations":{"10":100,"20":200},"btcConfirmations":{"10":5,"20":10},"publicLiquidityCheck":true}`)
+		correctHash := ethcrypto.Keccak256(correctConfigBytes)
+
+		// Use a different hash (tampered)
+		tamperedHashHex := hex.EncodeToString([]byte("tampered-hash"))
+
+		mockSignature := []byte("mock-signature")
+		mockSigner.On("SignBytes", correctHash).Return(mockSignature, nil)
+
+		signature, err := mockSigner.SignBytes(correctHash)
+		require.NoError(t, err)
+		signatureHex := hex.EncodeToString(signature)
+
+		signedConfig := &entities.Signed[liquidity_provider.GeneralConfiguration]{
+			Value:     mockConfig,
+			Hash:      tamperedHashHex, // Use tampered hash
+			Signature: signatureHex,
+		}
+
+		readFunction := func() (*entities.Signed[liquidity_provider.GeneralConfiguration], error) {
+			return signedConfig, nil
+		}
+
+		defer test.AssertLogContains(t, "Tampered test-config configuration. Using default configuration. Error: error during value integrity check, stored hash doesn't match actual hash")()
+
+		result, err := liquidity_provider.ValidateConfiguration(
+			displayName,
+			mockSigner,
+			ethcrypto.Keccak256,
+			readFunction,
+		)
+
+		require.Error(t, err)
+		require.Equal(t, entities.IntegrityError, err)
 		require.Nil(t, result)
 		mockSigner.AssertExpectations(t)
 	})
@@ -210,8 +264,8 @@ func TestValidateConfiguration(t *testing.T) {
 
 		result, err := liquidity_provider.ValidateConfiguration(
 			mockSigner,
-			readFunction,
 			ethcrypto.Keccak256,
+			readFunction,
 		)
 		require.ErrorIs(t, err, liquidity_provider.InvalidSignatureError)
 		require.Nil(t, result)

--- a/internal/entities/quote/pegout_quote.go
+++ b/internal/entities/quote/pegout_quote.go
@@ -43,6 +43,7 @@ type PegoutQuoteRepository interface {
 	DeleteQuotes(ctx context.Context, quotes []string) (uint, error)
 	UpsertPegoutDeposit(ctx context.Context, deposit PegoutDeposit) error
 	UpsertPegoutDeposits(ctx context.Context, deposits []PegoutDeposit) error
+	GetRetainedQuotesForAddress(ctx context.Context, address string, states ...PegoutState) ([]RetainedPegoutQuote, error)
 }
 
 type CreatedPegoutQuote struct {
@@ -120,15 +121,16 @@ func (quote *PegoutQuote) Total() *entities.Wei {
 }
 
 type RetainedPegoutQuote struct {
-	QuoteHash          string        `json:"quoteHash" bson:"quote_hash" validate:"required"`
-	DepositAddress     string        `json:"depositAddress" bson:"deposit_address" validate:"required"`
-	Signature          string        `json:"signature" bson:"signature" validate:"required"`
-	RequiredLiquidity  *entities.Wei `json:"requiredLiquidity" bson:"required_liquidity" validate:"required"`
-	State              PegoutState   `json:"state" bson:"state" validate:"required"`
-	UserRskTxHash      string        `json:"userRskTxHash" bson:"user_rsk_tx_hash"`
-	LpBtcTxHash        string        `json:"lpBtcTxHash" bson:"lp_btc_tx_hash"`
-	RefundPegoutTxHash string        `json:"refundPegoutTxHash" bson:"refund_pegout_tx_hash"`
-	BridgeRefundTxHash string        `json:"BridgeRefundTxHash" bson:"bridge_refund_tx_hash"`
+	QuoteHash           string        `json:"quoteHash" bson:"quote_hash" validate:"required"`
+	DepositAddress      string        `json:"depositAddress" bson:"deposit_address" validate:"required"`
+	Signature           string        `json:"signature" bson:"signature" validate:"required"`
+	RequiredLiquidity   *entities.Wei `json:"requiredLiquidity" bson:"required_liquidity" validate:"required"`
+	State               PegoutState   `json:"state" bson:"state" validate:"required"`
+	UserRskTxHash       string        `json:"userRskTxHash" bson:"user_rsk_tx_hash"`
+	LpBtcTxHash         string        `json:"lpBtcTxHash" bson:"lp_btc_tx_hash"`
+	RefundPegoutTxHash  string        `json:"refundPegoutTxHash" bson:"refund_pegout_tx_hash"`
+	BridgeRefundTxHash  string        `json:"BridgeRefundTxHash" bson:"bridge_refund_tx_hash"`
+	OwnerAccountAddress string        `json:"ownerAccountAddress" bson:"owner_account_address"`
 }
 
 type WatchedPegoutQuote struct {

--- a/internal/usecases/liquidity_provider/get_trusted_account.go
+++ b/internal/usecases/liquidity_provider/get_trusted_account.go
@@ -39,8 +39,8 @@ func (useCase *GetTrustedAccountUseCase) Run(ctx context.Context, address string
 	}
 	signedAccount, err := liquidity_provider.ValidateConfiguration(
 		useCase.signer,
-		readFunction,
 		useCase.hashFunction,
+		readFunction,
 	)
 	if errors.Is(err, liquidity_provider.TrustedAccountNotFoundError) {
 		return nil, err

--- a/internal/usecases/liquidity_provider/get_trusted_accounts.go
+++ b/internal/usecases/liquidity_provider/get_trusted_accounts.go
@@ -37,8 +37,8 @@ func (useCase *GetTrustedAccountsUseCase) Run(ctx context.Context) ([]entities.S
 		}
 		validatedAccount, err := liquidity_provider.ValidateConfiguration(
 			useCase.signer,
-			readFunction,
 			useCase.hashFunction,
+			readFunction,
 		)
 		if err != nil {
 			return nil, liquidity_provider.TamperedTrustedAccountError

--- a/internal/usecases/pegin/accept_pegin_quote.go
+++ b/internal/usecases/pegin/accept_pegin_quote.go
@@ -130,7 +130,7 @@ func (useCase *AcceptQuoteUseCase) getTrustedAccount(ctx context.Context, quoteH
 		return liquidity_provider.TrustedAccountDetails{}, err
 	}
 
-	trustedAccount, err := liquidity_provider.ValidateConfiguration(signer, func() (*entities.Signed[liquidity_provider.TrustedAccountDetails], error) {
+	trustedAccount, err := liquidity_provider.ValidateConfiguration(signer, useCase.hashFunction, func() (*entities.Signed[liquidity_provider.TrustedAccountDetails], error) {
 		return useCase.trustedAccountRepository.GetTrustedAccount(ctx, address)
 	})
 	if err != nil {

--- a/internal/usecases/pegin/accept_pegin_quote.go
+++ b/internal/usecases/pegin/accept_pegin_quote.go
@@ -132,7 +132,7 @@ func (useCase *AcceptQuoteUseCase) getTrustedAccount(ctx context.Context, quoteH
 
 	trustedAccount, err := liquidity_provider.ValidateConfiguration(signer, func() (*entities.Signed[liquidity_provider.TrustedAccountDetails], error) {
 		return useCase.trustedAccountRepository.GetTrustedAccount(ctx, address)
-	}, useCase.hashFunction)
+	})
 	if err != nil {
 		return liquidity_provider.TrustedAccountDetails{}, liquidity_provider.TamperedTrustedAccountError
 	}

--- a/internal/usecases/pegout/accept_pegout_quote.go
+++ b/internal/usecases/pegout/accept_pegout_quote.go
@@ -2,21 +2,24 @@ package pegout
 
 import (
 	"context"
+	"sync"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
-	"sync"
 )
 
 type AcceptQuoteUseCase struct {
-	quoteRepository      quote.PegoutQuoteRepository
-	contracts            blockchain.RskContracts
-	lp                   liquidity_provider.LiquidityProvider
-	pegoutLp             liquidity_provider.PegoutLiquidityProvider
-	eventBus             entities.EventBus
-	pegoutLiquidityMutex sync.Locker
+	quoteRepository          quote.PegoutQuoteRepository
+	contracts                blockchain.RskContracts
+	lp                       liquidity_provider.LiquidityProvider
+	pegoutLp                 liquidity_provider.PegoutLiquidityProvider
+	eventBus                 entities.EventBus
+	pegoutLiquidityMutex     sync.Locker
+	trustedAccountRepository liquidity_provider.TrustedAccountRepository
+	hashFunction             entities.HashFunction
 }
 
 func NewAcceptQuoteUseCase(
@@ -26,24 +29,29 @@ func NewAcceptQuoteUseCase(
 	pegoutLp liquidity_provider.PegoutLiquidityProvider,
 	eventBus entities.EventBus,
 	pegoutLiquidityMutex sync.Locker,
+	trustedAccountRepository liquidity_provider.TrustedAccountRepository,
+	hashFunction entities.HashFunction,
 ) *AcceptQuoteUseCase {
 	return &AcceptQuoteUseCase{
-		quoteRepository:      quoteRepository,
-		contracts:            contracts,
-		lp:                   lp,
-		pegoutLp:             pegoutLp,
-		eventBus:             eventBus,
-		pegoutLiquidityMutex: pegoutLiquidityMutex,
+		quoteRepository:          quoteRepository,
+		contracts:                contracts,
+		lp:                       lp,
+		pegoutLp:                 pegoutLp,
+		eventBus:                 eventBus,
+		pegoutLiquidityMutex:     pegoutLiquidityMutex,
+		trustedAccountRepository: trustedAccountRepository,
+		hashFunction:             hashFunction,
 	}
 }
 
-func (useCase *AcceptQuoteUseCase) Run(ctx context.Context, quoteHash string) (quote.AcceptedQuote, error) {
+func (useCase *AcceptQuoteUseCase) Run(ctx context.Context, quoteHash, signature string) (quote.AcceptedQuote, error) {
 	var err error
 	errorArgs := usecases.NewErrorArgs()
 	var pegoutQuote *quote.PegoutQuote
 	var retainedQuote *quote.RetainedPegoutQuote
 	var quoteSignature string
 	var requiredLiquidity *entities.Wei
+	var trustedAccount liquidity_provider.TrustedAccountDetails
 
 	if pegoutQuote, err = useCase.quoteRepository.GetQuote(ctx, quoteHash); err != nil {
 		return quote.AcceptedQuote{}, usecases.WrapUseCaseError(usecases.AcceptPegoutQuoteId, err)
@@ -51,10 +59,13 @@ func (useCase *AcceptQuoteUseCase) Run(ctx context.Context, quoteHash string) (q
 		errorArgs["quoteHash"] = quoteHash
 		return quote.AcceptedQuote{}, usecases.WrapUseCaseErrorArgs(usecases.AcceptPegoutQuoteId, usecases.QuoteNotFoundError, errorArgs)
 	}
-
 	if pegoutQuote.IsExpired() {
 		errorArgs["quoteHash"] = quoteHash
 		return quote.AcceptedQuote{}, usecases.WrapUseCaseErrorArgs(usecases.AcceptPegoutQuoteId, usecases.ExpiredQuoteError, errorArgs)
+	}
+
+	if trustedAccount, err = useCase.handleTrustedAccountSignature(ctx, quoteHash, signature, pegoutQuote); err != nil {
+		return quote.AcceptedQuote{}, err
 	}
 
 	useCase.pegoutLiquidityMutex.Lock()
@@ -78,15 +89,14 @@ func (useCase *AcceptQuoteUseCase) Run(ctx context.Context, quoteHash string) (q
 	}
 
 	retainedQuote = &quote.RetainedPegoutQuote{
-		QuoteHash:         quoteHash,
-		DepositAddress:    useCase.contracts.Lbc.GetAddress(),
-		Signature:         quoteSignature,
-		RequiredLiquidity: requiredLiquidity,
-		State:             quote.PegoutStateWaitingForDeposit,
+		QuoteHash:           quoteHash,
+		DepositAddress:      useCase.contracts.Lbc.GetAddress(),
+		Signature:           quoteSignature,
+		RequiredLiquidity:   requiredLiquidity,
+		State:               quote.PegoutStateWaitingForDeposit,
+		OwnerAccountAddress: trustedAccount.Address,
 	}
-
 	creationData := useCase.quoteRepository.GetPegoutCreationData(ctx, quoteHash)
-
 	if err = useCase.publishQuote(ctx, pegoutQuote, retainedQuote, creationData); err != nil {
 		return quote.AcceptedQuote{}, err
 	}
@@ -95,6 +105,74 @@ func (useCase *AcceptQuoteUseCase) Run(ctx context.Context, quoteHash string) (q
 		Signature:      retainedQuote.Signature,
 		DepositAddress: retainedQuote.DepositAddress,
 	}, nil
+}
+
+func (useCase *AcceptQuoteUseCase) handleTrustedAccountSignature(ctx context.Context, quoteHash string, signature string, pegoutQuote *quote.PegoutQuote) (liquidity_provider.TrustedAccountDetails, error) {
+	if signature == "" {
+		return liquidity_provider.TrustedAccountDetails{}, nil
+	}
+	trustedAccount, err := useCase.getTrustedAccount(ctx, quoteHash, useCase.lp.GetSigner(), signature)
+	if err != nil {
+		return liquidity_provider.TrustedAccountDetails{}, err
+	}
+	if err = useCase.checkLockingCap(ctx, trustedAccount, pegoutQuote); err != nil {
+		return liquidity_provider.TrustedAccountDetails{}, err
+	}
+	return trustedAccount, nil
+}
+
+func (useCase *AcceptQuoteUseCase) getTrustedAccount(ctx context.Context, quoteHash string, signer entities.Signer, signature string) (liquidity_provider.TrustedAccountDetails, error) {
+	address, err := usecases.RecoverSignerAddress(quoteHash, signature)
+	if err != nil {
+		return liquidity_provider.TrustedAccountDetails{}, err
+	}
+
+	trustedAccount, err := liquidity_provider.ValidateConfiguration("accept pegin quote", signer, useCase.hashFunction, func() (*entities.Signed[liquidity_provider.TrustedAccountDetails], error) {
+		return useCase.trustedAccountRepository.GetTrustedAccount(ctx, address)
+	})
+	if err != nil {
+		return liquidity_provider.TrustedAccountDetails{}, liquidity_provider.ErrTamperedTrustedAccount
+	}
+	return trustedAccount.Value, nil
+}
+
+func (useCase *AcceptQuoteUseCase) checkLockingCap(ctx context.Context, trustedAccount liquidity_provider.TrustedAccountDetails, pegoutQuote *quote.PegoutQuote) error {
+	errorArgs := usecases.NewErrorArgs()
+
+	activeQuotesStates := []quote.PegoutState{
+		quote.PegoutStateWaitingForDeposit,
+		quote.PegoutStateWaitingForDepositConfirmations,
+	}
+
+	// Get all retained quotes for this trusted account
+	quotes, err := useCase.quoteRepository.GetRetainedQuotesForAddress(ctx, trustedAccount.Address, activeQuotesStates...)
+	if err != nil {
+		return usecases.WrapUseCaseError(usecases.AcceptPeginQuoteId, err)
+	}
+
+	// Sum the total value of the quotes
+	totalLocked := entities.NewUWei(0)
+	for _, quote := range quotes {
+		totalLocked = new(entities.Wei).Add(totalLocked, quote.RequiredLiquidity)
+	}
+
+	// Add the value of the new quote and gas fee
+	totalWithNewQuote := new(entities.Wei).Add(totalLocked, pegoutQuote.Value)
+	totalWithNewQuote = new(entities.Wei).Add(totalWithNewQuote, pegoutQuote.GasFee)
+
+	// Check if the sum exceeds the locking cap
+	if totalWithNewQuote.Cmp(trustedAccount.BtcLockingCap) > 0 {
+		errorArgs["address"] = trustedAccount.Address
+		errorArgs["currentLocked"] = totalLocked.String()
+		errorArgs["lockingCap"] = trustedAccount.BtcLockingCap.String()
+		return usecases.WrapUseCaseErrorArgs(
+			usecases.AcceptPegoutQuoteId,
+			usecases.LockingCapExceededError,
+			errorArgs,
+		)
+	}
+
+	return nil
 }
 
 func (useCase *AcceptQuoteUseCase) calculateAndCheckLiquidity(ctx context.Context, pegoutQuote quote.PegoutQuote) (*entities.Wei, error) {

--- a/internal/usecases/pegout/accept_pegout_quote.go
+++ b/internal/usecases/pegout/accept_pegout_quote.go
@@ -127,11 +127,11 @@ func (useCase *AcceptQuoteUseCase) getTrustedAccount(ctx context.Context, quoteH
 		return liquidity_provider.TrustedAccountDetails{}, err
 	}
 
-	trustedAccount, err := liquidity_provider.ValidateConfiguration("accept pegin quote", signer, useCase.hashFunction, func() (*entities.Signed[liquidity_provider.TrustedAccountDetails], error) {
+	trustedAccount, err := liquidity_provider.ValidateConfiguration(signer, useCase.hashFunction, func() (*entities.Signed[liquidity_provider.TrustedAccountDetails], error) {
 		return useCase.trustedAccountRepository.GetTrustedAccount(ctx, address)
 	})
 	if err != nil {
-		return liquidity_provider.TrustedAccountDetails{}, liquidity_provider.ErrTamperedTrustedAccount
+		return liquidity_provider.TrustedAccountDetails{}, liquidity_provider.TamperedTrustedAccountError
 	}
 	return trustedAccount.Value, nil
 }

--- a/test/mocks/pegout_quote_repository_mock.go
+++ b/test/mocks/pegout_quote_repository_mock.go
@@ -317,6 +317,80 @@ func (_c *PegoutQuoteRepositoryMock_GetRetainedQuoteByState_Call) RunAndReturn(r
 	return _c
 }
 
+// GetRetainedQuotesForAddress provides a mock function with given fields: ctx, address, states
+func (_m *PegoutQuoteRepositoryMock) GetRetainedQuotesForAddress(ctx context.Context, address string, states ...quote.PegoutState) ([]quote.RetainedPegoutQuote, error) {
+	_va := make([]interface{}, len(states))
+	for _i := range states {
+		_va[_i] = states[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, address)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRetainedQuotesForAddress")
+	}
+
+	var r0 []quote.RetainedPegoutQuote
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...quote.PegoutState) ([]quote.RetainedPegoutQuote, error)); ok {
+		return rf(ctx, address, states...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, ...quote.PegoutState) []quote.RetainedPegoutQuote); ok {
+		r0 = rf(ctx, address, states...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]quote.RetainedPegoutQuote)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, ...quote.PegoutState) error); ok {
+		r1 = rf(ctx, address, states...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// PegoutQuoteRepositoryMock_GetRetainedQuotesForAddress_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRetainedQuotesForAddress'
+type PegoutQuoteRepositoryMock_GetRetainedQuotesForAddress_Call struct {
+	*mock.Call
+}
+
+// GetRetainedQuotesForAddress is a helper method to define mock.On call
+//   - ctx context.Context
+//   - address string
+//   - states ...quote.PegoutState
+func (_e *PegoutQuoteRepositoryMock_Expecter) GetRetainedQuotesForAddress(ctx interface{}, address interface{}, states ...interface{}) *PegoutQuoteRepositoryMock_GetRetainedQuotesForAddress_Call {
+	return &PegoutQuoteRepositoryMock_GetRetainedQuotesForAddress_Call{Call: _e.mock.On("GetRetainedQuotesForAddress",
+		append([]interface{}{ctx, address}, states...)...)}
+}
+
+func (_c *PegoutQuoteRepositoryMock_GetRetainedQuotesForAddress_Call) Run(run func(ctx context.Context, address string, states ...quote.PegoutState)) *PegoutQuoteRepositoryMock_GetRetainedQuotesForAddress_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]quote.PegoutState, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(quote.PegoutState)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *PegoutQuoteRepositoryMock_GetRetainedQuotesForAddress_Call) Return(_a0 []quote.RetainedPegoutQuote, _a1 error) *PegoutQuoteRepositoryMock_GetRetainedQuotesForAddress_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *PegoutQuoteRepositoryMock_GetRetainedQuotesForAddress_Call) RunAndReturn(run func(context.Context, string, ...quote.PegoutState) ([]quote.RetainedPegoutQuote, error)) *PegoutQuoteRepositoryMock_GetRetainedQuotesForAddress_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // InsertQuote provides a mock function with given fields: ctx, _a1
 func (_m *PegoutQuoteRepositoryMock) InsertQuote(ctx context.Context, _a1 quote.CreatedPegoutQuote) error {
 	ret := _m.Called(ctx, _a1)


### PR DESCRIPTION
## What
Add an endpoint and full flow to accept a pegout quote without CAPTCHA by introducing an additional optional parameter to the existing use case. This parameter is a signature from the owner account.

## Why
This change is part of the functionality to automate pegin and pegout flows

More info [here](https://www.notion.so/iovlabs/Flyover-Programmatic-PegIn-and-PegOut-capability-implementation-proposal-1b2c132873f980bfad2cf6c79dfbdb8b)

[Jira tk](https://rsklabs.atlassian.net/browse/GBI-2630)