### PR TITLE
chore: update rskj version in Dockerfile

### DIFF
--- a/docker-compose/rskj/Dockerfile
+++ b/docker-compose/rskj/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 ubuntu:noble@sha256:d22e4fb389065efa4a61bb36416768698ef6d955fe8a7e0cdb3cd6de80fa7eec
 
-ARG RSKJ_VERSION="8.0.0~noble"
+ARG RSKJ_VERSION="8.1.0~noble"
 ARG UID=1001
 ARG HOME="/home/rsk"
 


### PR DESCRIPTION
## What
Update the version of the rskj package in the rskj Dockerfile

## Why
Because only the latest version is published in the ubuntu repository so keeping the version 8.0.0 will cause an error in the pipeline

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [x] Deployment/Infrastructure changes
