### PR TITLE
chore: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: QA-Test
+    groups:
+      dependencies:
+        dependency-type: production
+      dev-dependencies:
+        dependency-type: development
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: QA-Test


### PR DESCRIPTION
## What
Update dependabot config so that docker and GH actions PRs are opened pointing to QA-Test too