### PR TITLE
hotfix: Fix Warning for Pegout and feePercentage [0,100] inclusion | GBI-2647 & GBI-2648

### DIFF
--- a/internal/adapters/entrypoints/rest/assets/static/management.js
+++ b/internal/adapters/entrypoints/rest/assets/static/management.js
@@ -358,16 +358,26 @@ const showWarningToast = (warningMessage) => {
 };
 
 function checkFeeWarnings() {
-    const fixedFeeCheckbox = document.querySelector('input[data-key="fixedFee_enabled"]');
-    const feePercentageCheckbox = document.querySelector('input[data-key="feePercentage_enabled"]');
+    const sections = ['generalConfig', 'peginConfig', 'pegoutConfig'];
     const existingToast = document.getElementById('warningToast');
-    
-    if (fixedFeeCheckbox && feePercentageCheckbox) {
-        if (!fixedFeeCheckbox.checked && !feePercentageCheckbox.checked) {
-            if (!existingToast) showWarningToast('It is recommended to enable at least one of "feePercentage" or "fixedFee".');
-        } else {
-            if (existingToast) existingToast.parentNode.removeChild(existingToast);
+    const shouldWarn = sections.some(sectionId => {
+        const sectionElement = document.getElementById(sectionId);
+        if (!sectionElement) return false;
+        const fixedFeeCheckbox = sectionElement.querySelector('input[data-key="fixedFee_enabled"]');
+        const feePercentageCheckbox = sectionElement.querySelector('input[data-key="feePercentage_enabled"]');
+        return (
+            fixedFeeCheckbox &&
+            feePercentageCheckbox &&
+            !fixedFeeCheckbox.checked &&
+            !feePercentageCheckbox.checked
+        );
+    });
+    if (shouldWarn) {
+        if (!existingToast) {
+            showWarningToast('It is recommended to enable at least one of "feePercentage" or "fixedFee".');
         }
+    } else if (existingToast) {
+        existingToast.parentNode.removeChild(existingToast);
     }
 }
 

--- a/pkg/liquidity_provider.go
+++ b/pkg/liquidity_provider.go
@@ -47,7 +47,7 @@ type PeginConfigurationDTO struct {
 	CallTime       uint32  `json:"callTime" validate:"required"`
 	PenaltyFee     string  `json:"penaltyFee" validate:"required,numeric,positive_string"`
 	FixedFee       string  `json:"fixedFee" validate:"required,numeric,min=0"`
-	FeePercentage  float64 `json:"feePercentage" validate:"numeric,gte=0,lt=100,max_decimal_places=2"`
+	FeePercentage  float64 `json:"feePercentage" validate:"numeric,gte=0,lte=100,max_decimal_places=2"`
 	MaxValue       string  `json:"maxValue" validate:"required,numeric,positive_string"`
 	MinValue       string  `json:"minValue" validate:"required,numeric,positive_string"`
 }
@@ -61,7 +61,7 @@ type PegoutConfigurationDTO struct {
 	ExpireTime           uint32  `json:"expireTime" validate:"required"`
 	PenaltyFee           string  `json:"penaltyFee" validate:"required,numeric,positive_string"`
 	FixedFee             string  `json:"fixedFee" validate:"required,numeric,min=0"`
-	FeePercentage        float64 `json:"feePercentage" validate:"required,gte=0,lt=100,max_decimal_places=2"`
+	FeePercentage        float64 `json:"feePercentage" validate:"numeric,gte=0,lte=100,max_decimal_places=2"`
 	MaxValue             string  `json:"maxValue" validate:"required,numeric,positive_string"`
 	MinValue             string  `json:"minValue" validate:"required,numeric,positive_string"`
 	ExpireBlocks         uint64  `json:"expireBlocks" validate:"required"`


### PR DESCRIPTION
**What:**
Fix warning not showing up when disabling both fees in pegout tab
Fix feePercentage not including 100%

**Tasks:**
[GBI-2647](https://rsklabs.atlassian.net/browse/GBI-2647)
[GBI-2648](https://rsklabs.atlassian.net/browse/GBI-2648)