### PR TITLE
feat: Improved FeeRate Logging | GBI-2658

### DIFF
--- a/internal/entities/utils/encoding.go
+++ b/internal/entities/utils/encoding.go
@@ -65,7 +65,7 @@ func (bf *BigFloat) UnmarshalBSONValue(bsonType bsontype.Type, bytes []byte) err
 }
 
 func (bf *BigFloat) String() string {
-	return bf.Native().String()
+	return bf.Native().Text('f', -1)
 }
 
 func DecodeKey(key string, expectedBytes int) ([]byte, error) {

--- a/internal/entities/utils/encoding_test.go
+++ b/internal/entities/utils/encoding_test.go
@@ -1,6 +1,7 @@
 package utils_test
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 	"reflect"
@@ -163,6 +164,20 @@ func TestNewBigFloat64(t *testing.T) {
 	}
 }
 
+func TestBigFloat_StringFormatsFixedPoint(t *testing.T) {
+    bf := utils.NewBigFloat64(0.000012)
+    expected := "0.000012"
+    require.Equal(t, expected, bf.String())
+}
+
+func TestStructFormatting_UsesFixedPoint(t *testing.T) {
+    type sample struct {
+        FeeRate *utils.BigFloat
+    }
+    payload := sample{FeeRate: utils.NewBigFloat64(0.000012)}
+    formatted := fmt.Sprintf("%+v", payload)
+    require.Contains(t, formatted, "FeeRate:0.000012")
+}
 func TestBigFloat_Native(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
**What:**
Improved FeeRate and String() logging by not using scientific notation
Added tests

**Task:**
[GBI-2658](https://rsklabs.atlassian.net/browse/GBI-2658)