### PR TITLE
feat/gbi2780/add loki integration for logs monitoring

### DIFF
--- a/docker-compose/local/alloy-config.alloy
+++ b/docker-compose/local/alloy-config.alloy
@@ -1,0 +1,63 @@
+// File discovery component to find LPS log files
+local.file_match "lps_logs" {
+  path_targets = [
+    {
+      __path__ = "/home/lps/logs/*.log",
+    },
+  ]
+}
+
+// Source component to read log files
+loki.source.file "lps" {
+  targets    = local.file_match.lps_logs.targets
+  forward_to = [loki.process.lps.receiver]
+}
+
+// Processing component for log transformation and labeling
+loki.process "lps" {
+  // Add static labels for identification
+  stage.static_labels {
+    values = {
+      job         = "liquidity-provider-server",
+      service     = "lps",
+      environment = "local",
+    }
+  }
+
+  // Extract log level from logrus format
+  stage.regex {
+    expression = "level=(?P<level>\\w+)"
+  }
+
+  // Extract timestamp from logrus format
+  stage.regex {
+    expression = "time=\"(?P<timestamp>[^\"]+)\""
+  }
+
+  // Set timestamp if extracted
+  stage.timestamp {
+    source = "timestamp"
+    format = "2006-01-02T15:04:05Z07:00"
+  }
+
+  // Add extracted level as a label
+  stage.labels {
+    values = {
+      level = "",
+    }
+  }
+
+  forward_to = [loki.write.lps.receiver]
+}
+
+// Write component to send logs to Loki
+loki.write "lps" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}
+
+// Enable live debugging for real-time log viewing in Alloy UI
+livedebugging {
+  enabled = true
+} 

--- a/docker-compose/local/docker-compose.metrics.yml
+++ b/docker-compose/local/docker-compose.metrics.yml
@@ -10,6 +10,29 @@ services:
       - ../monitoring/prometheus:/etc/prometheus
     networks:
       - net_lps
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./volumes/loki:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - net_lps
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    ports:
+      - "12345:12345"
+    volumes:
+      - ./alloy-config.alloy:/etc/alloy/config.alloy:ro
+      - ./volumes/lps/logs:/home/lps/logs:ro
+    command: run --server.http.listen-addr=0.0.0.0:12345 /etc/alloy/config.alloy
+    depends_on:
+      - loki
+    networks:
+      - net_lps
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
@@ -22,5 +45,7 @@ services:
       - ../monitoring/grafana:/etc/grafana/provisioning/datasources
     depends_on:
       - prometheus
+      - loki
+      - alloy
     networks:
       - net_lps

--- a/docker-compose/local/lps-env.sh
+++ b/docker-compose/local/lps-env.sh
@@ -103,6 +103,9 @@ LPS_HOME="${LPS_HOME:-./volumes/lps}"
 MONGO_HOME="${MONGO_HOME:-./volumes/mongo}"
 LOCALSTACK_HOME="${LOCALSTACK_HOME:-./volumes/localstack}"
 
+# Set LOG_FILE environment variable for LPS to write logs to file
+export LOG_FILE="/home/lps/logs/lps.log"
+
 [ -d "$BTCD_HOME" ] || mkdir -p "$BTCD_HOME" && chown "$LPS_UID" "$BTCD_HOME"
 [ -d "$RSKJ_HOME" ] || mkdir -p "$RSKJ_HOME/db" && mkdir -p "$RSKJ_HOME/logs" && chown -R "$LPS_UID" "$RSKJ_HOME"
 [ -d "$POWPEG_PEGIN_HOME" ] || mkdir -p "$POWPEG_PEGIN_HOME/db" && mkdir -p "$POWPEG_PEGIN_HOME/logs" && chown -R "$LPS_UID" "$POWPEG_PEGIN_HOME" && chmod -R 777 "$POWPEG_PEGIN_HOME"
@@ -110,8 +113,9 @@ LOCALSTACK_HOME="${LOCALSTACK_HOME:-./volumes/localstack}"
 [ -d "$LPS_HOME" ] || mkdir -p "$LPS_HOME/logs" && chmod -R 777 "$LPS_HOME"
 [ -d "$MONGO_HOME" ] || mkdir -p "$MONGO_HOME/db" && chown -R "$LPS_UID" "$MONGO_HOME"
 [ -d "$LOCALSTACK_HOME" ] || mkdir -p "$LOCALSTACK_HOME/db" && mkdir -p "$LOCALSTACK_HOME/logs" && chown -R "$LPS_UID" "$LOCALSTACK_HOME"
+[ -d "./volumes/loki" ] || mkdir -p "./volumes/loki" && chmod 777 "./volumes/loki"
 
-echo "LPS_UID: $LPS_UID; BTCD_HOME: '$BTCD_HOME'; RSKJ_HOME: '$RSKJ_HOME'; LPS_HOME: '$LPS_HOME'; MONGO_HOME: '$MONGO_HOME'; POWPEG_PEGIN_HOME: '$POWPEG_PEGIN_HOME'; POWPEG_PEGOUT_HOME: '$POWPEG_PEGOUT_HOME'; LOCALSTACK_HOME: '$LOCALSTACK_HOME'"
+echo "LPS_UID: $LPS_UID; BTCD_HOME: '$BTCD_HOME'; RSKJ_HOME: '$RSKJ_HOME'; LPS_HOME: '$LPS_HOME'; MONGO_HOME: '$MONGO_HOME'; POWPEG_PEGIN_HOME: '$POWPEG_PEGIN_HOME'; POWPEG_PEGOUT_HOME: '$POWPEG_PEGOUT_HOME'; LOCALSTACK_HOME: '$LOCALSTACK_HOME'; LOKI_HOME: './volumes/loki'"
 
 # start bitcoind and RSKJ dependant services
 docker compose --env-file "$ENV_FILE" up -d bitcoind rskj mongodb localstack
@@ -346,4 +350,4 @@ if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
   exit 1
 fi
 
-docker compose --env-file "$ENV_FILE" -f docker-compose.yml -f docker-compose.metrics.yml up -d prometheus grafana
+docker compose --env-file "$ENV_FILE" -f docker-compose.yml -f docker-compose.metrics.yml up -d prometheus loki alloy grafana

--- a/docker-compose/monitoring/grafana-template.json
+++ b/docker-compose/monitoring/grafana-template.json
@@ -7,6 +7,14 @@
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
     }
   ],
   "__elements": {},
@@ -30,6 +38,12 @@
       "version": "1.0.0"
     },
     {
+      "type": "datasource",
+      "id": "loki",
+      "name": "Loki",
+      "version": "1.0.0"
+    },
+    {
       "type": "panel",
       "id": "stat",
       "name": "Stat",
@@ -39,6 +53,12 @@
       "type": "panel",
       "id": "timeseries",
       "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
       "version": ""
     }
   ],
@@ -337,12 +357,211 @@
       "type": "piechart"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 9
+      },
+      "id": 35,
+      "panels": [],
+      "title": "Logs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "description": "Recent LPS application logs from all log levels",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 36,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
+          "editorMode": "code",
+          "expr": "{service=\"lps\"}",
+          "queryType": "",
+          "refId": "A"
+        }
+      ],
+      "title": "LPS Application Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "description": "Distribution of log levels in LPS application",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "warn"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "info"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "debug"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 37,
+      "options": {
+        "displayLabels": [
+          "name"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "percent",
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (level) (count_over_time({service=\"lps\"} [$__range]))",
+          "queryType": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Level Distribution",
+      "type": "piechart"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
       },
       "id": 30,
       "panels": [
@@ -553,7 +772,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 28
       },
       "id": 28,
       "panels": [],
@@ -624,7 +843,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 11
+        "y": 20
       },
       "id": 16,
       "options": {
@@ -721,7 +940,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 11
+        "y": 20
       },
       "id": 24,
       "options": {
@@ -818,7 +1037,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 19
+        "y": 28
       },
       "id": 26,
       "options": {
@@ -1085,7 +1304,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 36
       },
       "id": 14,
       "options": {
@@ -1182,7 +1401,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 36
       },
       "id": 20,
       "options": {
@@ -1279,7 +1498,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 44
       },
       "id": 22,
       "options": {
@@ -1377,7 +1596,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 44
       },
       "id": 8,
       "options": {
@@ -1473,7 +1692,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 52
       },
       "id": 4,
       "options": {
@@ -1583,7 +1802,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 52
       },
       "id": 27,
       "options": {

--- a/docker-compose/monitoring/grafana/datasources.yml
+++ b/docker-compose/monitoring/grafana/datasources.yml
@@ -7,3 +7,9 @@ datasources:
     isDefault: true
     access: proxy
     editable: true
+  - name: Loki
+    type: loki
+    url: http://loki:3100
+    isDefault: false
+    access: proxy
+    editable: true


### PR DESCRIPTION
## What
On this PR the LPS logs are taken from the `/logs` folder and feed into [Loki](https://grafana.com/docs/loki/latest/) using [Alloy](https://grafana.com/docs/alloy/latest/). This way the logs are passed to a software specialized into managing them and could be integrated in the Grafana dashboard to have everything related to observability of the LPS on a common place.

## Why
This PR and feature branch are part of the observability tools required as functionality and security improvements of the LPS.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [x] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [ ] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [x] Metrics and alerting

## Related Issues

[Jira ticket GBI-2780](https://rsklabs.atlassian.net/browse/GBI-2780)

## How to test
Run the LPS on local using `./lps-env.sh up`
Go to [http://localhost:3000/](http://localhost:3000/)
Use admin/test as credentials to login
Go to Dashboards in the left panel and import the content of `./docker-compose/monitoring/grafana-template.json`
Check that everything is correct and visualize the logs panel on the dashboard

## Reviewer Guidelines
Future tasks could include improving the way we feed the logs to Loki to improve the indexing/visualization but this is not part of this task

## Screenshots
![image](https://github.com/user-attachments/assets/3dc4bb33-76fd-4038-b1e1-110f30b359f4)
