### PR TITLE
Feat/gbi2794/alerts intitial config

### DIFF
--- a/docker-compose/local/docker-compose.metrics.yml
+++ b/docker-compose/local/docker-compose.metrics.yml
@@ -41,11 +41,28 @@ services:
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=test
+      - GF_SMTP_ENABLED=true
+      - GF_SMTP_HOST=mailhog:1025
+      - GF_SMTP_FROM_ADDRESS=alerts@lps-local.com
+      - GF_SMTP_FROM_NAME=LPS-Alerts-Local
+      - GF_SMTP_SKIP_VERIFY=true
     volumes:
-      - ../monitoring/grafana:/etc/grafana/provisioning/datasources
+      - ../monitoring/grafana:/etc/grafana/provisioning
     depends_on:
       - prometheus
       - loki
       - alloy
     networks:
       - net_lps
+  mailhog:
+    image: mailhog/mailhog
+    container_name: mailhog
+    ports:
+      - "1025:1025"  # SMTP port
+      - "8025:8025"  # Web UI port
+    networks:
+      - net_lps
+
+networks:
+  net_lps:
+    driver: "bridge"

--- a/docker-compose/local/lps-env.sh
+++ b/docker-compose/local/lps-env.sh
@@ -350,4 +350,4 @@ if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
   exit 1
 fi
 
-docker compose --env-file "$ENV_FILE" -f docker-compose.yml -f docker-compose.metrics.yml up -d prometheus loki alloy grafana
+docker compose --env-file "$ENV_FILE" -f docker-compose.yml -f docker-compose.metrics.yml up -d prometheus loki alloy grafana mailhog

--- a/docker-compose/monitoring/grafana/alerting/contact-points.yml
+++ b/docker-compose/monitoring/grafana/alerting/contact-points.yml
@@ -1,0 +1,18 @@
+apiVersion: 1
+contactPoints:
+  - name: liquidity-alerts-email
+    receivers:
+      - uid: email-receiver-01
+        type: email
+        settings:
+          addresses: "lps-alerts@localhost.com"
+          subject: "URGENT: LPS Liquidity Shortage"
+          body: |
+            Alert: {{ .GroupLabels.operation_type }} Liquidity Shortage
+            Environment: Local
+            
+            {{ range .Alerts }}
+            - {{ .Annotations.description }}
+            {{ end }}
+            
+            Time: {{ .CommonAnnotations.time }} 

--- a/docker-compose/monitoring/grafana/alerting/policies.yml
+++ b/docker-compose/monitoring/grafana/alerting/policies.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+policies:
+  - orgId: 1
+    receiver: liquidity-alerts-email
+    group_by:
+      - alertname
+      - operation_type
+    group_wait: 5s
+    group_interval: 30s
+    repeat_interval: 1m
+    matchers:
+      - severity = critical 

--- a/docker-compose/monitoring/grafana/alerting/rules.yml
+++ b/docker-compose/monitoring/grafana/alerting/rules.yml
@@ -1,0 +1,106 @@
+apiVersion: 1
+groups:
+  - name: lps-liquidity-alerts
+    title: "LPS Liquidity Alerts"
+    folder: "LPS"
+    interval: 30s
+    rules:
+      - uid: pegin-liquidity-shortage
+        title: "PegIn Liquidity Shortage"
+        condition: B
+        data:
+          - refId: A
+            queryType: ""
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: loki-uid
+            model:
+              expr: 'count_over_time({service="lps"} |~ "Alert! - Subject: PegIn: Out of liquidity" [1m])'
+          - refId: B
+            queryType: ""
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params: [0]
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+        noDataState: NoData
+        execErrState: Alerting
+        for: 0s
+        annotations:
+          summary: "PegIn Liquidity Shortage Detected"
+          description: "PegIn operations cannot be processed due to insufficient Bitcoin liquidity"
+        labels:
+          severity: critical
+          operation_type: pegin
+          
+      - uid: pegout-liquidity-shortage
+        title: "PegOut Liquidity Shortage"
+        condition: B
+        data:
+          - refId: A
+            queryType: ""
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: loki-uid
+            model:
+              expr: 'count_over_time({service="lps"} |~ "Alert! - Subject: PegOut: Out of liquidity" [1m])'
+          - refId: B
+            queryType: ""
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params: [0]
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+        noDataState: NoData
+        execErrState: Alerting
+        for: 0s
+        annotations:
+          summary: "PegOut Liquidity Shortage Detected"
+          description: "PegOut operations cannot be processed due to insufficient rBTC liquidity"
+        labels:
+          severity: critical
+          operation_type: pegout 

--- a/docker-compose/monitoring/grafana/datasources/datasources.yml
+++ b/docker-compose/monitoring/grafana/datasources/datasources.yml
@@ -7,9 +7,11 @@ datasources:
     isDefault: true
     access: proxy
     editable: true
+    uid: prometheus-uid
   - name: Loki
     type: loki
     url: http://loki:3100
     isDefault: false
     access: proxy
     editable: true
+    uid: loki-uid

--- a/internal/adapters/alerting/log.go
+++ b/internal/adapters/alerting/log.go
@@ -1,0 +1,27 @@
+package alerting
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/rsksmart/liquidity-provider-server/internal/entities"
+	log "github.com/sirupsen/logrus"
+)
+
+type LogAlertSender struct{}
+
+func NewLogAlertSender() entities.AlertSender {
+	return &LogAlertSender{}
+}
+
+func (sender *LogAlertSender) SendAlert(ctx context.Context, subject, body string, recipient []string) error {
+	if strings.TrimSpace(subject) == "" {
+		return errors.New("alert subject cannot be empty")
+	}
+
+	recipients := strings.Join(recipient, ", ")
+	log.Infof("Alert! - Subject: %s | Recipients: %s | Body: %s", subject, recipients, body)
+
+	return nil
+}

--- a/internal/adapters/alerting/log_test.go
+++ b/internal/adapters/alerting/log_test.go
@@ -1,0 +1,136 @@
+package alerting_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rsksmart/liquidity-provider-server/internal/adapters/alerting"
+	"github.com/rsksmart/liquidity-provider-server/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testSubject    = "Test Alert Subject"
+	testBody       = "Test alert body message"
+	testRecipient1 = "admin@example.com"
+	testRecipient2 = "support@example.com"
+)
+
+func TestLogAlertSender_SendAlert_SingleRecipient(t *testing.T) {
+	sender := alerting.NewLogAlertSender()
+	assertLogContains := test.AssertLogContains(t, "Alert! - Subject: Test Alert Subject | Recipients: admin@example.com | Body: Test alert body message")
+
+	err := sender.SendAlert(context.Background(), testSubject, testBody, []string{testRecipient1})
+
+	require.NoError(t, err)
+	assert.True(t, assertLogContains())
+}
+
+func TestLogAlertSender_SendAlert_MultipleRecipients(t *testing.T) {
+	sender := alerting.NewLogAlertSender()
+	assertLogContains := test.AssertLogContains(t, "Alert! - Subject: Test Alert Subject | Recipients: admin@example.com, support@example.com | Body: Test alert body message")
+
+	err := sender.SendAlert(context.Background(), testSubject, testBody, []string{testRecipient1, testRecipient2})
+
+	require.NoError(t, err)
+	assert.True(t, assertLogContains())
+}
+
+func TestLogAlertSender_SendAlert_EmptyRecipients(t *testing.T) {
+	sender := alerting.NewLogAlertSender()
+	assertLogContains := test.AssertLogContains(t, "Alert! - Subject: Test Alert Subject | Recipients:  | Body: Test alert body message")
+
+	err := sender.SendAlert(context.Background(), testSubject, testBody, []string{})
+
+	require.NoError(t, err)
+	assert.True(t, assertLogContains())
+}
+
+func TestLogAlertSender_SendAlert_NilRecipients(t *testing.T) {
+	sender := alerting.NewLogAlertSender()
+	assertLogContains := test.AssertLogContains(t, "Alert! - Subject: Test Alert Subject | Recipients:  | Body: Test alert body message")
+
+	err := sender.SendAlert(context.Background(), testSubject, testBody, nil)
+
+	require.NoError(t, err)
+	assert.True(t, assertLogContains())
+}
+
+func TestLogAlertSender_SendAlert_EmptySubject(t *testing.T) {
+	sender := alerting.NewLogAlertSender()
+
+	err := sender.SendAlert(context.Background(), "", testBody, []string{testRecipient1})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "alert subject cannot be empty")
+}
+
+func TestLogAlertSender_SendAlert_WhitespaceOnlySubject(t *testing.T) {
+	sender := alerting.NewLogAlertSender()
+
+	err := sender.SendAlert(context.Background(), "   \t\n   ", testBody, []string{testRecipient1})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "alert subject cannot be empty")
+}
+
+func TestLogAlertSender_SendAlert_ValidSubjectEmptyBody(t *testing.T) {
+	sender := alerting.NewLogAlertSender()
+	assertLogContains := test.AssertLogContains(t, "Alert! - Subject: Test Alert Subject | Recipients: admin@example.com | Body:")
+
+	err := sender.SendAlert(context.Background(), testSubject, "", []string{testRecipient1})
+
+	require.NoError(t, err)
+	assert.True(t, assertLogContains())
+}
+
+func TestLogAlertSender_SendAlert_SpecialCharacters(t *testing.T) {
+	subjectWithSpecialChars := "Alert: System Error! (Critical)"
+	bodyWithSpecialChars := "Error occurred: connection failed | status: 500 & timeout"
+	sender := alerting.NewLogAlertSender()
+	assertLogContains := test.AssertLogContains(t, "Alert: System Error! (Critical)")
+
+	err := sender.SendAlert(context.Background(), subjectWithSpecialChars, bodyWithSpecialChars, []string{testRecipient1})
+
+	require.NoError(t, err)
+	assert.True(t, assertLogContains())
+}
+
+func TestLogAlertSender_SendAlert_LongContent(t *testing.T) {
+	longSubject := "Very long subject that contains a lot of text to test how the logger handles extended content"
+	longBody := "This is a very long alert body that contains multiple sentences and a lot of information that might be present in a real alert message. It should be logged completely without truncation."
+	sender := alerting.NewLogAlertSender()
+	assertLogContains := test.AssertLogContains(t, longSubject)
+
+	err := sender.SendAlert(context.Background(), longSubject, longBody, []string{testRecipient1})
+
+	require.NoError(t, err)
+	assert.True(t, assertLogContains())
+}
+
+func TestLogAlertSender_SendAlert_JSONBody(t *testing.T) {
+	jsonBody := `{"error": "connection_failed", "details": {"host": "localhost", "port": 8080}, "timestamp": "2023-12-01T10:30:00Z"}`
+	sender := alerting.NewLogAlertSender()
+	assertLogContains := test.AssertLogContains(t, "Alert! - Subject: Test Alert Subject")
+
+	err := sender.SendAlert(context.Background(), testSubject, jsonBody, []string{testRecipient1})
+
+	require.NoError(t, err)
+	assert.True(t, assertLogContains())
+}
+
+func TestNewLogAlertSender(t *testing.T) {
+	sender := alerting.NewLogAlertSender()
+	assert.NotNil(t, sender)
+}
+
+func TestLogAlertSender_AlwaysSucceeds_WithValidSubject(t *testing.T) {
+	sender := alerting.NewLogAlertSender()
+
+	// Test multiple calls to ensure it always returns nil when subject is valid
+	for i := 0; i < 5; i++ {
+		err := sender.SendAlert(context.Background(), testSubject, testBody, []string{testRecipient1})
+		require.NoError(t, err)
+	}
+}

--- a/internal/configuration/registry/alert_sender.go
+++ b/internal/configuration/registry/alert_sender.go
@@ -2,18 +2,12 @@ package registry
 
 import (
 	"context"
-	"github.com/aws/aws-sdk-go-v2/service/ses"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/alerting"
 	"github.com/rsksmart/liquidity-provider-server/internal/configuration/environment"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
-	log "github.com/sirupsen/logrus"
 )
 
 func NewAlertSender(ctx context.Context, env environment.Environment) entities.AlertSender {
-	awsConfiguration, err := environment.GetAwsConfig(ctx, env)
-	if err != nil {
-		log.Fatal("error loading alert sender: ", err)
-	}
-	sesClient := ses.NewFromConfig(awsConfiguration)
-	return alerting.NewSesAlertSender(sesClient, env.Provider.AlertSenderEmail)
+	return alerting.NewLogAlertSender()
 }

--- a/internal/configuration/registry/alert_sender_test.go
+++ b/internal/configuration/registry/alert_sender_test.go
@@ -2,19 +2,19 @@ package registry_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/alerting"
 	"github.com/rsksmart/liquidity-provider-server/internal/configuration/environment"
 	"github.com/rsksmart/liquidity-provider-server/internal/configuration/registry"
-	"github.com/rsksmart/liquidity-provider-server/test"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestNewAlertSender(t *testing.T) {
 	env := environment.Environment{LpsStage: "testnet", Provider: environment.ProviderEnv{AlertSenderEmail: "fake@email.com"}}
 	sender := registry.NewAlertSender(context.Background(), env)
-	implementationPointer, ok := sender.(*alerting.SesAlertSender)
+	implementationPointer, ok := sender.(*alerting.LogAlertSender)
 	assert.NotNil(t, sender)
 	assert.True(t, ok)
-	assert.Equal(t, 2, test.CountNonZeroValues(*implementationPointer))
+	assert.NotNil(t, implementationPointer)
 }

--- a/internal/entities/alerts.go
+++ b/internal/entities/alerts.go
@@ -6,7 +6,7 @@ import "context"
 // Changing one of these constants impacts the external alerting system and there is not an automatic way
 // to identify that error.
 const (
-	AlertSubjectPeginPunishment      = "PegIn: Punishment"
+	AlertSubjectPenalization         = "LPS has been penalized"
 	AlertSubjectPeginOutOfLiquidity  = "PegIn: Out of liquidity"
 	AlertSubjectPegoutOutOfLiquidity = "PegOut: Out of liquidity"
 )

--- a/internal/entities/alerts.go
+++ b/internal/entities/alerts.go
@@ -2,6 +2,15 @@ package entities
 
 import "context"
 
+// This constants are used to standardize the alert subjects so they can be used in the alerting system
+// Changing one of these constants impacts the external alerting system and there is not an automatic way
+// to identify that error.
+const (
+	AlertSubjectPeginPunishment      = "PegIn: Punishment"
+	AlertSubjectPeginOutOfLiquidity  = "PegIn: Out of liquidity"
+	AlertSubjectPegoutOutOfLiquidity = "PegOut: Out of liquidity"
+)
+
 type AlertSender interface {
 	SendAlert(ctx context.Context, subject, body string, recipient []string) error
 }

--- a/internal/usecases/liquidity_provider/check_liquidity.go
+++ b/internal/usecases/liquidity_provider/check_liquidity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
@@ -16,7 +17,6 @@ type OperationType string
 const (
 	PeginOperation  OperationType = "PegIn"
 	PegoutOperation OperationType = "PegOut"
-	MessageSubject  string        = "%s: Out of liquidity"
 	MessageBody     string        = "You are out of liquidity to perform a %s. Please, do a deposit"
 )
 
@@ -54,7 +54,7 @@ func (useCase *CheckLiquidityUseCase) Run(ctx context.Context) error {
 	if errors.Is(err, usecases.NoLiquidityError) {
 		if err = useCase.alertSender.SendAlert(
 			ctx,
-			fmt.Sprintf(MessageSubject, PeginOperation),
+			entities.AlertSubjectPeginOutOfLiquidity,
 			fmt.Sprintf(MessageBody, PeginOperation),
 			[]string{useCase.recipient},
 		); err != nil {
@@ -68,7 +68,7 @@ func (useCase *CheckLiquidityUseCase) Run(ctx context.Context) error {
 	if errors.Is(err, usecases.NoLiquidityError) {
 		if err = useCase.alertSender.SendAlert(
 			ctx,
-			fmt.Sprintf(MessageSubject, PegoutOperation),
+			entities.AlertSubjectPegoutOutOfLiquidity,
 			fmt.Sprintf(MessageBody, PegoutOperation),
 			[]string{useCase.recipient},
 		); err != nil {

--- a/internal/usecases/liquidity_provider/check_liquidity_test.go
+++ b/internal/usecases/liquidity_provider/check_liquidity_test.go
@@ -3,6 +3,8 @@ package liquidity_provider_test
 import (
 	"bytes"
 	"context"
+	"testing"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
@@ -13,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestCheckLiquidityUseCase_Run(t *testing.T) {
@@ -39,7 +40,7 @@ func TestCheckLiquidityUseCase_Run_NoPeginLiquidity(t *testing.T) {
 	recipient := "recipient@test.com"
 	alertSender.On("SendAlert",
 		test.AnyCtx,
-		"PegIn: Out of liquidity",
+		entities.AlertSubjectPeginOutOfLiquidity,
 		"You are out of liquidity to perform a PegIn. Please, do a deposit",
 		[]string{recipient},
 	).Return(nil).Once()
@@ -62,7 +63,7 @@ func TestCheckLiquidityUseCase_Run_NoPegoutLiquidity(t *testing.T) {
 	recipient := "recipient@test.com"
 	alertSender.On("SendAlert",
 		test.AnyCtx,
-		"PegOut: Out of liquidity",
+		entities.AlertSubjectPegoutOutOfLiquidity,
 		"You are out of liquidity to perform a PegOut. Please, do a deposit",
 		[]string{recipient},
 	).Return(nil).Once()

--- a/internal/usecases/liquidity_provider/penalization_alert.go
+++ b/internal/usecases/liquidity_provider/penalization_alert.go
@@ -3,6 +3,7 @@ package liquidity_provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
@@ -27,7 +28,7 @@ func (useCase *PenalizationAlertUseCase) Run(ctx context.Context, fromBlock, toB
 	}
 	for _, event := range events {
 		body = fmt.Sprintf("You were punished in %v rBTC for the quoteHash %s", event.Penalty.ToRbtc(), event.QuoteHash)
-		if err = useCase.sender.SendAlert(ctx, "Pegin Punishment", body, []string{useCase.recipient}); err != nil {
+		if err = useCase.sender.SendAlert(ctx, entities.AlertSubjectPeginPunishment, body, []string{useCase.recipient}); err != nil {
 			log.Error("Error sending punishment alert: ", err)
 		}
 	}

--- a/internal/usecases/liquidity_provider/penalization_alert.go
+++ b/internal/usecases/liquidity_provider/penalization_alert.go
@@ -28,7 +28,7 @@ func (useCase *PenalizationAlertUseCase) Run(ctx context.Context, fromBlock, toB
 	}
 	for _, event := range events {
 		body = fmt.Sprintf("You were punished in %v rBTC for the quoteHash %s", event.Penalty.ToRbtc(), event.QuoteHash)
-		if err = useCase.sender.SendAlert(ctx, entities.AlertSubjectPeginPunishment, body, []string{useCase.recipient}); err != nil {
+		if err = useCase.sender.SendAlert(ctx, entities.AlertSubjectPenalization, body, []string{useCase.recipient}); err != nil {
 			log.Error("Error sending punishment alert: ", err)
 		}
 	}

--- a/internal/usecases/liquidity_provider/penalization_alert_test.go
+++ b/internal/usecases/liquidity_provider/penalization_alert_test.go
@@ -3,6 +3,8 @@ package liquidity_provider_test
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	lp "github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
@@ -12,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestPenalizationAlertUseCase_Run(t *testing.T) {
@@ -49,7 +50,7 @@ func TestPenalizationAlertUseCase_Run(t *testing.T) {
 		sender.On(
 			"SendAlert",
 			test.AnyCtx,
-			"Pegin Punishment",
+			entities.AlertSubjectPeginPunishment,
 			fmt.Sprintf("You were punished in %v rBTC for the quoteHash %s", events[i].Penalty.ToRbtc(), events[i].QuoteHash),
 			[]string{recipient},
 		).Return(nil).Once()

--- a/internal/usecases/liquidity_provider/penalization_alert_test.go
+++ b/internal/usecases/liquidity_provider/penalization_alert_test.go
@@ -50,7 +50,7 @@ func TestPenalizationAlertUseCase_Run(t *testing.T) {
 		sender.On(
 			"SendAlert",
 			test.AnyCtx,
-			entities.AlertSubjectPeginPunishment,
+			entities.AlertSubjectPenalization,
 			fmt.Sprintf("You were punished in %v rBTC for the quoteHash %s", events[i].Penalty.ToRbtc(), events[i].QuoteHash),
 			[]string{recipient},
 		).Return(nil).Once()


### PR DESCRIPTION
## What
Two things:
1. Modify the mechanism used to alert, from SES to log by creating a new implementation of AlertSender. 
2. Add local Docker config to test an alert using the new path of Alloy + Loki + Grafana and add [MailHog](https://github.com/mailhog/MailHog) as the last chain link to test the full flow in local. For this example the liquidity shortage where configured (pegin and pegout)

## Why
This PR and feature branch are part of the observability tools required as functionality and security improvements of the LPS.
The change to log instead of SES is because the SES is not configured so it's useless and the new observability pattern uses logs to monitor the LPS. 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] Security fix
- [x] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [ ] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [x] Metrics and alerting

## Related Issues

[Jira ticket GBI-2794](https://rsklabs.atlassian.net/browse/GBI-2794)

## How to test
### First part
Run the LPS on local using `./lps-env.sh up`
Go to [http://localhost:3000/](http://localhost:3000/). This is Grafana console.
Use admin/test as credentials to login
Go to Alerting -> Alert rules
Check that the rules are created.
### Second part
Run this command to simulate an alert notification from the LPS.
`docker exec -it lps01 /bin/sh -c 'echo "level=info msg=\"Alert! - Subject: PegIn: Out of liquidity | Recipients: lps-alerts@localhost.com | Body: This is a basic test - $(date)\"" >> /home/lps/logs/lps.log'`
Alternatively follow the full process to make the LPS run out of liquidity.
Check the rule for pegin to see the change to `firing` status (in Grafana console)
Wait for a minute and go to http://localhost:8025/# (this is MailHog)
Validate that a mail notification was sent.
### Third part
Repeat the same process with pegout using this command to inject the logs
`docker exec -it lps01 /bin/sh -c 'echo "level=info msg=\"Alert! - Subject: PegOut: Out of liquidity | Recipients: lps-alerts@localhost.com | Body: This is a basic test - $(date)\"" >> /home/lps/logs/lps.log'`

## Screenshots
Grafana firing:
![image](https://github.com/user-attachments/assets/67994aa9-aa8e-496d-abeb-c2ddd6daffb0)

MailHog:
![image](https://github.com/user-attachments/assets/c1d87297-71db-485b-8178-43eeca6405e7)

