### PR TITLE
feat: GBI-2563 | additional validation [Clean]

### DIFF
--- a/internal/configuration/registry/usecase.go
+++ b/internal/configuration/registry/usecase.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"sync"
+
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/dataproviders"
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/dataproviders/rootstock"
@@ -11,7 +13,6 @@ import (
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases/pegin"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases/pegout"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases/watcher"
-	"sync"
 )
 
 var signingHashFunction = crypto.Keccak256
@@ -208,6 +209,7 @@ func NewUseCaseRegistry(
 			databaseRegistry.LiquidityProviderRepository,
 			rskRegistry.Wallet,
 			signingHashFunction,
+			rskRegistry.Contracts,
 		),
 		setPegoutConfigUseCase: liquidity_provider.NewSetPegoutConfigUseCase(
 			databaseRegistry.LiquidityProviderRepository,

--- a/internal/entities/wei.go
+++ b/internal/entities/wei.go
@@ -4,10 +4,13 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"math/big"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
-	"math/big"
 )
+
+var ErrNonPositiveWei = errors.New("wei value must be positive")
 
 type Wei big.Int
 
@@ -17,6 +20,16 @@ var bTen = big.NewInt(10)
 var bEighteen = big.NewInt(18)
 var bTenPowTen = new(big.Int).Exp(bTen, bTen, nil)           // 10**10
 var bTenPowEighteen = new(big.Int).Exp(bTen, bEighteen, nil) // 10**18
+
+func ValidatePositiveWei(values ...*Wei) error {
+	zero := NewWei(0)
+	for _, v := range values {
+		if v == nil || v.Cmp(zero) < 0 {
+			return ErrNonPositiveWei
+		}
+	}
+	return nil
+}
 
 func NewWei(x int64) *Wei {
 	w := new(Wei)

--- a/internal/usecases/common.go
+++ b/internal/usecases/common.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
@@ -85,6 +86,9 @@ var (
 	ProviderNotResignedError    = errors.New("provided hasn't completed resignation process")
 	IllegalQuoteStateError      = errors.New("illegal quote state")
 	LockingCapExceededError     = errors.New("locking cap exceeded")
+	NonPositiveWeiError             = errors.New("wei value must be positive")
+	EmptyConfirmationsMapError      = errors.New("confirmations map cannot be empty")
+	NonPositiveConfirmationKeyError = errors.New("confirmation amount key must be positive")
 )
 
 type ErrorArgs map[string]string
@@ -276,4 +280,25 @@ func RecoverSignerAddress(quoteHash, signature string) (string, error) {
 
 	address := crypto.PubkeyToAddress(*pubKeyECDSA).Hex()
 	return address, nil
+}
+
+func ValidatePositiveWeiValues(useCase UseCaseId, weiValues ...*entities.Wei) error {
+	if err := entities.ValidatePositiveWei(weiValues...); err != nil {
+		return WrapUseCaseError(useCase, NonPositiveWeiError)
+	}
+	return nil
+}
+
+func ValidateConfirmations(useCase UseCaseId, confirmations liquidity_provider.ConfirmationsPerAmount) error {
+	if len(confirmations) == 0 {
+		return WrapUseCaseError(useCase, EmptyConfirmationsMapError)
+	}
+	for keyStr := range confirmations {
+		intKey, err := strconv.Atoi(keyStr)
+		if err != nil || intKey <= 0 {
+			args := ErrorArg("key", keyStr)
+			return WrapUseCaseErrorArgs(useCase, NonPositiveConfirmationKeyError, args)
+		}
+	}
+	return nil
 }

--- a/internal/usecases/common_test.go
+++ b/internal/usecases/common_test.go
@@ -411,3 +411,42 @@ func TestRecoverSignerAddress(t *testing.T) {
 		})
 	}
 }
+func TestValidatePositiveWeiValues(t *testing.T) {
+	var useCase u.UseCaseId = "validateWei"
+
+	t.Run("should return nil when all values are positive", func(t *testing.T) {
+		err := u.ValidatePositiveWeiValues(useCase, entities.NewWei(1), entities.NewWei(0), entities.NewWei(100))
+		require.NoError(t, err)
+	})
+
+	t.Run("should fail when any value is negative", func(t *testing.T) {
+		err := u.ValidatePositiveWeiValues(useCase, entities.NewWei(1), entities.NewWei(-1))
+		require.ErrorIs(t, err, u.NonPositiveWeiError)
+	})
+
+	t.Run("should fail when any value is nil", func(t *testing.T) {
+		err := u.ValidatePositiveWeiValues(useCase, entities.NewWei(1), nil)
+		require.ErrorIs(t, err, u.NonPositiveWeiError)
+	})
+}
+
+func TestValidateConfirmations(t *testing.T) {
+	var useCase u.UseCaseId = "validateConfirmations"
+
+	t.Run("should return nil for valid confirmations map", func(t *testing.T) {
+		confirmations := liquidity_provider.ConfirmationsPerAmount{"1": 6, "10": 10}
+		err := u.ValidateConfirmations(useCase, confirmations)
+		require.NoError(t, err)
+	})
+
+	t.Run("should fail for empty map", func(t *testing.T) {
+		err := u.ValidateConfirmations(useCase, liquidity_provider.ConfirmationsPerAmount{})
+		require.ErrorIs(t, err, u.EmptyConfirmationsMapError)
+	})
+
+	t.Run("should fail for non-positive keys", func(t *testing.T) {
+		confirmations := liquidity_provider.ConfirmationsPerAmount{"0": 1, "-5": 2}
+		err := u.ValidateConfirmations(useCase, confirmations)
+		require.ErrorIs(t, err, u.NonPositiveConfirmationKeyError)
+	})
+}

--- a/internal/usecases/liquidity_provider/set_general_config.go
+++ b/internal/usecases/liquidity_provider/set_general_config.go
@@ -2,6 +2,7 @@ package liquidity_provider
 
 import (
 	"context"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
@@ -22,6 +23,12 @@ func NewSetGeneralConfigUseCase(
 }
 
 func (useCase *SetGeneralConfigUseCase) Run(ctx context.Context, config liquidity_provider.GeneralConfiguration) error {
+	if err := usecases.ValidateConfirmations(usecases.SetGeneralConfigId, config.RskConfirmations); err != nil {
+		return err
+	}
+	if err := usecases.ValidateConfirmations(usecases.SetGeneralConfigId, config.BtcConfirmations); err != nil {
+		return err
+	}
 	signedConfig, err := usecases.SignConfiguration(usecases.SetGeneralConfigId, useCase.signer, useCase.hashFunc, config)
 	if err != nil {
 		return err

--- a/internal/usecases/liquidity_provider/set_general_config_test.go
+++ b/internal/usecases/liquidity_provider/set_general_config_test.go
@@ -2,15 +2,17 @@ package liquidity_provider_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	lp "github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/test"
 	"github.com/rsksmart/liquidity-provider-server/test/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestSetGeneralConfigUseCase_Run(t *testing.T) {
@@ -71,5 +73,45 @@ func TestSetGeneralConfigUseCase_Run_ErrorHandling(t *testing.T) {
 		require.Error(t, err)
 		lpRepository.AssertExpectations(t)
 		walletMock.AssertExpectations(t)
+	}
+}
+
+func TestSetGeneralConfigUseCase_Run_ValidateConfirmations(t *testing.T) {
+	walletMock := &mocks.RskWalletMock{}
+	hashMock := &mocks.HashMock{}
+
+	invalidConfigs := []lp.GeneralConfiguration{
+		// Empty RSK confirmations
+		{
+			RskConfirmations: map[string]uint16{},
+			BtcConfirmations: map[string]uint16{"10": 20},
+		},
+		// Empty BTC confirmations
+		{
+			RskConfirmations: map[string]uint16{"5": 10},
+			BtcConfirmations: map[string]uint16{},
+		},
+		// Negative key in RSK confirmations
+		{
+			RskConfirmations: map[string]uint16{"-1": 10},
+			BtcConfirmations: map[string]uint16{"10": 20},
+		},
+		// Zero key in BTC confirmations
+		{
+			RskConfirmations: map[string]uint16{"5": 10},
+			BtcConfirmations: map[string]uint16{"0": 20},
+		},
+	}
+
+	for _, cfg := range invalidConfigs {
+		lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+		useCase := liquidity_provider.NewSetGeneralConfigUseCase(lpRepository, walletMock, hashMock.Hash)
+		err := useCase.Run(context.Background(), cfg)
+		require.Error(t, err)
+		if len(cfg.RskConfirmations) == 0 || len(cfg.BtcConfirmations) == 0 {
+			require.ErrorIs(t, err, usecases.EmptyConfirmationsMapError)
+		} else {
+			require.ErrorIs(t, err, usecases.NonPositiveConfirmationKeyError)
+		}
 	}
 }

--- a/internal/usecases/liquidity_provider/set_pegin_config.go
+++ b/internal/usecases/liquidity_provider/set_pegin_config.go
@@ -2,7 +2,9 @@ package liquidity_provider
 
 import (
 	"context"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 )
@@ -11,23 +13,37 @@ type SetPeginConfigUseCase struct {
 	lpRepository liquidity_provider.LiquidityProviderRepository
 	signer       entities.Signer
 	hashFunc     entities.HashFunction
+	contracts    blockchain.RskContracts
 }
 
 func NewSetPeginConfigUseCase(
 	lpRepository liquidity_provider.LiquidityProviderRepository,
 	signer entities.Signer,
 	hashFunc entities.HashFunction,
+	contracts blockchain.RskContracts,
 ) *SetPeginConfigUseCase {
-	return &SetPeginConfigUseCase{lpRepository: lpRepository, signer: signer, hashFunc: hashFunc}
+	return &SetPeginConfigUseCase{lpRepository: lpRepository, signer: signer, hashFunc: hashFunc, contracts: contracts}
 }
 
 func (useCase *SetPeginConfigUseCase) Run(ctx context.Context, config liquidity_provider.PeginConfiguration) error {
+	if err := usecases.ValidatePositiveWeiValues(
+		usecases.SetPeginConfigId,
+		config.PenaltyFee,
+		config.FixedFee,
+		config.MaxValue,
+		config.MinValue,
+	); err != nil {
+		return err
+	}
+
+	if err := usecases.ValidateMinLockValue(usecases.SetPeginConfigId, useCase.contracts.Bridge, config.MinValue); err != nil {
+		return err
+	}
 	signedConfig, err := usecases.SignConfiguration(usecases.SetPeginConfigId, useCase.signer, useCase.hashFunc, config)
 	if err != nil {
 		return err
 	}
-	err = useCase.lpRepository.UpsertPeginConfiguration(ctx, signedConfig)
-	if err != nil {
+	if err = useCase.lpRepository.UpsertPeginConfiguration(ctx, signedConfig); err != nil {
 		return usecases.WrapUseCaseError(usecases.SetPeginConfigId, err)
 	}
 	return nil

--- a/internal/usecases/liquidity_provider/set_pegin_config_test.go
+++ b/internal/usecases/liquidity_provider/set_pegin_config_test.go
@@ -2,16 +2,19 @@ package liquidity_provider_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	lp "github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/utils"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/test"
 	"github.com/rsksmart/liquidity-provider-server/test/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 var peginConfigMock = entities.Signed[lp.PeginConfiguration]{
@@ -36,13 +39,18 @@ func TestSetPeginConfigUseCase_Run(t *testing.T) {
 	hashMock := &mocks.HashMock{}
 	hashMock.On("Hash", mock.Anything).Return([]byte{4, 5, 6})
 
-	useCase := liquidity_provider.NewSetPeginConfigUseCase(lpRepository, walletMock, hashMock.Hash)
+	bridge := &mocks.BridgeMock{}
+	bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1), nil)
+	contracts := blockchain.RskContracts{Bridge: bridge}
+
+	useCase := liquidity_provider.NewSetPeginConfigUseCase(lpRepository, walletMock, hashMock.Hash, contracts)
 
 	err := useCase.Run(context.Background(), peginConfigMock.Value)
 	require.NoError(t, err)
 	lpRepository.AssertExpectations(t)
 	walletMock.AssertExpectations(t)
 	hashMock.AssertExpectations(t)
+	bridge.AssertExpectations(t)
 }
 
 func TestSetPeginConfigUseCase_Run_ErrorHandling(t *testing.T) {
@@ -63,10 +71,129 @@ func TestSetPeginConfigUseCase_Run_ErrorHandling(t *testing.T) {
 		lpRepository := &mocks.LiquidityProviderRepositoryMock{}
 		walletMock := &mocks.RskWalletMock{}
 		errorSetup(lpRepository, walletMock)
-		useCase := liquidity_provider.NewSetPeginConfigUseCase(lpRepository, walletMock, hashMock.Hash)
+		bridge := &mocks.BridgeMock{}
+		bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1), nil)
+		contracts := blockchain.RskContracts{Bridge: bridge}
+		useCase := liquidity_provider.NewSetPeginConfigUseCase(lpRepository, walletMock, hashMock.Hash, contracts)
 		err := useCase.Run(context.Background(), peginConfigMock.Value)
 		require.Error(t, err)
 		lpRepository.AssertExpectations(t)
 		walletMock.AssertExpectations(t)
+		bridge.AssertExpectations(t)
 	}
+}
+
+func TestSetPeginConfigUseCase_Run_ValidateBridgeMin(t *testing.T) {
+	lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+	walletMock := &mocks.RskWalletMock{}
+	hashMock := &mocks.HashMock{}
+
+	bridge := &mocks.BridgeMock{}
+	bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(10), nil)
+	contracts := blockchain.RskContracts{Bridge: bridge}
+
+	useCase := liquidity_provider.NewSetPeginConfigUseCase(lpRepository, walletMock, hashMock.Hash, contracts)
+
+	err := useCase.Run(context.Background(), peginConfigMock.Value)
+	require.ErrorIs(t, err, usecases.TxBelowMinimumError)
+	bridge.AssertExpectations(t)
+}
+
+func TestSetPeginConfigUseCase_Run_ValidatePositiveWei(t *testing.T) {
+	lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+	walletMock := &mocks.RskWalletMock{}
+	hashMock := &mocks.HashMock{}
+
+	invalidConfig := lp.PeginConfiguration{
+		TimeForDeposit: 1,
+		CallTime:       2,
+		PenaltyFee:     entities.NewWei(3),
+		FixedFee:       entities.NewWei(-1),
+		FeePercentage:  utils.NewBigFloat64(4.5),
+		MaxValue:       entities.NewWei(5),
+		MinValue:       entities.NewWei(1),
+	}
+
+	bridge := &mocks.BridgeMock{}
+	bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1), nil)
+	contracts := blockchain.RskContracts{Bridge: bridge}
+
+	useCase := liquidity_provider.NewSetPeginConfigUseCase(lpRepository, walletMock, hashMock.Hash, contracts)
+
+	err := useCase.Run(context.Background(), invalidConfig)
+	require.ErrorIs(t, err, usecases.NonPositiveWeiError)
+}
+
+func TestSetPeginConfigUseCase_Run_ZeroFixedFee(t *testing.T) {
+    lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+    walletMock := &mocks.RskWalletMock{}
+    hashMock := &mocks.HashMock{}
+
+    cfg := lp.PeginConfiguration{
+        TimeForDeposit: 1,
+        CallTime:       2,
+        PenaltyFee:     entities.NewWei(3),
+        FixedFee:       entities.NewWei(0),
+        FeePercentage:  utils.NewBigFloat64(4.5),
+        MaxValue:       entities.NewWei(5),
+        MinValue:       entities.NewWei(1),
+    }
+
+    bridge := &mocks.BridgeMock{}
+    bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1), nil)
+    contracts := blockchain.RskContracts{Bridge: bridge}
+
+    lpRepository.On("UpsertPeginConfiguration", test.AnyCtx, mock.Anything).Return(nil)
+    walletMock.On("SignBytes", mock.Anything).Return([]byte{1,2,3}, nil)
+    hashMock.On("Hash", mock.Anything).Return([]byte{4,5,6})
+
+    useCase := liquidity_provider.NewSetPeginConfigUseCase(lpRepository, walletMock, hashMock.Hash, contracts)
+
+    err := useCase.Run(context.Background(), cfg)
+    require.NoError(t, err)
+    bridge.AssertExpectations(t)
+    lpRepository.AssertExpectations(t)
+}
+
+func TestSetPegoutConfigUseCase_Run_ValidatePositiveWei_EachField(t *testing.T) {
+    lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+    walletMock := &mocks.RskWalletMock{}
+    hashMock := &mocks.HashMock{}
+
+    baseCfg := lp.PegoutConfiguration{
+        TimeForDeposit:       1,
+        ExpireTime:           2,
+        PenaltyFee:           entities.NewWei(3),
+        FixedFee:             entities.NewWei(4),
+        FeePercentage:        utils.NewBigFloat64(4.5),
+        MaxValue:             entities.NewWei(5),
+        MinValue:             entities.NewWei(1),
+        ExpireBlocks:         10,
+        BridgeTransactionMin: entities.NewWei(5),
+    }
+
+    makeCfg := func(modify func(*lp.PegoutConfiguration)) lp.PegoutConfiguration {
+        cfg := baseCfg
+        modify(&cfg)
+        return cfg
+    }
+
+    cases := []lp.PegoutConfiguration{
+        makeCfg(func(c *lp.PegoutConfiguration) { c.PenaltyFee = entities.NewWei(-1) }),
+        makeCfg(func(c *lp.PegoutConfiguration) { c.FixedFee = entities.NewWei(-1) }),
+        makeCfg(func(c *lp.PegoutConfiguration) { c.MaxValue = entities.NewWei(-1) }),
+        makeCfg(func(c *lp.PegoutConfiguration) { c.MinValue = entities.NewWei(-1) }),
+        makeCfg(func(c *lp.PegoutConfiguration) { c.BridgeTransactionMin = entities.NewWei(-1) }),
+    }
+
+    for _, cfg := range cases {
+        bridge := &mocks.BridgeMock{}
+        bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1), nil).Maybe()
+        contracts := blockchain.RskContracts{Bridge: bridge}
+
+        useCase := liquidity_provider.NewSetPegoutConfigUseCase(lpRepository, walletMock, hashMock.Hash, contracts)
+        err := useCase.Run(context.Background(), cfg)
+        require.ErrorIs(t, err, usecases.NonPositiveWeiError)
+        bridge.AssertExpectations(t)
+    }
 }

--- a/internal/usecases/liquidity_provider/set_pegout_config.go
+++ b/internal/usecases/liquidity_provider/set_pegout_config.go
@@ -2,6 +2,7 @@ package liquidity_provider
 
 import (
 	"context"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
@@ -25,6 +26,17 @@ func NewSetPegoutConfigUseCase(
 }
 
 func (useCase *SetPegoutConfigUseCase) Run(ctx context.Context, config liquidity_provider.PegoutConfiguration) error {
+	if err := usecases.ValidatePositiveWeiValues(
+		usecases.SetPegoutConfigId,
+		config.PenaltyFee,
+		config.FixedFee,
+		config.MaxValue,
+		config.MinValue,
+		config.BridgeTransactionMin,
+	); err != nil {
+		return err
+	}
+
 	var err error
 	if err = usecases.ValidateMinLockValue(usecases.SetPegoutConfigId, useCase.contracts.Bridge, config.BridgeTransactionMin); err != nil {
 		return err

--- a/internal/usecases/liquidity_provider/set_pegout_config_test.go
+++ b/internal/usecases/liquidity_provider/set_pegout_config_test.go
@@ -2,6 +2,8 @@ package liquidity_provider_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	lp "github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
@@ -13,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 var pegoutConfigMock = entities.Signed[lp.PegoutConfiguration]{
@@ -97,5 +98,106 @@ func TestSetPegoutConfigUseCase_Run_ErrorHandling(t *testing.T) {
 		require.Error(t, err)
 		lpRepository.AssertExpectations(t)
 		walletMock.AssertExpectations(t)
+		bridge.AssertExpectations(t)
 	}
+}
+
+func TestSetPegoutConfigUseCase_Run_ValidatePositiveWei(t *testing.T) {
+    lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+    walletMock := &mocks.RskWalletMock{}
+    hashMock := &mocks.HashMock{}
+
+    invalidConfig := lp.PegoutConfiguration{
+        TimeForDeposit:       1,
+        ExpireTime:           2,
+        PenaltyFee:           entities.NewWei(-3),
+        FixedFee:             entities.NewWei(4),
+        FeePercentage:        utils.NewBigFloat64(4.5),
+        MaxValue:             entities.NewWei(5),
+        MinValue:             entities.NewWei(1),
+        ExpireBlocks:         10,
+        BridgeTransactionMin: entities.NewWei(5),
+    }
+
+    bridge := &mocks.BridgeMock{}
+    bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1), nil)
+    contracts := blockchain.RskContracts{Bridge: bridge}
+
+    useCase := liquidity_provider.NewSetPegoutConfigUseCase(lpRepository, walletMock, hashMock.Hash, contracts)
+
+    err := useCase.Run(context.Background(), invalidConfig)
+    require.ErrorIs(t, err, usecases.NonPositiveWeiError)
+}
+
+func TestSetPegoutConfigUseCase_Run_ZeroFixedFee(t *testing.T) {
+    lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+    walletMock := &mocks.RskWalletMock{}
+    hashMock := &mocks.HashMock{}
+
+    cfg := lp.PegoutConfiguration{
+        TimeForDeposit:       1,
+        ExpireTime:           2,
+        PenaltyFee:           entities.NewWei(3),
+        FixedFee:             entities.NewWei(0),
+        FeePercentage:        utils.NewBigFloat64(4.5),
+        MaxValue:             entities.NewWei(5),
+        MinValue:             entities.NewWei(1),
+        ExpireBlocks:         10,
+        BridgeTransactionMin: entities.NewWei(5),
+    }
+
+    bridge := &mocks.BridgeMock{}
+    bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1), nil)
+    contracts := blockchain.RskContracts{Bridge: bridge}
+
+    lpRepository.On("UpsertPegoutConfiguration", test.AnyCtx, mock.Anything).Return(nil)
+    walletMock.On("SignBytes", mock.Anything).Return([]byte{1,2,3}, nil)
+    hashMock.On("Hash", mock.Anything).Return([]byte{4,5,6})
+
+    useCase := liquidity_provider.NewSetPegoutConfigUseCase(lpRepository, walletMock, hashMock.Hash, contracts)
+
+    err := useCase.Run(context.Background(), cfg)
+    require.NoError(t, err)
+    bridge.AssertExpectations(t)
+    lpRepository.AssertExpectations(t)
+}
+
+func TestSetPeginConfigUseCase_Run_ValidatePositiveWei_EachField(t *testing.T) {
+    lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+    walletMock := &mocks.RskWalletMock{}
+    hashMock := &mocks.HashMock{}
+
+    baseCfg := lp.PeginConfiguration{
+        TimeForDeposit: 1,
+        CallTime:       2,
+        PenaltyFee:     entities.NewWei(3),
+        FixedFee:       entities.NewWei(4),
+        FeePercentage:  utils.NewBigFloat64(4.5),
+        MaxValue:       entities.NewWei(5),
+        MinValue:       entities.NewWei(1),
+    }
+
+    makeCfg := func(modify func(*lp.PeginConfiguration)) lp.PeginConfiguration {
+        cfg := baseCfg
+        modify(&cfg)
+        return cfg
+    }
+
+    cases := []lp.PeginConfiguration{
+        makeCfg(func(c *lp.PeginConfiguration) { c.PenaltyFee = entities.NewWei(-1) }),
+        makeCfg(func(c *lp.PeginConfiguration) { c.FixedFee = entities.NewWei(-1) }),
+        makeCfg(func(c *lp.PeginConfiguration) { c.MaxValue = entities.NewWei(-1) }),
+        makeCfg(func(c *lp.PeginConfiguration) { c.MinValue = entities.NewWei(-1) }),
+    }
+
+    for _, cfg := range cases {
+        bridge := &mocks.BridgeMock{}
+        bridge.On("GetMinimumLockTxValue").Return(entities.NewWei(1), nil)
+        contracts := blockchain.RskContracts{Bridge: bridge}
+
+        useCase := liquidity_provider.NewSetPeginConfigUseCase(lpRepository, walletMock, hashMock.Hash, contracts)
+        err := useCase.Run(context.Background(), cfg)
+        require.ErrorIs(t, err, usecases.NonPositiveWeiError)
+        bridge.AssertNotCalled(t, "GetMinimumLockTxValue")
+    }
 }


### PR DESCRIPTION
**What:**
Check the minPegin is above the bridge minimum in SetPeginConfigUseCase.
Validate all the wei values are positive in the three types of configuration.
Check that both rsk and btc ConfirmationsPerAmount have at least one entry in SetGeneralConfigUseCase , and that the keys of the map are all positive.

**Task:**
[GBI-2563](https://rsklabs.atlassian.net/browse/GBI-2563)