### PR TITLE
Feat/fly2049/financial api/assets report

### DIFF
--- a/internal/adapters/entrypoints/rest/handlers/get_reports_assets.go
+++ b/internal/adapters/entrypoints/rest/handlers/get_reports_assets.go
@@ -2,10 +2,11 @@ package handlers
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases/reports"
 	"github.com/rsksmart/liquidity-provider-server/pkg"
-	"net/http"
 )
 
 type GetAssetsReportUseCase interface {
@@ -14,25 +15,19 @@ type GetAssetsReportUseCase interface {
 
 // NewGetReportsAssetsHandler
 // @Title Get asset Reports
-// @Description Get the asset information for the LPS.
-// @Success 200 pkg.GetAssetsReportDTO
-// @Route /reports/assets [get]
+// @Description Get the asset information for the LPS including BTC and RBTC balances, locations, and allocations.
+// @Success 200 {object} pkg.GetAssetsReportResponse "Detailed asset report with BTC and RBTC information"
+// @Router /reports/assets [get]
 func NewGetReportsAssetsHandler(useCase GetAssetsReportUseCase) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		response, err := useCase.Run(req.Context())
 		if err != nil {
-			jsonErr := rest.NewErrorResponseWithDetails("Request error", rest.DetailsFromError(err), false)
-			rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
+			jsonErr := rest.NewErrorResponseWithDetails(UnknownErrorMessage, rest.DetailsFromError(err), false)
+			rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
 			return
 		}
-		responseDto := pkg.GetAssetsReportDTO{
-			RbtcLocked:    response.RbtcLocked,
-			RbtcBalance:   response.RbtcBalance,
-			RbtcLiquidity: response.RbtcLiquidity,
-			BtcLocked:     response.BtcLocked,
-			BtcBalance:    response.BtcBalance,
-			BtcLiquidity:  response.BtcLiquidity,
-		}
+
+		responseDto := pkg.ToGetAssetsReportResponse(response)
 
 		rest.JsonResponseWithBody(w, http.StatusOK, &responseDto)
 	}

--- a/internal/adapters/entrypoints/rest/handlers/get_reports_assets_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/get_reports_assets_test.go
@@ -1,67 +1,256 @@
 package handlers_test
 
 import (
-	"fmt"
-	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest/handlers"
-	"github.com/rsksmart/liquidity-provider-server/internal/usecases/reports"
-	"github.com/rsksmart/liquidity-provider-server/test/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
+	"context"
+	"encoding/json"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
+
+	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest/handlers"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases/reports"
+	"github.com/rsksmart/liquidity-provider-server/pkg"
+	"github.com/rsksmart/liquidity-provider-server/test/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
-func TestNewGetReportsAssetsHandler(t *testing.T) {
-	const (
-		path = "/reports/assets"
-		verb = "GET"
-	)
-
-	successReturn := reports.GetAssetsReportResult{
-		BtcBalance:    big.NewInt(100000),
-		RbtcBalance:   big.NewInt(100000),
-		BtcLocked:     big.NewInt(15000),
-		RbtcLocked:    big.NewInt(17500),
-		BtcLiquidity:  big.NewInt(85000),
-		RbtcLiquidity: big.NewInt(67500),
-	}
-
-	failReturn := reports.GetAssetsReportResult{
-		BtcBalance:    big.NewInt(0),
-		RbtcBalance:   big.NewInt(0),
-		BtcLocked:     big.NewInt(0),
-		RbtcLocked:    big.NewInt(0),
-		BtcLiquidity:  big.NewInt(0),
-		RbtcLiquidity: big.NewInt(0),
-	}
-
-	t.Run("should return 200 on success", func(t *testing.T) {
+//nolint:funlen
+func TestNewGetReportsAssetsHandler_Success(t *testing.T) {
+	t.Run("should return 200 with correct structure on success", func(t *testing.T) {
 		useCase := new(mocks.GetAssetsReportUseCaseMock)
-		useCase.EXPECT().Run(mock.Anything).Return(successReturn, nil)
+
+		expectedResult := reports.GetAssetsReportResult{
+			BtcAssetReport: reports.BtcAssetReport{
+				Total: entities.NewWei(67500000), // 0.675 BTC
+				Location: reports.BtcAssetLocation{
+					BtcWallet:  entities.NewWei(50000000), // 0.5 BTC
+					Federation: entities.NewWei(5000000),  // 0.05 BTC
+					RskWallet:  entities.NewWei(6500000),  // 0.065 BTC
+					Lbc:        entities.NewWei(6000000),  // 0.06 BTC
+				},
+				Allocation: reports.BtcAssetAllocation{
+					ReservedForUsers: entities.NewWei(4500000),  // 0.045 BTC
+					WaitingForRefund: entities.NewWei(11500000), // 0.115 BTC
+					Available:        entities.NewWei(51500000), // 0.515 BTC
+				},
+			},
+			RbtcAssetReport: reports.RbtcAssetReport{
+				Total: entities.NewBigWei(new(big.Int).SetUint64(17000000000000000000)), // 17 RBTC
+				Location: reports.RbtcAssetLocation{
+					RskWallet:  entities.NewBigWei(new(big.Int).SetUint64(10000000000000000000)), // 10 RBTC
+					Lbc:        entities.NewBigWei(new(big.Int).SetUint64(5000000000000000000)),  // 5 RBTC
+					Federation: entities.NewBigWei(new(big.Int).SetUint64(2000000000000000000)),  // 2 RBTC
+				},
+				Allocation: reports.RbtcAssetAllocation{
+					ReservedForUsers: entities.NewBigWei(new(big.Int).SetUint64(3000000000000000000)),  // 3 RBTC
+					WaitingForRefund: entities.NewBigWei(new(big.Int).SetUint64(2000000000000000000)),  // 2 RBTC
+					Available:        entities.NewBigWei(new(big.Int).SetUint64(12000000000000000000)), // 12 RBTC
+				},
+			},
+		}
+
+		useCase.EXPECT().Run(mock.Anything).Return(expectedResult, nil).Once()
 
 		handler := handlers.NewGetReportsAssetsHandler(useCase)
-		reqBody := `{}`
-		req := httptest.NewRequest(http.MethodPost, "/reports/assets", strings.NewReader(reqBody))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-		handler(w, req)
-		assert.Equal(t, http.StatusOK, w.Code)
-		assert.HTTPBodyContains(t, handler, verb, path, nil, fmt.Sprintf(`"btcBalance":%d`, successReturn.BtcBalance))
-		assert.HTTPBodyContains(t, handler, verb, path, nil, fmt.Sprintf(`"rbtcBalance":%d`, successReturn.RbtcBalance))
-		assert.HTTPBodyContains(t, handler, verb, path, nil, fmt.Sprintf(`"btcLocked":%d`, successReturn.BtcLocked))
-		assert.HTTPBodyContains(t, handler, verb, path, nil, fmt.Sprintf(`"rbtcLocked":%d`, successReturn.RbtcLocked))
-		assert.HTTPBodyContains(t, handler, verb, path, nil, fmt.Sprintf(`"btcLiquidity":%d`, successReturn.BtcLiquidity))
-		assert.HTTPBodyContains(t, handler, verb, path, nil, fmt.Sprintf(`"rbtcLiquidity":%d`, successReturn.RbtcLiquidity))
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/reports/assets", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response pkg.GetAssetsReportResponse
+		err = json.NewDecoder(rr.Body).Decode(&response)
+		require.NoError(t, err)
+
+		assert.Equal(t, expectedResult.BtcAssetReport.Total.AsBigInt(), response.BtcAssetReport.Total)
+		assert.Equal(t, expectedResult.BtcAssetReport.Location.BtcWallet.AsBigInt(), response.BtcAssetReport.Location.BtcWallet)
+		assert.Equal(t, expectedResult.BtcAssetReport.Location.Federation.AsBigInt(), response.BtcAssetReport.Location.Federation)
+		assert.Equal(t, expectedResult.BtcAssetReport.Location.RskWallet.AsBigInt(), response.BtcAssetReport.Location.RskWallet)
+		assert.Equal(t, expectedResult.BtcAssetReport.Location.Lbc.AsBigInt(), response.BtcAssetReport.Location.Lbc)
+		assert.Equal(t, expectedResult.BtcAssetReport.Allocation.ReservedForUsers.AsBigInt(), response.BtcAssetReport.Allocation.ReservedForUsers)
+		assert.Equal(t, expectedResult.BtcAssetReport.Allocation.WaitingForRefund.AsBigInt(), response.BtcAssetReport.Allocation.WaitingForRefund)
+		assert.Equal(t, expectedResult.BtcAssetReport.Allocation.Available.AsBigInt(), response.BtcAssetReport.Allocation.Available)
+
+		assert.Equal(t, expectedResult.RbtcAssetReport.Total.AsBigInt(), response.RbtcAssetReport.Total)
+		assert.Equal(t, expectedResult.RbtcAssetReport.Location.RskWallet.AsBigInt(), response.RbtcAssetReport.Location.RskWallet)
+		assert.Equal(t, expectedResult.RbtcAssetReport.Location.Lbc.AsBigInt(), response.RbtcAssetReport.Location.Lbc)
+		assert.Equal(t, expectedResult.RbtcAssetReport.Location.Federation.AsBigInt(), response.RbtcAssetReport.Location.Federation)
+		assert.Equal(t, expectedResult.RbtcAssetReport.Allocation.ReservedForUsers.AsBigInt(), response.RbtcAssetReport.Allocation.ReservedForUsers)
+		assert.Equal(t, expectedResult.RbtcAssetReport.Allocation.WaitingForRefund.AsBigInt(), response.RbtcAssetReport.Allocation.WaitingForRefund)
+		assert.Equal(t, expectedResult.RbtcAssetReport.Allocation.Available.AsBigInt(), response.RbtcAssetReport.Allocation.Available)
+
 		useCase.AssertExpectations(t)
 	})
-	t.Run("Should return an error when use case fail", func(t *testing.T) {
+
+	t.Run("should handle zero balances correctly", func(t *testing.T) {
 		useCase := new(mocks.GetAssetsReportUseCaseMock)
-		useCase.EXPECT().Run(mock.Anything).Return(failReturn, assert.AnError)
+
+		expectedResult := reports.GetAssetsReportResult{
+			BtcAssetReport: reports.BtcAssetReport{
+				Total: entities.NewWei(0),
+				Location: reports.BtcAssetLocation{
+					BtcWallet:  entities.NewWei(0),
+					Federation: entities.NewWei(0),
+					RskWallet:  entities.NewWei(0),
+					Lbc:        entities.NewWei(0),
+				},
+				Allocation: reports.BtcAssetAllocation{
+					ReservedForUsers: entities.NewWei(0),
+					WaitingForRefund: entities.NewWei(0),
+					Available:        entities.NewWei(0),
+				},
+			},
+			RbtcAssetReport: reports.RbtcAssetReport{
+				Total: entities.NewWei(0),
+				Location: reports.RbtcAssetLocation{
+					RskWallet:  entities.NewWei(0),
+					Lbc:        entities.NewWei(0),
+					Federation: entities.NewWei(0),
+				},
+				Allocation: reports.RbtcAssetAllocation{
+					ReservedForUsers: entities.NewWei(0),
+					WaitingForRefund: entities.NewWei(0),
+					Available:        entities.NewWei(0),
+				},
+			},
+		}
+
+		useCase.EXPECT().Run(mock.Anything).Return(expectedResult, nil).Once()
+
 		handler := handlers.NewGetReportsAssetsHandler(useCase)
-		assert.HTTPError(t, handler, verb, path, nil)
-		assert.HTTPBodyContains(t, handler, verb, path, nil, `{"error":"assert.AnError general error for testing"}`)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/reports/assets", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response pkg.GetAssetsReportResponse
+		err = json.NewDecoder(rr.Body).Decode(&response)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(0), response.BtcAssetReport.Total.Int64())
+		assert.Equal(t, int64(0), response.RbtcAssetReport.Total.Int64())
+
+		useCase.AssertExpectations(t)
 	})
+
+	t.Run("should handle large balances correctly", func(t *testing.T) {
+		useCase := new(mocks.GetAssetsReportUseCaseMock)
+
+		expectedResult := reports.GetAssetsReportResult{
+			BtcAssetReport: reports.BtcAssetReport{
+				Total: entities.NewWei(2100000000000000), // 21 million BTC in satoshis
+				Location: reports.BtcAssetLocation{
+					BtcWallet:  entities.NewWei(1000000000000000),
+					Federation: entities.NewWei(500000000000000),
+					RskWallet:  entities.NewWei(300000000000000),
+					Lbc:        entities.NewWei(300000000000000),
+				},
+				Allocation: reports.BtcAssetAllocation{
+					ReservedForUsers: entities.NewWei(100000000000000),
+					WaitingForRefund: entities.NewWei(800000000000000),
+					Available:        entities.NewWei(1200000000000000),
+				},
+			},
+			RbtcAssetReport: reports.RbtcAssetReport{
+				Total: mustParseBigWei("21000000000000000000000000"), // 21 million RBTC in wei
+				Location: reports.RbtcAssetLocation{
+					RskWallet:  mustParseBigWei("10000000000000000000000000"),
+					Lbc:        mustParseBigWei("8000000000000000000000000"),
+					Federation: mustParseBigWei("3000000000000000000000000"),
+				},
+				Allocation: reports.RbtcAssetAllocation{
+					ReservedForUsers: mustParseBigWei("2000000000000000000000000"),
+					WaitingForRefund: mustParseBigWei("3000000000000000000000000"),
+					Available:        mustParseBigWei("16000000000000000000000000"),
+				},
+			},
+		}
+
+		useCase.EXPECT().Run(mock.Anything).Return(expectedResult, nil).Once()
+
+		handler := handlers.NewGetReportsAssetsHandler(useCase)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/reports/assets", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response pkg.GetAssetsReportResponse
+		err = json.NewDecoder(rr.Body).Decode(&response)
+		require.NoError(t, err)
+
+		assert.Equal(t, expectedResult.BtcAssetReport.Total.AsBigInt(), response.BtcAssetReport.Total)
+		assert.Equal(t, expectedResult.RbtcAssetReport.Total.AsBigInt(), response.RbtcAssetReport.Total)
+
+		useCase.AssertExpectations(t)
+	})
+}
+
+func TestNewGetReportsAssetsHandler_Error(t *testing.T) {
+	t.Run("should return 500 when use case returns an error", func(t *testing.T) {
+		useCase := new(mocks.GetAssetsReportUseCaseMock)
+
+		// Mock the use case to return an error
+		useCase.EXPECT().Run(mock.Anything).Return(reports.GetAssetsReportResult{}, assert.AnError).Once()
+
+		handler := handlers.NewGetReportsAssetsHandler(useCase)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/reports/assets", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		// Verify error status code
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+		// Verify error response contains error message
+		var errorResponse map[string]interface{}
+		err = json.NewDecoder(rr.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Contains(t, errorResponse, "message")
+		assert.Contains(t, errorResponse, "details")
+		assert.Equal(t, "unknown error", errorResponse["message"])
+
+		useCase.AssertExpectations(t)
+	})
+
+	t.Run("should return proper error structure", func(t *testing.T) {
+		useCase := new(mocks.GetAssetsReportUseCaseMock)
+
+		useCase.EXPECT().Run(mock.Anything).Return(reports.GetAssetsReportResult{}, assert.AnError).Once()
+
+		handler := handlers.NewGetReportsAssetsHandler(useCase)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/reports/assets", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+		useCase.AssertExpectations(t)
+	})
+}
+
+// mustParseBigWei creates a *entities.Wei from a string representation of a large number
+func mustParseBigWei(s string) *entities.Wei {
+	val := new(big.Int)
+	val, ok := val.SetString(s, 10)
+	if !ok {
+		panic("failed to parse big wei: " + s)
+	}
+	return entities.NewBigWei(val)
 }

--- a/internal/configuration/registry/usecase.go
+++ b/internal/configuration/registry/usecase.go
@@ -278,6 +278,7 @@ func NewUseCaseRegistry(
 			liquidityProvider,
 			databaseRegistry.PeginRepository,
 			databaseRegistry.PegoutRepository,
+			rskRegistry.Contracts,
 		),
 		getTransactionsReportUseCase: reports.NewGetTransactionsUseCase(
 			databaseRegistry.PeginRepository,

--- a/internal/usecases/reports/get_assets_report_test.go
+++ b/internal/usecases/reports/get_assets_report_test.go
@@ -2,6 +2,8 @@ package reports_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
@@ -9,354 +11,1120 @@ import (
 	"github.com/rsksmart/liquidity-provider-server/test/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"math/big"
-	"testing"
 )
 
-var retainedPeginQuotes = []quote.RetainedPeginQuote{
-	{
-		QuoteHash:         "mockPeginQuoteHash1",
-		RequiredLiquidity: entities.NewWei(1500),
-		State:             quote.PeginStateWaitingForDeposit,
-	},
-	{
-		QuoteHash:         "mockPeginQuoteHash2",
-		RequiredLiquidity: entities.NewWei(2500),
-		State:             quote.PeginStateCallForUserSucceeded,
-	},
-	{
-		QuoteHash:         "mockPeginQuoteHash3",
-		RequiredLiquidity: entities.NewWei(3500),
-		State:             quote.PeginStateWaitingForDeposit,
-	},
-	{
-		QuoteHash:         "mockPeginQuoteHash4",
-		RequiredLiquidity: entities.NewWei(4500),
-		State:             quote.PeginStateCallForUserSucceeded,
-	},
-	{
-		QuoteHash:         "mockPeginQuoteHash5",
-		RequiredLiquidity: entities.NewWei(5500),
-		State:             quote.PeginStateWaitingForDeposit,
-	},
+type ExpectedBtcCalculations struct {
+	WalletBalance         *entities.Wei
+	Rebalancing           *entities.Wei // Federation
+	WaitingForRebalancing *entities.Wei // RSK Wallet
+	InLbc                 *entities.Wei
+	ReservedForUsers      *entities.Wei
+	WaitingForRefund      *entities.Wei
+	Total                 *entities.Wei
+	Available             *entities.Wei
 }
 
-var retainedPegoutQuotes = []quote.RetainedPegoutQuote{
-	{
-		QuoteHash:         "mockQuoteHash1",
-		RequiredLiquidity: entities.NewWei(1000),
-		State:             quote.PegoutStateWaitingForDeposit,
-	},
-	{
-		QuoteHash:         "mockQuoteHash2",
-		RequiredLiquidity: entities.NewWei(2000),
-		State:             quote.PegoutStateWaitingForDepositConfirmations,
-	},
-	{
-		QuoteHash:         "mockQuoteHash3",
-		RequiredLiquidity: entities.NewWei(3000),
-		State:             quote.PegoutStateWaitingForDeposit,
-	},
-	{
-		QuoteHash:         "mockQuoteHash4",
-		RequiredLiquidity: entities.NewWei(4000),
-		State:             quote.PegoutStateWaitingForDepositConfirmations,
-	},
-	{
-		QuoteHash:         "mockQuoteHash5",
-		RequiredLiquidity: entities.NewWei(5000),
-		State:             quote.PegoutStateWaitingForDeposit,
-	},
+type ExpectedRbtcCalculations struct {
+	RskWalletBalance *entities.Wei // Raw RSK wallet balance
+	InRskWallet      *entities.Wei // Adjusted RSK wallet (subtracting BTC waiting for rebalancing)
+	LockedInLbc      *entities.Wei
+	WaitingForRefund *entities.Wei // Federation
+	ReservedForUsers *entities.Wei
+	Total            *entities.Wei
+	Available        *entities.Wei
 }
 
+// nolint:exhaustive
+func calculateExpectedBtcValues(quotes []quote.RetainedPegoutQuote, btcWalletBalance *entities.Wei) ExpectedBtcCalculations {
+	expectedBtcRebalancing := entities.NewWei(0)           // BridgeTxSucceeded
+	expectedBtcWaitingForRebalancing := entities.NewWei(0) // RefundPegOutSucceeded
+	expectedBtcInLbc := entities.NewWei(0)                 // SendPegoutSucceeded
+	expectedBtcReservedForUsers := entities.NewWei(0)      // WaitingForDeposit + WaitingForDepositConfirmations
+	expectedBtcWaitingForRefund := entities.NewWei(0)      // RefundPegOutSucceeded + SendPegoutSucceeded + BridgeTxSucceeded
+
+	// Calculate sums based on quote states
+	for _, q := range quotes {
+		switch q.State {
+		case quote.PegoutStateBridgeTxSucceeded:
+			expectedBtcRebalancing.Add(expectedBtcRebalancing, q.RequiredLiquidity)
+			expectedBtcWaitingForRefund.Add(expectedBtcWaitingForRefund, q.RequiredLiquidity)
+		case quote.PegoutStateRefundPegOutSucceeded:
+			expectedBtcWaitingForRebalancing.Add(expectedBtcWaitingForRebalancing, q.RequiredLiquidity)
+			expectedBtcWaitingForRefund.Add(expectedBtcWaitingForRefund, q.RequiredLiquidity)
+		case quote.PegoutStateSendPegoutSucceeded:
+			expectedBtcInLbc.Add(expectedBtcInLbc, q.RequiredLiquidity)
+			expectedBtcWaitingForRefund.Add(expectedBtcWaitingForRefund, q.RequiredLiquidity)
+		case quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations:
+			expectedBtcReservedForUsers.Add(expectedBtcReservedForUsers, q.RequiredLiquidity)
+		}
+	}
+
+	expectedBtcTotal := entities.NewWei(0)
+	expectedBtcTotal.Add(expectedBtcTotal, btcWalletBalance)
+	expectedBtcTotal.Add(expectedBtcTotal, expectedBtcRebalancing)
+	expectedBtcTotal.Add(expectedBtcTotal, expectedBtcWaitingForRebalancing)
+	expectedBtcTotal.Add(expectedBtcTotal, expectedBtcInLbc)
+
+	expectedBtcAvailable := entities.NewWei(0).Sub(btcWalletBalance, expectedBtcReservedForUsers)
+
+	return ExpectedBtcCalculations{
+		WalletBalance:         btcWalletBalance,
+		Rebalancing:           expectedBtcRebalancing,
+		WaitingForRebalancing: expectedBtcWaitingForRebalancing,
+		InLbc:                 expectedBtcInLbc,
+		ReservedForUsers:      expectedBtcReservedForUsers,
+		WaitingForRefund:      expectedBtcWaitingForRefund,
+		Total:                 expectedBtcTotal,
+		Available:             expectedBtcAvailable,
+	}
+}
+
+// nolint:exhaustive
+func calculateExpectedRbtcValues(
+	peginQuotes []quote.RetainedPeginQuote,
+	rbtcWalletBalance *entities.Wei,
+	rbtcLockedInLbc *entities.Wei,
+	btcWaitingForRebalancing *entities.Wei,
+) ExpectedRbtcCalculations {
+	expectedRbtcWaitingForRefund := entities.NewWei(0) // CallForUserSucceeded
+	expectedRbtcReservedForUsers := entities.NewWei(0) // WaitingForDeposit + WaitingForDepositConfirmations
+
+	// Calculate sums based on pegin quote states
+	for _, q := range peginQuotes {
+		switch q.State {
+		case quote.PeginStateCallForUserSucceeded:
+			expectedRbtcWaitingForRefund.Add(expectedRbtcWaitingForRefund, q.RequiredLiquidity)
+		case quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations:
+			expectedRbtcReservedForUsers.Add(expectedRbtcReservedForUsers, q.RequiredLiquidity)
+		}
+	}
+
+	// A part of the RBTC in the RSK wallet is a representation of BTC waiting to be sent to the bridge for rebalancing
+	expectedRbtcInRskWallet := entities.NewWei(0).Sub(rbtcWalletBalance, btcWaitingForRebalancing)
+
+	expectedRbtcTotal := entities.NewWei(0)
+	expectedRbtcTotal.Add(expectedRbtcTotal, expectedRbtcInRskWallet)
+	expectedRbtcTotal.Add(expectedRbtcTotal, rbtcLockedInLbc)
+	expectedRbtcTotal.Add(expectedRbtcTotal, expectedRbtcWaitingForRefund)
+
+	expectedRbtcAvailable := entities.NewWei(0).Add(
+		entities.NewWei(0).Sub(expectedRbtcInRskWallet, expectedRbtcReservedForUsers),
+		rbtcLockedInLbc,
+	)
+
+	return ExpectedRbtcCalculations{
+		RskWalletBalance: rbtcWalletBalance,
+		InRskWallet:      expectedRbtcInRskWallet,
+		LockedInLbc:      rbtcLockedInLbc,
+		WaitingForRefund: expectedRbtcWaitingForRefund,
+		ReservedForUsers: expectedRbtcReservedForUsers,
+		Total:            expectedRbtcTotal,
+		Available:        expectedRbtcAvailable,
+	}
+}
+
+// Tests the BTC Asset Report generation with multiple pegout quote states to verify proper calculation of:
+// - BTC Location: BtcWallet, Federation (rebalancing), RskWallet (waiting for rebalancing), Lbc
+// - BTC Allocation: ReservedForUsers, WaitingForRefund, Available
+// - Mathematical integrity of the BtcAssetReport
+// nolint:exhaustive,funlen,maintidx
+func TestGetAssetsReportUseCase_Run_BtcAssetReport_Success(t *testing.T) {
+	testCases := []struct {
+		name             string
+		btcWalletBalance *entities.Wei
+		pegoutQuotes     []quote.RetainedPegoutQuote
+		description      string
+	}{
+		{
+			name:             "Multiple quotes in various states",
+			btcWalletBalance: entities.NewWei(50000000), // 0.5 BTC
+			pegoutQuotes: []quote.RetainedPegoutQuote{
+				// WaitingForDeposit quotes - should be counted in ReservedForUsers
+				{QuoteHash: "waiting_deposit_1", RequiredLiquidity: entities.NewWei(1000000), State: quote.PegoutStateWaitingForDeposit},
+				{QuoteHash: "waiting_deposit_2", RequiredLiquidity: entities.NewWei(2000000), State: quote.PegoutStateWaitingForDeposit},
+				// WaitingForDepositConfirmations quotes - should be counted in ReservedForUsers
+				{QuoteHash: "waiting_confirmations_1", RequiredLiquidity: entities.NewWei(1500000), State: quote.PegoutStateWaitingForDepositConfirmations},
+				// BridgeTxSucceeded quotes - should be counted in Federation (rebalancing)
+				{QuoteHash: "bridge_succeeded_1", RequiredLiquidity: entities.NewWei(5000000), State: quote.PegoutStateBridgeTxSucceeded},
+				{QuoteHash: "bridge_succeeded_2", RequiredLiquidity: entities.NewWei(3000000), State: quote.PegoutStateBridgeTxSucceeded},
+				// RefundPegOutSucceeded quotes - should be counted in RskWallet (waiting for rebalancing)
+				{QuoteHash: "refund_succeeded_1", RequiredLiquidity: entities.NewWei(4000000), State: quote.PegoutStateRefundPegOutSucceeded},
+				{QuoteHash: "refund_succeeded_2", RequiredLiquidity: entities.NewWei(2500000), State: quote.PegoutStateRefundPegOutSucceeded},
+				// SendPegoutSucceeded quotes - should be counted in LBC (LP sent BTC, waiting for RBTC)
+				{QuoteHash: "send_succeeded_1", RequiredLiquidity: entities.NewWei(3500000), State: quote.PegoutStateSendPegoutSucceeded},
+				{QuoteHash: "send_succeeded_2", RequiredLiquidity: entities.NewWei(1800000), State: quote.PegoutStateSendPegoutSucceeded},
+				// Other states that should not affect calculations
+				{QuoteHash: "time_elapsed_1", RequiredLiquidity: entities.NewWei(1000000), State: quote.PegoutStateTimeForDepositElapsed},
+				{QuoteHash: "send_failed_1", RequiredLiquidity: entities.NewWei(2000000), State: quote.PegoutStateSendPegoutFailed},
+			},
+			description: "Tests with quotes in all relevant states including waiting, rebalancing, and completed states",
+		},
+		{
+			name:             "Only waiting for deposit quotes",
+			btcWalletBalance: entities.NewWei(100000000), // 1.0 BTC
+			pegoutQuotes: []quote.RetainedPegoutQuote{
+				{
+					QuoteHash:         "waiting_1",
+					RequiredLiquidity: entities.NewWei(5000000),
+					State:             quote.PegoutStateWaitingForDeposit,
+				},
+				{
+					QuoteHash:         "waiting_2",
+					RequiredLiquidity: entities.NewWei(3000000),
+					State:             quote.PegoutStateWaitingForDeposit,
+				},
+				{
+					QuoteHash:         "waiting_confirmations_1",
+					RequiredLiquidity: entities.NewWei(2000000),
+					State:             quote.PegoutStateWaitingForDepositConfirmations,
+				},
+			},
+			description: "All BTC should be in wallet with reserved amount, large available balance",
+		},
+		{
+			name:             "Only rebalancing quotes",
+			btcWalletBalance: entities.NewWei(30000000), // 0.3 BTC
+			pegoutQuotes: []quote.RetainedPegoutQuote{
+				{
+					QuoteHash:         "bridge_1",
+					RequiredLiquidity: entities.NewWei(10000000),
+					State:             quote.PegoutStateBridgeTxSucceeded,
+				},
+				{
+					QuoteHash:         "bridge_2",
+					RequiredLiquidity: entities.NewWei(15000000),
+					State:             quote.PegoutStateBridgeTxSucceeded,
+				},
+			},
+			description: "BTC distributed between wallet and federation (rebalancing)",
+		},
+		{
+			name:             "Mix of refund and send states",
+			btcWalletBalance: entities.NewWei(20000000), // 0.2 BTC
+			pegoutQuotes: []quote.RetainedPegoutQuote{
+				{
+					QuoteHash:         "refund_1",
+					RequiredLiquidity: entities.NewWei(8000000),
+					State:             quote.PegoutStateRefundPegOutSucceeded,
+				},
+				{
+					QuoteHash:         "send_1",
+					RequiredLiquidity: entities.NewWei(5000000),
+					State:             quote.PegoutStateSendPegoutSucceeded,
+				},
+				{
+					QuoteHash:         "send_2",
+					RequiredLiquidity: entities.NewWei(7000000),
+					State:             quote.PegoutStateSendPegoutSucceeded,
+				},
+			},
+			description: "BTC in wallet, RSK wallet (waiting for rebalancing), and LBC",
+		},
+		{
+			name:             "Empty quotes - only wallet balance",
+			btcWalletBalance: entities.NewWei(75000000), // 0.75 BTC
+			pegoutQuotes:     []quote.RetainedPegoutQuote{},
+			description:      "All BTC in wallet, no quotes, everything available",
+		},
+		{
+			name:             "All states combined - complex scenario",
+			btcWalletBalance: entities.NewWei(200000000), // 2.0 BTC
+			pegoutQuotes: []quote.RetainedPegoutQuote{
+				{QuoteHash: "waiting_1", RequiredLiquidity: entities.NewWei(10000000), State: quote.PegoutStateWaitingForDeposit},
+				{QuoteHash: "waiting_2", RequiredLiquidity: entities.NewWei(5000000), State: quote.PegoutStateWaitingForDepositConfirmations},
+				{QuoteHash: "bridge_1", RequiredLiquidity: entities.NewWei(25000000), State: quote.PegoutStateBridgeTxSucceeded},
+				{QuoteHash: "bridge_2", RequiredLiquidity: entities.NewWei(30000000), State: quote.PegoutStateBridgeTxSucceeded},
+				{QuoteHash: "refund_1", RequiredLiquidity: entities.NewWei(20000000), State: quote.PegoutStateRefundPegOutSucceeded},
+				{QuoteHash: "refund_2", RequiredLiquidity: entities.NewWei(15000000), State: quote.PegoutStateRefundPegOutSucceeded},
+				{QuoteHash: "send_1", RequiredLiquidity: entities.NewWei(18000000), State: quote.PegoutStateSendPegoutSucceeded},
+				{QuoteHash: "send_2", RequiredLiquidity: entities.NewWei(12000000), State: quote.PegoutStateSendPegoutSucceeded},
+			},
+			description: "Large wallet with quotes in all states - comprehensive test",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			expected := calculateExpectedBtcValues(tc.pegoutQuotes, tc.btcWalletBalance)
+
+			btcWallet := &mocks.BitcoinWalletMock{}
+			rskRpc := &mocks.RootstockRpcServerMock{}
+			lp := &mocks.ProviderMock{}
+			peginProvider := &mocks.ProviderMock{}
+			pegoutProvider := &mocks.ProviderMock{}
+			peginRepository := &mocks.PeginQuoteRepositoryMock{}
+			pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+			lbcContract := &mocks.LiquidityBridgeContractMock{}
+
+			contracts := blockchain.RskContracts{
+				Lbc: lbcContract,
+			}
+
+			btcWallet.On("GetBalance").Return(tc.btcWalletBalance, nil).Once()
+
+			// Separate quotes by state for repository expectations
+			bridgeQuotes := []quote.RetainedPegoutQuote{}
+			refundQuotes := []quote.RetainedPegoutQuote{}
+			sendQuotes := []quote.RetainedPegoutQuote{}
+			waitingQuotes := []quote.RetainedPegoutQuote{}
+			combinedWaitingForRefundQuotes := []quote.RetainedPegoutQuote{}
+
+			for _, q := range tc.pegoutQuotes {
+				switch q.State {
+				case quote.PegoutStateBridgeTxSucceeded:
+					bridgeQuotes = append(bridgeQuotes, q)
+					combinedWaitingForRefundQuotes = append(combinedWaitingForRefundQuotes, q)
+				case quote.PegoutStateRefundPegOutSucceeded:
+					refundQuotes = append(refundQuotes, q)
+					combinedWaitingForRefundQuotes = append(combinedWaitingForRefundQuotes, q)
+				case quote.PegoutStateSendPegoutSucceeded:
+					sendQuotes = append(sendQuotes, q)
+					combinedWaitingForRefundQuotes = append(combinedWaitingForRefundQuotes, q)
+				case quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations:
+					waitingQuotes = append(waitingQuotes, q)
+				}
+			}
+
+			// BridgeTxSucceeded state (rebalancing)
+			pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+				Return(bridgeQuotes, nil).Once()
+
+			// RefundPegOutSucceeded state (waiting for rebalancing)
+			pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+				Return(refundQuotes, nil).Once()
+
+			// SendPegoutSucceeded state (in LBC)
+			pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+				Return(sendQuotes, nil).Once()
+
+			// WaitingForDeposit and WaitingForDepositConfirmations states (reserved for users)
+			pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).
+				Return(waitingQuotes, nil).Once()
+
+			// Combined states for waiting for refund calculation
+			pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded, quote.PegoutStateSendPegoutSucceeded, quote.PegoutStateBridgeTxSucceeded).
+				Return(combinedWaitingForRefundQuotes, nil).Once()
+
+			// Setup mock expectations for RBTC-related calls (minimal setup to make them pass)
+			rskRpc.On("GetBalance", ctx, "test-rsk-address").Return(entities.NewWei(0), nil).Once()
+			lp.On("RskAddress").Return("test-rsk-address").Twice() // Called twice: once for RSK balance, once for LBC balance
+			lbcContract.On("GetBalance", "test-rsk-address").Return(entities.NewWei(0), nil).Once()
+			peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateCallForUserSucceeded).
+				Return([]quote.RetainedPeginQuote{}, nil).Once()
+			peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations).
+				Return([]quote.RetainedPeginQuote{}, nil).Once()
+
+			useCase := reports.NewGetAssetsReportUseCase(
+				btcWallet,
+				blockchain.Rpc{Rsk: rskRpc},
+				lp,
+				peginProvider,
+				pegoutProvider,
+				peginRepository,
+				pegoutRepository,
+				contracts,
+			)
+
+			result, err := useCase.Run(ctx)
+
+			require.NoError(t, err)
+
+			assert.Equal(t, expected.Total.String(), result.BtcAssetReport.Total.String(), "BTC total should match expected")
+			assert.Equal(t, expected.WalletBalance.String(), result.BtcAssetReport.Location.BtcWallet.String(), "BTC wallet balance should match")
+			assert.Equal(t, expected.Rebalancing.String(), result.BtcAssetReport.Location.Federation.String(), "BTC federation balance should match")
+			assert.Equal(t, expected.WaitingForRebalancing.String(), result.BtcAssetReport.Location.RskWallet.String(), "BTC RSK wallet balance should match")
+			assert.Equal(t, expected.InLbc.String(), result.BtcAssetReport.Location.Lbc.String(), "BTC LBC balance should match")
+			assert.Equal(t, expected.ReservedForUsers.String(), result.BtcAssetReport.Allocation.ReservedForUsers.String(), "BTC reserved for users should match")
+			assert.Equal(t, expected.WaitingForRefund.String(), result.BtcAssetReport.Allocation.WaitingForRefund.String(), "BTC waiting for refund should match")
+			assert.Equal(t, expected.Available.String(), result.BtcAssetReport.Allocation.Available.String(), "BTC available should match")
+
+			locationSum := entities.NewWei(0)
+			locationSum.Add(locationSum, result.BtcAssetReport.Location.BtcWallet)
+			locationSum.Add(locationSum, result.BtcAssetReport.Location.Federation)
+			locationSum.Add(locationSum, result.BtcAssetReport.Location.RskWallet)
+			locationSum.Add(locationSum, result.BtcAssetReport.Location.Lbc)
+			assert.Equal(t, result.BtcAssetReport.Total.String(), locationSum.String(), "Location sum should equal Total")
+
+			allocationSum := entities.NewWei(0)
+			allocationSum.Add(allocationSum, result.BtcAssetReport.Allocation.ReservedForUsers)
+			allocationSum.Add(allocationSum, result.BtcAssetReport.Allocation.WaitingForRefund)
+			allocationSum.Add(allocationSum, result.BtcAssetReport.Allocation.Available)
+			assert.Equal(t, result.BtcAssetReport.Total.String(), allocationSum.String(), "Allocation sum should equal Total")
+
+			btcWallet.AssertExpectations(t)
+			rskRpc.AssertExpectations(t)
+			lp.AssertExpectations(t)
+			peginRepository.AssertExpectations(t)
+			pegoutRepository.AssertExpectations(t)
+			lbcContract.AssertExpectations(t)
+		})
+	}
+}
+
+// Tests the RBTC Asset Report generation with multiple pegin quote states to verify proper calculation of:
+// - RBTC Location: RskWallet, Lbc, Federation (waiting for refund)
+// - RBTC Allocation: ReservedForUsers, WaitingForRefund, Available
+// - Mathematical integrity of the RbtcAssetReport
+// nolint:funlen,exhaustive
+func TestGetAssetsReportUseCase_Run_RbtcAssetReport_Success(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		rbtcWalletBalance        *entities.Wei
+		rbtcLockedInLbc          *entities.Wei
+		peginQuotes              []quote.RetainedPeginQuote
+		btcWaitingForRebalancing *entities.Wei // BTC value needed for RBTC calculation
+		description              string
+	}{
+		{
+			name:                     "Multiple pegin quotes in various states",
+			rbtcWalletBalance:        entities.NewWei(50000000), // 0.5 RBTC in RSK wallet
+			rbtcLockedInLbc:          entities.NewWei(30000000), // 0.3 RBTC in LBC
+			btcWaitingForRebalancing: entities.NewWei(10000000), // 0.1 BTC waiting for rebalancing
+			peginQuotes: []quote.RetainedPeginQuote{
+				// CallForUserSucceeded quotes - should be counted in WaitingForRefund (Federation)
+				{QuoteHash: "call_succeeded_1", RequiredLiquidity: entities.NewWei(5000000), State: quote.PeginStateCallForUserSucceeded},
+				{QuoteHash: "call_succeeded_2", RequiredLiquidity: entities.NewWei(3000000), State: quote.PeginStateCallForUserSucceeded},
+				// WaitingForDeposit quotes - should be counted in ReservedForUsers
+				{QuoteHash: "pegin_waiting_1", RequiredLiquidity: entities.NewWei(7000000), State: quote.PeginStateWaitingForDeposit},
+				// WaitingForDepositConfirmations quotes - should be counted in ReservedForUsers
+				{QuoteHash: "pegin_waiting_conf_1", RequiredLiquidity: entities.NewWei(4000000), State: quote.PeginStateWaitingForDepositConfirmations},
+				// Other states that should not affect calculations
+				{QuoteHash: "time_elapsed_1", RequiredLiquidity: entities.NewWei(2000000), State: quote.PeginStateTimeForDepositElapsed},
+				{QuoteHash: "register_failed_1", RequiredLiquidity: entities.NewWei(1000000), State: quote.PeginStateRegisterPegInFailed},
+			},
+			description: "Tests with pegin quotes in all relevant states including waiting and completed states",
+		},
+		{
+			name:                     "Only waiting for deposit quotes",
+			rbtcWalletBalance:        entities.NewWei(100000000), // 1.0 RBTC
+			rbtcLockedInLbc:          entities.NewWei(50000000),  // 0.5 RBTC
+			btcWaitingForRebalancing: entities.NewWei(0),         // No BTC waiting
+			peginQuotes: []quote.RetainedPeginQuote{
+				{QuoteHash: "waiting_1", RequiredLiquidity: entities.NewWei(15000000), State: quote.PeginStateWaitingForDeposit},
+				{QuoteHash: "waiting_2", RequiredLiquidity: entities.NewWei(10000000), State: quote.PeginStateWaitingForDeposit},
+				{QuoteHash: "waiting_conf_1", RequiredLiquidity: entities.NewWei(5000000), State: quote.PeginStateWaitingForDepositConfirmations},
+			},
+			description: "All RBTC in wallet and LBC with reserved amount, large available balance",
+		},
+		{
+			name:                     "Only CallForUserSucceeded quotes",
+			rbtcWalletBalance:        entities.NewWei(80000000), // 0.8 RBTC
+			rbtcLockedInLbc:          entities.NewWei(40000000), // 0.4 RBTC
+			btcWaitingForRebalancing: entities.NewWei(5000000),  // 0.05 BTC waiting
+			peginQuotes: []quote.RetainedPeginQuote{
+				{QuoteHash: "call_1", RequiredLiquidity: entities.NewWei(12000000), State: quote.PeginStateCallForUserSucceeded},
+				{QuoteHash: "call_2", RequiredLiquidity: entities.NewWei(8000000), State: quote.PeginStateCallForUserSucceeded},
+			},
+			description: "RBTC waiting for refund in federation",
+		},
+		{
+			name:                     "Empty quotes - only wallet and LBC balance",
+			rbtcWalletBalance:        entities.NewWei(120000000), // 1.2 RBTC
+			rbtcLockedInLbc:          entities.NewWei(80000000),  // 0.8 RBTC
+			btcWaitingForRebalancing: entities.NewWei(20000000),  // 0.2 BTC waiting
+			peginQuotes:              []quote.RetainedPeginQuote{},
+			description:              "All RBTC available, no quotes",
+		},
+		{
+			name:                     "Large BTC waiting for rebalancing affects RSK wallet",
+			rbtcWalletBalance:        entities.NewWei(150000000), // 1.5 RBTC raw balance
+			rbtcLockedInLbc:          entities.NewWei(60000000),  // 0.6 RBTC
+			btcWaitingForRebalancing: entities.NewWei(50000000),  // 0.5 BTC waiting (reduces effective RSK wallet)
+			peginQuotes: []quote.RetainedPeginQuote{
+				{QuoteHash: "waiting_1", RequiredLiquidity: entities.NewWei(20000000), State: quote.PeginStateWaitingForDeposit},
+				{QuoteHash: "call_1", RequiredLiquidity: entities.NewWei(15000000), State: quote.PeginStateCallForUserSucceeded},
+			},
+			description: "BTC waiting for rebalancing reduces effective RBTC in RSK wallet",
+		},
+		{
+			name:                     "All states combined - complex scenario",
+			rbtcWalletBalance:        entities.NewWei(200000000), // 2.0 RBTC
+			rbtcLockedInLbc:          entities.NewWei(100000000), // 1.0 RBTC
+			btcWaitingForRebalancing: entities.NewWei(30000000),  // 0.3 BTC waiting
+			peginQuotes: []quote.RetainedPeginQuote{
+				{QuoteHash: "waiting_1", RequiredLiquidity: entities.NewWei(25000000), State: quote.PeginStateWaitingForDeposit},
+				{QuoteHash: "waiting_2", RequiredLiquidity: entities.NewWei(15000000), State: quote.PeginStateWaitingForDepositConfirmations},
+				{QuoteHash: "call_1", RequiredLiquidity: entities.NewWei(35000000), State: quote.PeginStateCallForUserSucceeded},
+				{QuoteHash: "call_2", RequiredLiquidity: entities.NewWei(20000000), State: quote.PeginStateCallForUserSucceeded},
+				{QuoteHash: "call_3", RequiredLiquidity: entities.NewWei(10000000), State: quote.PeginStateCallForUserSucceeded},
+			},
+			description: "Large wallet with pegin quotes in all states - comprehensive test",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			expectedRbtc := calculateExpectedRbtcValues(tc.peginQuotes, tc.rbtcWalletBalance, tc.rbtcLockedInLbc, tc.btcWaitingForRebalancing)
+
+			btcWallet := &mocks.BitcoinWalletMock{}
+			rskRpc := &mocks.RootstockRpcServerMock{}
+			lp := &mocks.ProviderMock{}
+			peginProvider := &mocks.ProviderMock{}
+			pegoutProvider := &mocks.ProviderMock{}
+			peginRepository := &mocks.PeginQuoteRepositoryMock{}
+			pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+			lbcContract := &mocks.LiquidityBridgeContractMock{}
+			contracts := blockchain.RskContracts{
+				Lbc: lbcContract,
+			}
+
+			// Setup mock expectations for BTC-related calls (minimal setup to make them pass)
+			// Note: We need to mock pegout quotes to calculate btcWaitingForRebalancing
+			btcWallet.On("GetBalance").Return(entities.NewWei(100000000), nil).Once()
+
+			// Create pegout quotes that will result in the desired btcWaitingForRebalancing
+			pegoutQuotesForRebalancing := []quote.RetainedPegoutQuote{}
+			if tc.btcWaitingForRebalancing.Cmp(entities.NewWei(0)) > 0 {
+				pegoutQuotesForRebalancing = append(pegoutQuotesForRebalancing, quote.RetainedPegoutQuote{
+					QuoteHash:         "refund_for_test",
+					RequiredLiquidity: tc.btcWaitingForRebalancing,
+					State:             quote.PegoutStateRefundPegOutSucceeded,
+				})
+			}
+
+			pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+				Return([]quote.RetainedPegoutQuote{}, nil).Once()
+			pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+				Return(pegoutQuotesForRebalancing, nil).Once()
+			pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+				Return([]quote.RetainedPegoutQuote{}, nil).Once()
+			pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).
+				Return([]quote.RetainedPegoutQuote{}, nil).Once()
+			pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded, quote.PegoutStateSendPegoutSucceeded, quote.PegoutStateBridgeTxSucceeded).
+				Return(pegoutQuotesForRebalancing, nil).Once()
+
+			// Setup mock expectations for RBTC-related calls
+			rskRpc.On("GetBalance", ctx, "test-rsk-address").Return(tc.rbtcWalletBalance, nil).Once()
+			lp.On("RskAddress").Return("test-rsk-address").Twice() // Called twice: once for RSK balance, once for LBC balance
+			lbcContract.On("GetBalance", "test-rsk-address").Return(tc.rbtcLockedInLbc, nil).Once()
+
+			// Setup mock expectations for pegin quotes by different states
+			callSucceededQuotes := []quote.RetainedPeginQuote{}
+			waitingQuotes := []quote.RetainedPeginQuote{}
+
+			for _, q := range tc.peginQuotes {
+				switch q.State {
+				case quote.PeginStateCallForUserSucceeded:
+					callSucceededQuotes = append(callSucceededQuotes, q)
+				case quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations:
+					waitingQuotes = append(waitingQuotes, q)
+				}
+			}
+
+			peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateCallForUserSucceeded).
+				Return(callSucceededQuotes, nil).Once()
+			peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations).
+				Return(waitingQuotes, nil).Once()
+
+			useCase := reports.NewGetAssetsReportUseCase(
+				btcWallet,
+				blockchain.Rpc{Rsk: rskRpc},
+				lp,
+				peginProvider,
+				pegoutProvider,
+				peginRepository,
+				pegoutRepository,
+				contracts,
+			)
+
+			result, err := useCase.Run(ctx)
+
+			require.NoError(t, err)
+
+			assert.Equal(t, expectedRbtc.Total.String(), result.RbtcAssetReport.Total.String(), "RBTC total should match expected")
+			assert.Equal(t, expectedRbtc.InRskWallet.String(), result.RbtcAssetReport.Location.RskWallet.String(), "RBTC RSK wallet balance should match")
+			assert.Equal(t, expectedRbtc.LockedInLbc.String(), result.RbtcAssetReport.Location.Lbc.String(), "RBTC LBC balance should match")
+			assert.Equal(t, expectedRbtc.WaitingForRefund.String(), result.RbtcAssetReport.Location.Federation.String(), "RBTC federation balance should match")
+			assert.Equal(t, expectedRbtc.ReservedForUsers.String(), result.RbtcAssetReport.Allocation.ReservedForUsers.String(), "RBTC reserved for users should match")
+			assert.Equal(t, expectedRbtc.WaitingForRefund.String(), result.RbtcAssetReport.Allocation.WaitingForRefund.String(), "RBTC waiting for refund should match")
+			assert.Equal(t, expectedRbtc.Available.String(), result.RbtcAssetReport.Allocation.Available.String(), "RBTC available should match")
+
+			locationSum := entities.NewWei(0)
+			locationSum.Add(locationSum, result.RbtcAssetReport.Location.RskWallet)
+			locationSum.Add(locationSum, result.RbtcAssetReport.Location.Lbc)
+			locationSum.Add(locationSum, result.RbtcAssetReport.Location.Federation)
+			assert.Equal(t, result.RbtcAssetReport.Total.String(), locationSum.String(), "RBTC Location sum should equal Total")
+
+			allocationSum := entities.NewWei(0)
+			allocationSum.Add(allocationSum, result.RbtcAssetReport.Allocation.ReservedForUsers)
+			allocationSum.Add(allocationSum, result.RbtcAssetReport.Allocation.WaitingForRefund)
+			allocationSum.Add(allocationSum, result.RbtcAssetReport.Allocation.Available)
+			assert.Equal(t, result.RbtcAssetReport.Total.String(), allocationSum.String(), "RBTC Allocation sum should equal Total")
+
+			btcWallet.AssertExpectations(t)
+			rskRpc.AssertExpectations(t)
+			lp.AssertExpectations(t)
+			peginRepository.AssertExpectations(t)
+			pegoutRepository.AssertExpectations(t)
+			lbcContract.AssertExpectations(t)
+		})
+	}
+}
+
+// Tests that total assets remain constant as quotes progress through their lifecycle states.
+// This verifies that the report correctly tracks assets regardless of quote state changes.
 // nolint:funlen
-func TestGetAssetsReportUseCase_Run(t *testing.T) {
+func TestGetAssetsReportUseCase_Run_AssetConservation_ThroughQuoteLifecycle(t *testing.T) {
 	ctx := context.Background()
 
-	rskAddress := "rskAddress"
+	initialBtcWalletBalance := entities.NewWei(100000000)  // 1.0 BTC
+	initialRbtcWalletBalance := entities.NewWei(200000000) // 2.0 RBTC
+	initialRbtcLbcBalance := entities.NewWei(50000000)     // 0.5 RBTC
 
-	wallet := mocks.NewBitcoinWalletMock(t)
-	wallet.On("GetBalance").Return(entities.NewWei(100000), nil)
+	// Calculate initial total assets (without fees for simplicity)
+	expectedTotalBtc := entities.NewWei(0).Add(entities.NewWei(0), initialBtcWalletBalance)
+	expectedTotalRbtc := entities.NewWei(0).Add(entities.NewWei(0), initialRbtcWalletBalance)
+	expectedTotalRbtc.Add(expectedTotalRbtc, initialRbtcLbcBalance)
 
-	lpMock := &mocks.ProviderMock{}
-	lpMock.On("RskAddress").Return(rskAddress)
+	pegoutQuote1Amount := entities.NewWei(10000000) // 0.1 BTC
+	pegoutQuote2Amount := entities.NewWei(15000000) // 0.15 BTC
+	peginQuote1Amount := entities.NewWei(20000000)  // 0.2 RBTC
+	peginQuote2Amount := entities.NewWei(25000000)  // 0.25 RBTC
 
-	rsk := new(mocks.RootstockRpcServerMock)
-	rpc := blockchain.Rpc{Rsk: rsk}
+	// Scenario 1: Initial state - quotes just accepted (waiting for deposit)
+	t.Run("Scenario_1_Quotes_Waiting_For_Deposit", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
 
-	rsk.On("GetBalance", ctx, rskAddress).Return(entities.NewWei(100000), nil)
+		pegoutQuotes := []quote.RetainedPegoutQuote{
+			{QuoteHash: "pegout_1", RequiredLiquidity: pegoutQuote1Amount, State: quote.PegoutStateWaitingForDeposit},
+			{QuoteHash: "pegout_2", RequiredLiquidity: pegoutQuote2Amount, State: quote.PegoutStateWaitingForDepositConfirmations},
+		}
+		peginQuotes := []quote.RetainedPeginQuote{
+			{QuoteHash: "pegin_1", RequiredLiquidity: peginQuote1Amount, State: quote.PeginStateWaitingForDeposit},
+			{QuoteHash: "pegin_2", RequiredLiquidity: peginQuote2Amount, State: quote.PeginStateWaitingForDepositConfirmations},
+		}
 
-	lp := new(mocks.ProviderMock)
-	lp.On("AvailablePeginLiquidity", ctx).Return(entities.NewWei(67500), nil)
-	lp.On("AvailablePegoutLiquidity", ctx).Return(entities.NewWei(85000), nil)
+		btcWallet.On("GetBalance").Return(initialBtcWalletBalance, nil).Once()
+		rskRpc.On("GetBalance", ctx, "test-rsk-address").Return(initialRbtcWalletBalance, nil).Once()
+		lp.On("RskAddress").Return("test-rsk-address").Twice()
+		lbcContract.On("GetBalance", "test-rsk-address").Return(initialRbtcLbcBalance, nil).Once()
 
-	peginRepository := mocks.NewPeginQuoteRepositoryMock(t)
-	peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations).Return(retainedPeginQuotes, nil)
-	pegoutRepository := mocks.NewPegoutQuoteRepositoryMock(t)
-	pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).Return(retainedPegoutQuotes, nil)
+		// Pegout repository mocks
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).
+			Return(pegoutQuotes, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded, quote.PegoutStateSendPegoutSucceeded, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
 
-	useCase := reports.NewGetAssetsReportUseCase(wallet, rpc, lpMock, lp, lp, peginRepository, pegoutRepository)
+		// Pegin repository mocks
+		peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateCallForUserSucceeded).
+			Return([]quote.RetainedPeginQuote{}, nil).Once()
+		peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations).
+			Return(peginQuotes, nil).Once()
 
-	result, err := useCase.Run(ctx)
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
 
-	require.NoError(t, err)
-	require.Equal(t, result.RbtcLiquidity, big.NewInt(67500))
-	require.Equal(t, result.BtcLiquidity, big.NewInt(85000))
-	require.Equal(t, result.BtcBalance, big.NewInt(100000))
-	require.Equal(t, result.RbtcBalance, big.NewInt(100000))
-	require.Equal(t, result.RbtcLocked, big.NewInt(17500))
-	require.Equal(t, result.BtcLocked, big.NewInt(15000))
-	lp.AssertExpectations(t)
-	peginRepository.AssertExpectations(t)
-	pegoutRepository.AssertExpectations(t)
-	rsk.AssertExpectations(t)
-	lpMock.AssertExpectations(t)
-	wallet.AssertExpectations(t)
+		require.NoError(t, err)
+		assert.Equal(t, expectedTotalBtc.String(), result.BtcAssetReport.Total.String(), "Scenario 1: BTC total should remain constant")
+		assert.Equal(t, expectedTotalRbtc.String(), result.RbtcAssetReport.Total.String(), "Scenario 1: RBTC total should remain constant")
+
+		btcWallet.AssertExpectations(t)
+		rskRpc.AssertExpectations(t)
+		lp.AssertExpectations(t)
+		peginRepository.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+		lbcContract.AssertExpectations(t)
+	})
+
+	// Scenario 2: Quotes progress - LP sends BTC (pegout), LP calls for user (pegin)
+	t.Run("Scenario_2_Quotes_In_Progress", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
+
+		// Scenario 2: User deposits completed, assets moved but not yet fully cycled
+		// - pegout_1: User deposited RBTC, LP refunded (RefundPegOutSucceeded) - LP now has RBTC in wallet
+		//   The report counts this RBTC as "BTC waiting for rebalancing" because LP will convert it back to BTC
+		// - pegout_2: Still waiting for user deposit
+		// - pegin_1: LP called for user (CallForUserSucceeded) - LP sent RBTC, waiting for BTC from user
+		// - pegin_2: Still waiting for user deposit
+
+		pegoutQuotesRefunded := []quote.RetainedPegoutQuote{
+			{QuoteHash: "pegout_1", RequiredLiquidity: pegoutQuote1Amount, State: quote.PegoutStateRefundPegOutSucceeded},
+		}
+		pegoutQuotesReserved := []quote.RetainedPegoutQuote{
+			{QuoteHash: "pegout_2", RequiredLiquidity: pegoutQuote2Amount, State: quote.PegoutStateWaitingForDepositConfirmations},
+		}
+		peginQuotesWaitingRefund := []quote.RetainedPeginQuote{
+			{QuoteHash: "pegin_1", RequiredLiquidity: peginQuote1Amount, State: quote.PeginStateCallForUserSucceeded},
+		}
+		peginQuotesReserved := []quote.RetainedPeginQuote{
+			{QuoteHash: "pegin_2", RequiredLiquidity: peginQuote2Amount, State: quote.PeginStateWaitingForDepositConfirmations},
+		}
+
+		// RBTC wallet balance changes:
+		// - Reduced by pegin_1 amount (sent to user in callForUser)
+		// - Increased by pegout_1 amount (received from user's RBTC deposit)
+		// Net: initialRbtcWalletBalance - peginQuote1Amount + pegoutQuote1Amount
+		currentRbtcWalletBalance := entities.NewWei(0).Add(initialRbtcWalletBalance, entities.NewWei(0))
+		currentRbtcWalletBalance.Sub(currentRbtcWalletBalance, peginQuote1Amount)
+		currentRbtcWalletBalance.Add(currentRbtcWalletBalance, pegoutQuote1Amount)
+
+		// Expected totals adjust for the asset type conversion:
+		// BTC total increases by pegoutQuote1Amount (RBTC counted as "BTC waiting for rebalancing")
+		// RBTC total stays the same (pegin_1 sent out, pegout_1 received in)
+		expectedBtcScenario2 := entities.NewWei(0).Add(expectedTotalBtc, pegoutQuote1Amount)
+
+		btcWallet.On("GetBalance").Return(initialBtcWalletBalance, nil).Once()
+		rskRpc.On("GetBalance", ctx, "test-rsk-address").Return(currentRbtcWalletBalance, nil).Once()
+		lp.On("RskAddress").Return("test-rsk-address").Twice()
+		lbcContract.On("GetBalance", "test-rsk-address").Return(initialRbtcLbcBalance, nil).Once()
+
+		// Pegout repository mocks
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+			Return(pegoutQuotesRefunded, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).
+			Return(pegoutQuotesReserved, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded, quote.PegoutStateSendPegoutSucceeded, quote.PegoutStateBridgeTxSucceeded).
+			Return(pegoutQuotesRefunded, nil).Once()
+
+		// Pegin repository mocks
+		peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateCallForUserSucceeded).
+			Return(peginQuotesWaitingRefund, nil).Once()
+		peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations).
+			Return(peginQuotesReserved, nil).Once()
+
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedBtcScenario2.String(), result.BtcAssetReport.Total.String(), "Scenario 2: BTC total includes RBTC waiting for rebalancing")
+		assert.Equal(t, expectedTotalRbtc.String(), result.RbtcAssetReport.Total.String(), "Scenario 2: RBTC total remains constant")
+
+		btcWallet.AssertExpectations(t)
+		rskRpc.AssertExpectations(t)
+		lp.AssertExpectations(t)
+		peginRepository.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+		lbcContract.AssertExpectations(t)
+	})
+
+	// Scenario 3: Final state - quotes completed and refunded
+	t.Run("Scenario_3_Quotes_Completed_And_Refunded", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
+
+		// Scenario 3: All quotes completed and refunded
+		// - pegout_1: LP sent BTC, user deposited RBTC to LBC, LP refunded (RefundPegOutSucceeded)
+		// - pegout_2: Still waiting for user deposit (WaitingForDepositConfirmations)
+		// - pegin_1: LP called for user, user sent BTC, LP registered and got refunded - quote completed (no longer in system)
+		// - pegin_2: Still waiting for user deposit (WaitingForDepositConfirmations)
+
+		pegoutQuotesRefunded := []quote.RetainedPegoutQuote{
+			{QuoteHash: "pegout_1", RequiredLiquidity: pegoutQuote1Amount, State: quote.PegoutStateRefundPegOutSucceeded},
+		}
+		pegoutQuotesStillWaiting := []quote.RetainedPegoutQuote{
+			{QuoteHash: "pegout_2", RequiredLiquidity: pegoutQuote2Amount, State: quote.PegoutStateWaitingForDepositConfirmations},
+		}
+		peginQuotesStillWaiting := []quote.RetainedPeginQuote{
+			{QuoteHash: "pegin_2", RequiredLiquidity: peginQuote2Amount, State: quote.PeginStateWaitingForDepositConfirmations},
+		}
+
+		// LP got RBTC back from pegin_1 refund, now has the RBTC in RSK wallet (not in LBC anymore, assuming LP withdrew)
+		// The pegin_1 amount is back in the wallet
+		finalRbtcWalletBalance := entities.NewWei(0).Add(initialRbtcWalletBalance, entities.NewWei(0))
+		// LP has the RBTC from pegout_1 in RSK wallet (received from refund)
+		finalRbtcWalletBalance.Add(finalRbtcWalletBalance, pegoutQuote1Amount)
+
+		btcWallet.On("GetBalance").Return(initialBtcWalletBalance, nil).Once()
+		rskRpc.On("GetBalance", ctx, "test-rsk-address").Return(finalRbtcWalletBalance, nil).Once()
+		lp.On("RskAddress").Return("test-rsk-address").Twice()
+		lbcContract.On("GetBalance", "test-rsk-address").Return(initialRbtcLbcBalance, nil).Once()
+
+		// Pegout repository mocks
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+			Return(pegoutQuotesRefunded, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).
+			Return(pegoutQuotesStillWaiting, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded, quote.PegoutStateSendPegoutSucceeded, quote.PegoutStateBridgeTxSucceeded).
+			Return(pegoutQuotesRefunded, nil).Once()
+
+		// Pegin repository mocks
+		peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateCallForUserSucceeded).
+			Return([]quote.RetainedPeginQuote{}, nil).Once()
+		peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations).
+			Return(peginQuotesStillWaiting, nil).Once()
+
+		// Expected totals: Same as Scenario 2 since pegout_1 is still in RefundPegOutSucceeded state
+		expectedBtcScenario3 := entities.NewWei(0).Add(expectedTotalBtc, pegoutQuote1Amount)
+
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedBtcScenario3.String(), result.BtcAssetReport.Total.String(), "Scenario 3: BTC total includes RBTC waiting for rebalancing")
+		assert.Equal(t, expectedTotalRbtc.String(), result.RbtcAssetReport.Total.String(), "Scenario 3: RBTC total remains constant")
+
+		btcWallet.AssertExpectations(t)
+		rskRpc.AssertExpectations(t)
+		lp.AssertExpectations(t)
+		peginRepository.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+		lbcContract.AssertExpectations(t)
+	})
 }
 
-func TestGetAssetsReportUseCase_Run_btcBalanceError(t *testing.T) {
+// Tests error handling in the GetAssetsReportUseCase for various failure scenarios.
+// Verifies that errors from dependencies are properly propagated.
+// nolint:funlen,maintidx
+func TestGetAssetsReportUseCase_Run_ErrorHandling(t *testing.T) {
 	ctx := context.Background()
 
-	wallet := mocks.NewBitcoinWalletMock(t)
-	wallet.On("GetBalance").Return(nil, assert.AnError)
+	t.Run("Error_BtcWallet_GetBalance_Fails", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
 
-	lpMock := &mocks.ProviderMock{}
+		btcWallet.On("GetBalance").Return(nil, assert.AnError).Once()
 
-	rsk := new(mocks.RootstockRpcServerMock)
-	rpc := blockchain.Rpc{Rsk: rsk}
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
 
-	lp := new(mocks.ProviderMock)
+		require.Error(t, err)
+		assert.Equal(t, reports.GetAssetsReportResult{}, result)
+		btcWallet.AssertExpectations(t)
+	})
 
-	peginRepository := mocks.NewPeginQuoteRepositoryMock(t)
-	pegoutRepository := mocks.NewPegoutQuoteRepositoryMock(t)
+	t.Run("Error_PegoutRepository_BridgeTxSucceeded_Fails", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
 
-	useCase := reports.NewGetAssetsReportUseCase(wallet, rpc, lpMock, lp, lp, peginRepository, pegoutRepository)
+		btcWallet.On("GetBalance").Return(entities.NewWei(100000000), nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return(nil, assert.AnError).Once()
 
-	result, err := useCase.Run(ctx)
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
 
-	require.Error(t, err)
-	require.Equal(t, result.RbtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcLocked, big.NewInt(0))
-	require.Equal(t, result.BtcLocked, big.NewInt(0))
-	lp.AssertNotCalled(t, "AvailablePeginLiquidity")
-	lp.AssertNotCalled(t, "AvailablePegoutLiquidity")
-	peginRepository.AssertNotCalled(t, "GetRetainedQuoteByState")
-	pegoutRepository.AssertNotCalled(t, "GetRetainedQuoteByState")
-	rsk.AssertNotCalled(t, "GetBalance")
-	lpMock.AssertNotCalled(t, "RskAddress")
-	wallet.AssertExpectations(t)
-}
+		require.Error(t, err)
+		assert.Equal(t, reports.GetAssetsReportResult{}, result)
+		btcWallet.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+	})
 
-func TestGetAssetsReportUseCase_Run_rbtcBalanceError(t *testing.T) {
-	ctx := context.Background()
+	t.Run("Error_PegoutRepository_RefundPegOutSucceeded_Fails", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
 
-	rskAddress := "rskAddress"
+		btcWallet.On("GetBalance").Return(entities.NewWei(100000000), nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+			Return(nil, assert.AnError).Once()
 
-	wallet := mocks.NewBitcoinWalletMock(t)
-	wallet.On("GetBalance").Return(entities.NewWei(100000), nil)
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
 
-	lpMock := &mocks.ProviderMock{}
-	lpMock.On("RskAddress").Return(rskAddress)
+		require.Error(t, err)
+		assert.Equal(t, reports.GetAssetsReportResult{}, result)
+		btcWallet.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+	})
 
-	rsk := new(mocks.RootstockRpcServerMock)
-	rpc := blockchain.Rpc{Rsk: rsk}
+	t.Run("Error_PegoutRepository_SendPegoutSucceeded_Fails", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
 
-	rsk.On("GetBalance", ctx, rskAddress).Return(nil, assert.AnError)
+		btcWallet.On("GetBalance").Return(entities.NewWei(100000000), nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+			Return(nil, assert.AnError).Once()
 
-	lp := new(mocks.ProviderMock)
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
 
-	peginRepository := mocks.NewPeginQuoteRepositoryMock(t)
-	pegoutRepository := mocks.NewPegoutQuoteRepositoryMock(t)
+		require.Error(t, err)
+		assert.Equal(t, reports.GetAssetsReportResult{}, result)
+		btcWallet.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+	})
 
-	useCase := reports.NewGetAssetsReportUseCase(wallet, rpc, lpMock, lp, lp, peginRepository, pegoutRepository)
+	t.Run("Error_PegoutRepository_WaitingForDeposit_Fails", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
 
-	result, err := useCase.Run(ctx)
+		btcWallet.On("GetBalance").Return(entities.NewWei(100000000), nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).
+			Return(nil, assert.AnError).Once()
 
-	require.Error(t, err)
-	require.Equal(t, result.RbtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcLocked, big.NewInt(0))
-	require.Equal(t, result.BtcLocked, big.NewInt(0))
-	lp.AssertNotCalled(t, "AvailablePeginLiquidity")
-	lp.AssertNotCalled(t, "AvailablePegoutLiquidity")
-	peginRepository.AssertNotCalled(t, "GetRetainedQuoteByState")
-	pegoutRepository.AssertNotCalled(t, "GetRetainedQuoteByState")
-	rsk.AssertExpectations(t)
-	lpMock.AssertExpectations(t)
-	wallet.AssertExpectations(t)
-}
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
 
-func TestGetAssetsReportUseCase_Run_rbtcLockedError(t *testing.T) {
-	ctx := context.Background()
+		require.Error(t, err)
+		assert.Equal(t, reports.GetAssetsReportResult{}, result)
+		btcWallet.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+	})
 
-	rskAddress := "rskAddress"
+	t.Run("Error_PegoutRepository_WaitingForRefund_Fails", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
 
-	wallet := mocks.NewBitcoinWalletMock(t)
-	wallet.On("GetBalance").Return(entities.NewWei(100000), nil)
+		btcWallet.On("GetBalance").Return(entities.NewWei(100000000), nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded, quote.PegoutStateSendPegoutSucceeded, quote.PegoutStateBridgeTxSucceeded).
+			Return(nil, assert.AnError).Once()
 
-	lpMock := &mocks.ProviderMock{}
-	lpMock.On("RskAddress").Return(rskAddress)
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
 
-	rsk := new(mocks.RootstockRpcServerMock)
-	rpc := blockchain.Rpc{Rsk: rsk}
+		require.Error(t, err)
+		assert.Equal(t, reports.GetAssetsReportResult{}, result)
+		btcWallet.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+	})
 
-	rsk.On("GetBalance", ctx, rskAddress).Return(entities.NewWei(100000), nil)
+	t.Run("Error_RskRpc_GetBalance_Fails", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
 
-	lp := new(mocks.ProviderMock)
+		btcWallet.On("GetBalance").Return(entities.NewWei(100000000), nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded, quote.PegoutStateSendPegoutSucceeded, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		lp.On("RskAddress").Return("test-rsk-address").Once()
+		rskRpc.On("GetBalance", ctx, "test-rsk-address").Return(nil, assert.AnError).Once()
 
-	peginRepository := mocks.NewPeginQuoteRepositoryMock(t)
-	peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations).Return(nil, assert.AnError)
-	pegoutRepository := mocks.NewPegoutQuoteRepositoryMock(t)
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
 
-	useCase := reports.NewGetAssetsReportUseCase(wallet, rpc, lpMock, lp, lp, peginRepository, pegoutRepository)
+		require.Error(t, err)
+		assert.Equal(t, reports.GetAssetsReportResult{}, result)
+		btcWallet.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+		rskRpc.AssertExpectations(t)
+		lp.AssertExpectations(t)
+	})
 
-	result, err := useCase.Run(ctx)
+	t.Run("Error_LbcContract_GetBalance_Fails", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
 
-	require.Error(t, err)
-	require.Equal(t, result.RbtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcLocked, big.NewInt(0))
-	require.Equal(t, result.BtcLocked, big.NewInt(0))
-	lp.AssertNotCalled(t, "AvailablePeginLiquidity")
-	lp.AssertNotCalled(t, "AvailablePegoutLiquidity")
-	peginRepository.AssertExpectations(t)
-	pegoutRepository.AssertNotCalled(t, "GetRetainedQuoteByState")
-	rsk.AssertExpectations(t)
-	lpMock.AssertExpectations(t)
-	wallet.AssertExpectations(t)
-}
+		btcWallet.On("GetBalance").Return(entities.NewWei(100000000), nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded, quote.PegoutStateSendPegoutSucceeded, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		lp.On("RskAddress").Return("test-rsk-address").Twice()
+		rskRpc.On("GetBalance", ctx, "test-rsk-address").Return(entities.NewWei(200000000), nil).Once()
+		lbcContract.On("GetBalance", "test-rsk-address").Return(nil, assert.AnError).Once()
 
-func TestGetAssetsReportUseCase_Run_BtcLockedError(t *testing.T) {
-	ctx := context.Background()
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
 
-	rskAddress := "rskAddress"
+		require.Error(t, err)
+		assert.Equal(t, reports.GetAssetsReportResult{}, result)
+		btcWallet.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+		rskRpc.AssertExpectations(t)
+		lp.AssertExpectations(t)
+		lbcContract.AssertExpectations(t)
+	})
 
-	wallet := mocks.NewBitcoinWalletMock(t)
-	wallet.On("GetBalance").Return(entities.NewWei(100000), nil)
+	t.Run("Error_PeginRepository_CallForUserSucceeded_Fails", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
 
-	lpMock := &mocks.ProviderMock{}
-	lpMock.On("RskAddress").Return(rskAddress)
+		btcWallet.On("GetBalance").Return(entities.NewWei(100000000), nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded, quote.PegoutStateSendPegoutSucceeded, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		lp.On("RskAddress").Return("test-rsk-address").Twice()
+		rskRpc.On("GetBalance", ctx, "test-rsk-address").Return(entities.NewWei(200000000), nil).Once()
+		lbcContract.On("GetBalance", "test-rsk-address").Return(entities.NewWei(50000000), nil).Once()
+		peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateCallForUserSucceeded).
+			Return(nil, assert.AnError).Once()
 
-	rsk := new(mocks.RootstockRpcServerMock)
-	rpc := blockchain.Rpc{Rsk: rsk}
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
 
-	rsk.On("GetBalance", ctx, rskAddress).Return(entities.NewWei(100000), nil)
+		require.Error(t, err)
+		assert.Equal(t, reports.GetAssetsReportResult{}, result)
+		btcWallet.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+		rskRpc.AssertExpectations(t)
+		lp.AssertExpectations(t)
+		lbcContract.AssertExpectations(t)
+		peginRepository.AssertExpectations(t)
+	})
 
-	lp := new(mocks.ProviderMock)
+	t.Run("Error_PeginRepository_WaitingForDeposit_Fails", func(t *testing.T) {
+		btcWallet := &mocks.BitcoinWalletMock{}
+		rskRpc := &mocks.RootstockRpcServerMock{}
+		lp := &mocks.ProviderMock{}
+		peginProvider := &mocks.ProviderMock{}
+		pegoutProvider := &mocks.ProviderMock{}
+		peginRepository := &mocks.PeginQuoteRepositoryMock{}
+		pegoutRepository := &mocks.PegoutQuoteRepositoryMock{}
+		lbcContract := &mocks.LiquidityBridgeContractMock{}
+		contracts := blockchain.RskContracts{Lbc: lbcContract}
 
-	peginRepository := mocks.NewPeginQuoteRepositoryMock(t)
-	peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations).Return(retainedPeginQuotes, nil)
-	pegoutRepository := mocks.NewPegoutQuoteRepositoryMock(t)
-	pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).Return(nil, assert.AnError)
-	useCase := reports.NewGetAssetsReportUseCase(wallet, rpc, lpMock, lp, lp, peginRepository, pegoutRepository)
+		btcWallet.On("GetBalance").Return(entities.NewWei(100000000), nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateSendPegoutSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateRefundPegOutSucceeded, quote.PegoutStateSendPegoutSucceeded, quote.PegoutStateBridgeTxSucceeded).
+			Return([]quote.RetainedPegoutQuote{}, nil).Once()
+		lp.On("RskAddress").Return("test-rsk-address").Twice()
+		rskRpc.On("GetBalance", ctx, "test-rsk-address").Return(entities.NewWei(200000000), nil).Once()
+		lbcContract.On("GetBalance", "test-rsk-address").Return(entities.NewWei(50000000), nil).Once()
+		peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateCallForUserSucceeded).
+			Return([]quote.RetainedPeginQuote{}, nil).Once()
+		peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations).
+			Return(nil, assert.AnError).Once()
 
-	result, err := useCase.Run(ctx)
+		useCase := reports.NewGetAssetsReportUseCase(btcWallet, blockchain.Rpc{Rsk: rskRpc}, lp, peginProvider, pegoutProvider, peginRepository, pegoutRepository, contracts)
+		result, err := useCase.Run(ctx)
 
-	require.Error(t, err)
-	require.Equal(t, result.RbtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcLocked, big.NewInt(0))
-	require.Equal(t, result.BtcLocked, big.NewInt(0))
-	lp.AssertNotCalled(t, "AvailablePeginLiquidity")
-	lp.AssertNotCalled(t, "AvailablePegoutLiquidity")
-	peginRepository.AssertExpectations(t)
-	pegoutRepository.AssertExpectations(t)
-	rsk.AssertExpectations(t)
-	lpMock.AssertExpectations(t)
-	wallet.AssertExpectations(t)
-}
-
-func TestGetAssetsReportUseCase_Run_BtcLiquidityError(t *testing.T) {
-	ctx := context.Background()
-
-	rskAddress := "rskAddress"
-
-	wallet := mocks.NewBitcoinWalletMock(t)
-	wallet.On("GetBalance").Return(entities.NewWei(100000), nil)
-
-	lpMock := &mocks.ProviderMock{}
-	lpMock.On("RskAddress").Return(rskAddress)
-
-	rsk := new(mocks.RootstockRpcServerMock)
-	rpc := blockchain.Rpc{Rsk: rsk}
-
-	rsk.On("GetBalance", ctx, rskAddress).Return(entities.NewWei(100000), nil)
-
-	lp := new(mocks.ProviderMock)
-	lp.On("AvailablePegoutLiquidity", ctx).Return(entities.NewWei(0), assert.AnError)
-
-	peginRepository := mocks.NewPeginQuoteRepositoryMock(t)
-	peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations).Return(retainedPeginQuotes, nil)
-	pegoutRepository := mocks.NewPegoutQuoteRepositoryMock(t)
-	pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).Return(retainedPegoutQuotes, nil)
-	useCase := reports.NewGetAssetsReportUseCase(wallet, rpc, lpMock, lp, lp, peginRepository, pegoutRepository)
-
-	result, err := useCase.Run(ctx)
-
-	require.Error(t, err)
-	require.Equal(t, result.RbtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcLocked, big.NewInt(0))
-	require.Equal(t, result.BtcLocked, big.NewInt(0))
-	lp.AssertExpectations(t)
-	lp.AssertNotCalled(t, "AvailablePegoutLiquidity")
-	peginRepository.AssertExpectations(t)
-	pegoutRepository.AssertExpectations(t)
-	rsk.AssertExpectations(t)
-	lpMock.AssertExpectations(t)
-	wallet.AssertExpectations(t)
-}
-
-func TestGetAssetsReportUseCase_Run_RbtcLiquidityError(t *testing.T) {
-	ctx := context.Background()
-
-	rskAddress := "rskAddress"
-
-	wallet := mocks.NewBitcoinWalletMock(t)
-	wallet.On("GetBalance").Return(entities.NewWei(100000), nil)
-
-	lpMock := &mocks.ProviderMock{}
-	lpMock.On("RskAddress").Return(rskAddress)
-
-	rsk := new(mocks.RootstockRpcServerMock)
-	rpc := blockchain.Rpc{Rsk: rsk}
-
-	rsk.On("GetBalance", ctx, rskAddress).Return(entities.NewWei(100000), nil)
-
-	lp := new(mocks.ProviderMock)
-	lp.On("AvailablePeginLiquidity", ctx).Return(entities.NewWei(0), assert.AnError)
-	lp.On("AvailablePegoutLiquidity", ctx).Return(entities.NewWei(100000), nil)
-
-	peginRepository := mocks.NewPeginQuoteRepositoryMock(t)
-	peginRepository.On("GetRetainedQuoteByState", ctx, quote.PeginStateWaitingForDeposit, quote.PeginStateWaitingForDepositConfirmations).Return(retainedPeginQuotes, nil)
-	pegoutRepository := mocks.NewPegoutQuoteRepositoryMock(t)
-	pegoutRepository.On("GetRetainedQuoteByState", ctx, quote.PegoutStateWaitingForDeposit, quote.PegoutStateWaitingForDepositConfirmations).Return(retainedPegoutQuotes, nil)
-	useCase := reports.NewGetAssetsReportUseCase(wallet, rpc, lpMock, lp, lp, peginRepository, pegoutRepository)
-
-	result, err := useCase.Run(ctx)
-
-	require.Error(t, err)
-	require.Equal(t, result.RbtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcLiquidity, big.NewInt(0))
-	require.Equal(t, result.BtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcBalance, big.NewInt(0))
-	require.Equal(t, result.RbtcLocked, big.NewInt(0))
-	require.Equal(t, result.BtcLocked, big.NewInt(0))
-	lp.AssertExpectations(t)
-	peginRepository.AssertExpectations(t)
-	pegoutRepository.AssertExpectations(t)
-	rsk.AssertExpectations(t)
-	lpMock.AssertExpectations(t)
-	wallet.AssertExpectations(t)
+		require.Error(t, err)
+		assert.Equal(t, reports.GetAssetsReportResult{}, result)
+		btcWallet.AssertExpectations(t)
+		pegoutRepository.AssertExpectations(t)
+		rskRpc.AssertExpectations(t)
+		lp.AssertExpectations(t)
+		lbcContract.AssertExpectations(t)
+		peginRepository.AssertExpectations(t)
+	})
 }

--- a/pkg/liquidity_provider.go
+++ b/pkg/liquidity_provider.go
@@ -182,13 +182,49 @@ type GetRevenueReportResponse struct {
 	TotalProfit        *big.Int `json:"totalProfit" validate:"required"`
 }
 
-type GetAssetsReportDTO struct {
-	BtcBalance    *big.Int `json:"btcBalance" example:"1000000000" description:"Current balance on the bitcoin wallet" validate:"required"`
-	RbtcBalance   *big.Int `json:"rbtcBalance" example:"1000000000" description:"Current balance on the RBTC wallet" validate:"required"`
-	BtcLocked     *big.Int `json:"btcLocked" example:"1000000000" description:"Amount of BTC locked by quotes" validate:"required"`
-	RbtcLocked    *big.Int `json:"rbtcLocked" example:"1000000000" description:"Amount of RBTC locked by quotes" validate:"required"`
-	BtcLiquidity  *big.Int `json:"btcLiquidity" example:"1000000000" description:"Amount of BTC liquidity available for new quotes" validate:"required"`
-	RbtcLiquidity *big.Int `json:"rbtcLiquidity" example:"1000000000" description:"Amount of RBTC liquidity available for new quotes" validate:"required"`
+// BTC Asset Report structures
+type BtcAssetLocationDTO struct {
+	BtcWallet  *big.Int `json:"btcWallet" example:"50000000" description:"BTC in the LP's Bitcoin wallet" validate:"required"`
+	Federation *big.Int `json:"federation" example:"5000000" description:"BTC in the federation (rebalancing or waiting for refund)" validate:"required"`
+	RskWallet  *big.Int `json:"rskWallet" example:"6500000" description:"BTC represented as RBTC in the RSK wallet (waiting for rebalancing)" validate:"required"`
+	Lbc        *big.Int `json:"lbc" example:"5300000" description:"BTC represented as RBTC locked in the Liquidity Bridge Contract" validate:"required"`
+}
+
+type BtcAssetAllocationDTO struct {
+	ReservedForUsers *big.Int `json:"reservedForUsers" example:"4500000" description:"BTC reserved for users (accepted pegout quotes)" validate:"required"`
+	WaitingForRefund *big.Int `json:"waitingForRefund" example:"19800000" description:"BTC waiting to be refunded to the LP" validate:"required"`
+	Available        *big.Int `json:"available" example:"43200000" description:"BTC available for new pegout quotes" validate:"required"`
+}
+
+type BtcAssetReportDTO struct {
+	Total      *big.Int              `json:"total" example:"67500000" description:"Total BTC assets under LP control" validate:"required"`
+	Location   BtcAssetLocationDTO   `json:"location" description:"BTC distribution across different locations" validate:"required"`
+	Allocation BtcAssetAllocationDTO `json:"allocation" description:"BTC allocation by usage/purpose" validate:"required"`
+}
+
+// RBTC Asset Report structures
+type RbtcAssetLocationDTO struct {
+	RskWallet  *big.Int `json:"rskWallet" example:"10000000000000000000" description:"RBTC in the LP's RSK wallet" validate:"required"`
+	Lbc        *big.Int `json:"lbc" example:"5000000000000000000" description:"RBTC locked in the Liquidity Bridge Contract" validate:"required"`
+	Federation *big.Int `json:"federation" example:"2000000000000000000" description:"RBTC in the federation (waiting for refund)" validate:"required"`
+}
+
+type RbtcAssetAllocationDTO struct {
+	ReservedForUsers *big.Int `json:"reservedForUsers" example:"3000000000000000000" description:"RBTC reserved for users (accepted pegin quotes)" validate:"required"`
+	WaitingForRefund *big.Int `json:"waitingForRefund" example:"2000000000000000000" description:"RBTC waiting to be refunded to the LP" validate:"required"`
+	Available        *big.Int `json:"available" example:"12000000000000000000" description:"RBTC available for new pegin quotes" validate:"required"`
+}
+
+type RbtcAssetReportDTO struct {
+	Total      *big.Int               `json:"total" example:"17000000000000000000" description:"Total RBTC assets under LP control" validate:"required"`
+	Location   RbtcAssetLocationDTO   `json:"location" description:"RBTC distribution across different locations" validate:"required"`
+	Allocation RbtcAssetAllocationDTO `json:"allocation" description:"RBTC allocation by usage/purpose" validate:"required"`
+}
+
+// Combined Assets Report Response
+type GetAssetsReportResponse struct {
+	BtcAssetReport  BtcAssetReportDTO  `json:"btcAssetReport" description:"Detailed BTC asset report" validate:"required"`
+	RbtcAssetReport RbtcAssetReportDTO `json:"rbtcAssetReport" description:"Detailed RBTC asset report" validate:"required"`
 }
 
 type AvailableLiquidityDTO struct {
@@ -236,6 +272,62 @@ func ToSummaryResultDTO(result reports.SummaryResult) SummaryResultDTO {
 	return SummaryResultDTO{
 		PeginSummary:  ToSummaryDataDTO(result.PeginSummary),
 		PegoutSummary: ToSummaryDataDTO(result.PegoutSummary),
+	}
+}
+
+func ToBtcAssetLocationDTO(location reports.BtcAssetLocation) BtcAssetLocationDTO {
+	return BtcAssetLocationDTO{
+		BtcWallet:  location.BtcWallet.AsBigInt(),
+		Federation: location.Federation.AsBigInt(),
+		RskWallet:  location.RskWallet.AsBigInt(),
+		Lbc:        location.Lbc.AsBigInt(),
+	}
+}
+
+func ToBtcAssetAllocationDTO(allocation reports.BtcAssetAllocation) BtcAssetAllocationDTO {
+	return BtcAssetAllocationDTO{
+		ReservedForUsers: allocation.ReservedForUsers.AsBigInt(),
+		WaitingForRefund: allocation.WaitingForRefund.AsBigInt(),
+		Available:        allocation.Available.AsBigInt(),
+	}
+}
+
+func ToBtcAssetReportDTO(report reports.BtcAssetReport) BtcAssetReportDTO {
+	return BtcAssetReportDTO{
+		Total:      report.Total.AsBigInt(),
+		Location:   ToBtcAssetLocationDTO(report.Location),
+		Allocation: ToBtcAssetAllocationDTO(report.Allocation),
+	}
+}
+
+func ToRbtcAssetLocationDTO(location reports.RbtcAssetLocation) RbtcAssetLocationDTO {
+	return RbtcAssetLocationDTO{
+		RskWallet:  location.RskWallet.AsBigInt(),
+		Lbc:        location.Lbc.AsBigInt(),
+		Federation: location.Federation.AsBigInt(),
+	}
+}
+
+func ToRbtcAssetAllocationDTO(allocation reports.RbtcAssetAllocation) RbtcAssetAllocationDTO {
+	return RbtcAssetAllocationDTO{
+		ReservedForUsers: allocation.ReservedForUsers.AsBigInt(),
+		WaitingForRefund: allocation.WaitingForRefund.AsBigInt(),
+		Available:        allocation.Available.AsBigInt(),
+	}
+}
+
+func ToRbtcAssetReportDTO(report reports.RbtcAssetReport) RbtcAssetReportDTO {
+	return RbtcAssetReportDTO{
+		Total:      report.Total.AsBigInt(),
+		Location:   ToRbtcAssetLocationDTO(report.Location),
+		Allocation: ToRbtcAssetAllocationDTO(report.Allocation),
+	}
+}
+
+func ToGetAssetsReportResponse(result reports.GetAssetsReportResult) GetAssetsReportResponse {
+	return GetAssetsReportResponse{
+		BtcAssetReport:  ToBtcAssetReportDTO(result.BtcAssetReport),
+		RbtcAssetReport: ToRbtcAssetReportDTO(result.RbtcAssetReport),
 	}
 }
 


### PR DESCRIPTION
## What
- Adds feature to get a report telling all the BTC and RBTC totals, their locations and what are they being used to.
- 
## Why
This PR is part of the financial API to give Liquidity Providers a way to have information about the financial status of the server.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [x] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [ ] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [x] Metrics and alerting

## Related Issues

[Jira ticket FLY-2049](https://rsklabs.atlassian.net/browse/FLY-2049)

## How to test
1. Run the LPS on local using `./lps-env.sh up`
2. Create some pegin and pegout quotes and move them to different states.
3. On each state call the GET /reports/assets endpoint and check the result.

## Images
<img width="2084" height="1206" alt="image" src="https://github.com/user-attachments/assets/b4d6feb7-f904-440c-822e-cdf66806363e" />

