### PR TITLE
feat: add excess tolerance

### DIFF
--- a/docker-compose/local/lps-env.sh
+++ b/docker-compose/local/lps-env.sh
@@ -280,7 +280,12 @@ curl -sfS -b cookie_jar.txt 'http://localhost:8080/configuration' \
               "8000000000000000000": 40
           },
           "publicLiquidityCheck": true,
-          "maxLiquidity": "10000000000000000000"
+          "maxLiquidity": "10000000000000000000",
+          "excessTolerance": {
+            "isFixed": false,
+            "percentageValue": 15,
+            "fixedValue": "0"
+          }
       }
   }' || { echo "Error in configuring general regtest configuration"; exit 1; }
 

--- a/internal/adapters/dataproviders/database/mongo/liquidity_provider_test.go
+++ b/internal/adapters/dataproviders/database/mongo/liquidity_provider_test.go
@@ -62,6 +62,11 @@ var generalTestConfig = &entities.Signed[liquidity_provider.GeneralConfiguration
 		},
 		PublicLiquidityCheck: false,
 		MaxLiquidity:         entities.NewWei(123),
+		ExcessTolerance: liquidity_provider.ExcessTolerance{
+			IsFixed:         true,
+			PercentageValue: utils.NewBigFloat64(10),
+			FixedValue:      entities.NewWei(555),
+		},
 	},
 	Signature: "general signature",
 	Hash:      "general hash",
@@ -152,7 +157,7 @@ func TestLpMongoRepository_GetGeneralConfiguration(t *testing.T) {
 	filter := bson.D{primitive.E{Key: "name", Value: mongo.ConfigurationName("general")}}
 	log.SetLevel(log.DebugLevel)
 	t.Run("general configuration read successfully", func(t *testing.T) {
-		const expectedLog = "READ interaction with db: {Value:{RskConfirmations:map[1:2 3:4] BtcConfirmations:map[5:6 7:8] PublicLiquidityCheck:false MaxLiquidity:123} Signature:general signature Hash:general hash}"
+		const expectedLog = "READ interaction with db: {Value:{RskConfirmations:map[1:2 3:4] BtcConfirmations:map[5:6 7:8] PublicLiquidityCheck:false MaxLiquidity:123 ExcessTolerance:{IsFixed:true PercentageValue:10 FixedValue:555}} Signature:general signature Hash:general hash}"
 		client, collection := getClientAndCollectionMocks(mongo.LiquidityProviderCollection)
 		repo := mongo.NewLiquidityProviderRepository(mongo.NewConnection(client, time.Duration(1)))
 		collection.On("FindOne", mock.Anything, filter).
@@ -276,7 +281,7 @@ func TestLpMongoRepository_UpsertGeneralConfiguration(t *testing.T) {
 	configName := mongo.ConfigurationName("general")
 	filter := bson.D{primitive.E{Key: "name", Value: configName}}
 	t.Run("general configuration upserted successfully", func(t *testing.T) {
-		const expectedLog = "INSERT interaction with db: {Signed:{Value:{RskConfirmations:map[1:2 3:4] BtcConfirmations:map[5:6 7:8] PublicLiquidityCheck:false MaxLiquidity:123} Signature:general signature Hash:general hash} Name:general}"
+		const expectedLog = "INSERT interaction with db: {Signed:{Value:{RskConfirmations:map[1:2 3:4] BtcConfirmations:map[5:6 7:8] PublicLiquidityCheck:false MaxLiquidity:123 ExcessTolerance:{IsFixed:true PercentageValue:10 FixedValue:555}} Signature:general signature Hash:general hash} Name:general}"
 		client, collection := getClientAndCollectionMocks(mongo.LiquidityProviderCollection)
 		repo := mongo.NewLiquidityProviderRepository(mongo.NewConnection(client, time.Duration(1)))
 		collection.On("ReplaceOne", mock.Anything, filter, mongo.StoredConfiguration[liquidity_provider.GeneralConfiguration]{

--- a/internal/adapters/dataproviders/liquidity_provider_test.go
+++ b/internal/adapters/dataproviders/liquidity_provider_test.go
@@ -669,9 +669,14 @@ func getGeneralConfigurationMock() *entities.Signed[liquidity_provider.GeneralCo
 			},
 			PublicLiquidityCheck: false,
 			MaxLiquidity:         entities.NewWei(100000000000000000),
+			ExcessTolerance: liquidity_provider.ExcessTolerance{
+				IsFixed:         true,
+				PercentageValue: utils.NewBigFloat64(10),
+				FixedValue:      entities.NewWei(20),
+			},
 		},
-		Signature: "034a913d067f54f3c096d569f7913836f7d451a81f3fb6cbfbe0177758a1c22603173d0c26c0a3507310fad61bd7275e5b326eb7f3ccfb56d8b13bbab8d8a32100",
-		Hash:      "89b4fbdf620883d99d77324428f5375e2baf4b05c10d12f2a6ee81a5ea0cc956",
+		Signature: "df95db8df35ee48ddfd8a5a297d2037abbd776f855014b45c4fd4abbfafad32c294adf5cef677b1d7448679b8e578d51a73da9c6956a32fd1161393db4e63a0200",
+		Hash:      "c5bbc996d4f36f6d538cfdc2337e14886d03e8cafd75d4965ff4aa066ce2ae38",
 	}
 }
 func getPeginConfigurationMock() *entities.Signed[liquidity_provider.PeginConfiguration] {

--- a/internal/adapters/entrypoints/rest/handlers/set_general_config.go
+++ b/internal/adapters/entrypoints/rest/handlers/set_general_config.go
@@ -37,7 +37,7 @@ func NewSetGeneralConfigHandler(useCase SetGeneralConfigUseCase) http.HandlerFun
 		}
 
 		err = useCase.Run(req.Context(), config)
-		if errors.Is(err, liquidity_provider.AmountOutOfRangeError) {
+		if errors.Is(err, liquidity_provider.AmountOutOfRangeError) || errors.Is(err, liquidity_provider.InvalidConfigurationError) {
 			jsonErr := rest.NewErrorResponseWithDetails("Invalid configuration", rest.DetailsFromError(err), true)
 			rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
 			return

--- a/internal/entities/common_test.go
+++ b/internal/entities/common_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// nolint:funlen
 func TestSigned_CheckIntegrity(t *testing.T) {
 	peginConfig := liquidity_provider.PeginConfiguration{
 		TimeForDeposit: 3600,
@@ -53,6 +54,11 @@ func TestSigned_CheckIntegrity(t *testing.T) {
 		},
 		PublicLiquidityCheck: true,
 		MaxLiquidity:         entities.NewUWei(10000000000000000000),
+		ExcessTolerance: liquidity_provider.ExcessTolerance{
+			IsFixed:         true,
+			PercentageValue: utils.NewBigFloat64(20),
+			FixedValue:      entities.NewWei(111),
+		},
 	}
 
 	tests := []struct {
@@ -61,7 +67,7 @@ func TestSigned_CheckIntegrity(t *testing.T) {
 	}{
 		{signed: entities.Signed[any]{Value: peginConfig, Hash: "5ab75cad18e0ad640908a3b70d6bf2e3cdca66bb53544e91833c942c4f5430af"}},
 		{signed: entities.Signed[any]{Value: pegoutConfig, Hash: "35a51729bb71bb891db62dd968f33ea2479ddb17143da32ca6bb55142a488052"}},
-		{signed: entities.Signed[any]{Value: generalConfig, Hash: "9765cfc5c4ba0fa42bc6617149fff51c65a7a3d7fa8667fefa4c36564067c080"}},
+		{signed: entities.Signed[any]{Value: generalConfig, Hash: "e39fa24d7358d9800f5d91d6f3cc3e8c761b7560cd7127932dfebbddbe90ac19"}},
 		{signed: entities.Signed[any]{Value: peginConfig, Hash: "f3daab424654d2eeb2b50dc00b3e453e24ca1c690d80015f5f54d5f1fefaf900"}, err: entities.IntegrityError},
 		{signed: entities.Signed[any]{Value: pegoutConfig, Hash: "3b3e7b075eb60b8c249f44a117f406c64992bafda1273f540277448abd14077e"}, err: entities.IntegrityError},
 		{signed: entities.Signed[any]{Value: generalConfig, Hash: "3fecc42296c21a63dff80885f972ea88caf5038e47f014b1c91bb9b80529b757"}, err: entities.IntegrityError},

--- a/internal/entities/liquidity_provider/default.go
+++ b/internal/entities/liquidity_provider/default.go
@@ -6,7 +6,10 @@ import (
 )
 
 const (
-	DefaultMaxLiquidity = 1000000000000000000
+	DefaultMaxLiquidity                   = 1000000000000000000
+	DefaultExcessToleranceIsFixed         = false
+	DefaultExcessTolerancePercentageValue = 20
+	DefaultExcessToleranceFixedValue      = 100000000000000000
 )
 
 const (
@@ -83,5 +86,10 @@ func DefaultGeneralConfiguration() GeneralConfiguration {
 		BtcConfirmations:     DefaultBtcConfirmationsPerAmount(),
 		PublicLiquidityCheck: false,
 		MaxLiquidity:         entities.NewWei(DefaultMaxLiquidity),
+		ExcessTolerance: ExcessTolerance{
+			IsFixed:         DefaultExcessToleranceIsFixed,
+			PercentageValue: utils.NewBigFloat64(DefaultExcessTolerancePercentageValue),
+			FixedValue:      entities.NewWei(DefaultExcessToleranceFixedValue),
+		},
 	}
 }

--- a/internal/entities/liquidity_provider/default_test.go
+++ b/internal/entities/liquidity_provider/default_test.go
@@ -75,5 +75,10 @@ func TestDefaultGeneralConfiguration(t *testing.T) {
 		BtcConfirmations:     liquidity_provider.DefaultBtcConfirmationsPerAmount(),
 		PublicLiquidityCheck: false,
 		MaxLiquidity:         entities.NewWei(1000000000000000000),
+		ExcessTolerance: liquidity_provider.ExcessTolerance{
+			IsFixed:         false,
+			PercentageValue: utils.NewBigFloat64(20),
+			FixedValue:      entities.NewWei(100000000000000000),
+		},
 	}, config)
 }

--- a/internal/entities/liquidity_provider/liquidity_provider_test.go
+++ b/internal/entities/liquidity_provider/liquidity_provider_test.go
@@ -3,6 +3,7 @@ package liquidity_provider_test
 import (
 	"encoding/hex"
 	"errors"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/utils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 
@@ -92,8 +93,13 @@ func TestValidateConfiguration(t *testing.T) {
 			},
 			PublicLiquidityCheck: true,
 			MaxLiquidity:         entities.NewWei(1000000),
+			ExcessTolerance: liquidity_provider.ExcessTolerance{
+				IsFixed:         true,
+				PercentageValue: utils.NewBigFloat64(20),
+				FixedValue:      entities.NewWei(1234),
+			},
 		}
-		mockConfigBytes := []byte(`{"rskConfirmations":{"10":100,"20":200},"btcConfirmations":{"10":5,"20":10},"publicLiquidityCheck":true,"maxLiquidity":1000000}`)
+		mockConfigBytes := []byte(`{"rskConfirmations":{"10":100,"20":200},"btcConfirmations":{"10":5,"20":10},"publicLiquidityCheck":true,"maxLiquidity":1000000,"excessTolerance":{"isFixed":true,"percentageValue":20,"fixedValue":1234}}`)
 
 		hash := ethcrypto.Keccak256(mockConfigBytes)
 		hashHex := hex.EncodeToString(hash)
@@ -129,6 +135,9 @@ func TestValidateConfiguration(t *testing.T) {
 		require.Equal(t, mockConfig.BtcConfirmations, result.Value.BtcConfirmations)
 		require.Equal(t, mockConfig.PublicLiquidityCheck, result.Value.PublicLiquidityCheck)
 		require.Equal(t, mockConfig.MaxLiquidity, result.Value.MaxLiquidity)
+		require.Equal(t, mockConfig.ExcessTolerance.FixedValue, result.Value.ExcessTolerance.FixedValue)
+		require.Equal(t, mockConfig.ExcessTolerance.IsFixed, result.Value.ExcessTolerance.IsFixed)
+		require.Equal(t, mockConfig.ExcessTolerance.PercentageValue, result.Value.ExcessTolerance.PercentageValue)
 		require.Equal(t, hashHex, result.Hash)
 		require.Equal(t, signatureHex, result.Signature)
 
@@ -187,8 +196,13 @@ func TestValidateConfiguration(t *testing.T) {
 			},
 			PublicLiquidityCheck: true,
 			MaxLiquidity:         entities.NewWei(1000000),
+			ExcessTolerance: liquidity_provider.ExcessTolerance{
+				IsFixed:         true,
+				PercentageValue: utils.NewBigFloat64(20),
+				FixedValue:      entities.NewWei(1234),
+			},
 		}
-		mockConfigBytes := []byte(`{"rskConfirmations":{"10":100,"20":200},"btcConfirmations":{"10":5,"20":10},"publicLiquidityCheck":true,"maxLiquidity":1000000}`)
+		mockConfigBytes := []byte(`{"rskConfirmations":{"10":100,"20":200},"btcConfirmations":{"10":5,"20":10},"publicLiquidityCheck":true,"maxLiquidity":1000000,"excessTolerance":{"isFixed":true,"percentageValue":20,"fixedValue":1234}}`)
 
 		hash := ethcrypto.Keccak256(mockConfigBytes)
 		hashHex := hex.EncodeToString(hash)

--- a/internal/usecases/liquidity_provider/set_general_config.go
+++ b/internal/usecases/liquidity_provider/set_general_config.go
@@ -42,7 +42,10 @@ func (useCase *SetGeneralConfigUseCase) Run(ctx context.Context, config liquidit
 	if err := useCase.validateMaxLiquidity(ctx, config.MaxLiquidity); err != nil {
 		return err
 	}
-
+	config.ExcessTolerance.Normalize()
+	if err := config.ExcessTolerance.Validate(); err != nil {
+		return usecases.WrapUseCaseError(usecases.SetGeneralConfigId, err)
+	}
 	signedConfig, err := usecases.SignConfiguration(usecases.SetGeneralConfigId, useCase.signer, useCase.hashFunc, config)
 	if err != nil {
 		return err

--- a/internal/usecases/liquidity_provider/set_general_config_test.go
+++ b/internal/usecases/liquidity_provider/set_general_config_test.go
@@ -2,6 +2,8 @@ package liquidity_provider_test
 
 import (
 	"context"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/utils"
+	"math/big"
 	"testing"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
@@ -22,6 +24,11 @@ func TestSetGeneralConfigUseCase_Run(t *testing.T) {
 			BtcConfirmations:     map[string]uint16{"10": 20},
 			PublicLiquidityCheck: true,
 			MaxLiquidity:         entities.NewWei(100),
+			ExcessTolerance: lp.ExcessTolerance{
+				IsFixed:         false,
+				PercentageValue: utils.NewBigFloat64(15),
+				FixedValue:      entities.NewWei(0),
+			},
 		},
 		Signature: "010203",
 		Hash:      "040506",
@@ -53,6 +60,11 @@ func TestSetGeneralConfigUseCase_Run_ErrorHandling(t *testing.T) {
 			RskConfirmations: map[string]uint16{"5": 10},
 			BtcConfirmations: map[string]uint16{"10": 20},
 			MaxLiquidity:     entities.NewWei(100),
+			ExcessTolerance: lp.ExcessTolerance{
+				IsFixed:         false,
+				PercentageValue: utils.NewBigFloat64(15),
+				FixedValue:      entities.NewWei(0),
+			},
 		},
 		Signature: "010203",
 		Hash:      "040506",
@@ -144,6 +156,11 @@ func TestSetGeneralConfigUseCase_Run_ValidateMaxLiquidity(t *testing.T) {
 			RskConfirmations: map[string]uint16{"5": 10},
 			BtcConfirmations: map[string]uint16{"10": 20},
 			MaxLiquidity:     entities.NewWei(-100),
+			ExcessTolerance: lp.ExcessTolerance{
+				IsFixed:         false,
+				PercentageValue: utils.NewBigFloat64(15),
+				FixedValue:      entities.NewWei(0),
+			},
 		}
 
 		err := useCase.Run(context.Background(), config)
@@ -163,10 +180,83 @@ func TestSetGeneralConfigUseCase_Run_ValidateMaxLiquidity(t *testing.T) {
 			RskConfirmations: map[string]uint16{"5": 10},
 			BtcConfirmations: map[string]uint16{"10": 20},
 			MaxLiquidity:     entities.NewWei(1),
+			ExcessTolerance: lp.ExcessTolerance{
+				IsFixed:         false,
+				PercentageValue: utils.NewBigFloat64(15),
+				FixedValue:      entities.NewWei(0),
+			},
 		}
 
 		err := useCase.Run(context.Background(), config)
 		require.ErrorIs(t, err, lp.AmountOutOfRangeError)
 		require.ErrorContains(t, err, "maxLiquidity 1 is not enough to support one minimum pegin and pegout (3)")
+	})
+}
+
+// nolint:funlen
+func TestSetGeneralConfigUseCase_Run_ValidateExcessTolerance(t *testing.T) {
+	t.Run("should normalize excess tolerance", func(t *testing.T) {
+		config := entities.Signed[lp.GeneralConfiguration]{
+			Value: lp.GeneralConfiguration{
+				RskConfirmations: map[string]uint16{"5": 10}, BtcConfirmations: map[string]uint16{"10": 20},
+				PublicLiquidityCheck: true, MaxLiquidity: entities.NewWei(100),
+				ExcessTolerance: lp.ExcessTolerance{IsFixed: false, PercentageValue: utils.NewBigFloat64(15), FixedValue: entities.NewWei(10)},
+			},
+		}
+		lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+		lpRepository.On("UpsertGeneralConfiguration", mock.Anything, mock.MatchedBy(func(c entities.Signed[lp.GeneralConfiguration]) bool {
+			return c.Value.ExcessTolerance.PercentageValue.Native().Cmp(big.NewFloat(15)) <= 0 &&
+				c.Value.ExcessTolerance.FixedValue.Cmp(entities.NewWei(0)) == 0
+		})).Return(nil)
+		walletMock := &mocks.RskWalletMock{}
+		walletMock.On("SignBytes", mock.Anything).Return([]byte{1, 2, 3}, nil)
+		hashMock := &mocks.HashMock{}
+		hashMock.On("Hash", mock.Anything).Return([]byte{4, 5, 6})
+		providerMock := &mocks.ProviderMock{}
+		providerMock.On("PeginConfiguration", mock.Anything).Return(peginConfigMock.Value)
+		providerMock.On("PegoutConfiguration", mock.Anything).Return(pegoutConfigMock.Value)
+		useCase := liquidity_provider.NewSetGeneralConfigUseCase(lpRepository, providerMock, providerMock, walletMock, hashMock.Hash)
+		err := useCase.Run(context.Background(), config.Value)
+		require.NoError(t, err)
+	})
+	t.Run("should return error if excess tolerance is fixed but fixed value is 0", func(t *testing.T) {
+		config := entities.Signed[lp.GeneralConfiguration]{
+			Value: lp.GeneralConfiguration{
+				RskConfirmations: map[string]uint16{"5": 10}, BtcConfirmations: map[string]uint16{"10": 20},
+				PublicLiquidityCheck: true, MaxLiquidity: entities.NewWei(100),
+				ExcessTolerance: lp.ExcessTolerance{IsFixed: true, PercentageValue: utils.NewBigFloat64(15), FixedValue: entities.NewWei(0)},
+			},
+		}
+		lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+		walletMock := &mocks.RskWalletMock{}
+		walletMock.On("SignBytes", mock.Anything).Return([]byte{1, 2, 3}, nil)
+		hashMock := &mocks.HashMock{}
+		hashMock.On("Hash", mock.Anything).Return([]byte{4, 5, 6})
+		providerMock := &mocks.ProviderMock{}
+		providerMock.On("PeginConfiguration", mock.Anything).Return(peginConfigMock.Value)
+		providerMock.On("PegoutConfiguration", mock.Anything).Return(pegoutConfigMock.Value)
+		useCase := liquidity_provider.NewSetGeneralConfigUseCase(lpRepository, providerMock, providerMock, walletMock, hashMock.Hash)
+		err := useCase.Run(context.Background(), config.Value)
+		require.ErrorIs(t, err, lp.InvalidConfigurationError)
+	})
+	t.Run("should return error if excess tolerance is a percentage but percentage value is 0", func(t *testing.T) {
+		config := entities.Signed[lp.GeneralConfiguration]{
+			Value: lp.GeneralConfiguration{
+				RskConfirmations: map[string]uint16{"5": 10}, BtcConfirmations: map[string]uint16{"10": 20},
+				PublicLiquidityCheck: true, MaxLiquidity: entities.NewWei(100),
+				ExcessTolerance: lp.ExcessTolerance{IsFixed: false, PercentageValue: utils.NewBigFloat64(0), FixedValue: entities.NewWei(10)},
+			},
+		}
+		lpRepository := &mocks.LiquidityProviderRepositoryMock{}
+		walletMock := &mocks.RskWalletMock{}
+		walletMock.On("SignBytes", mock.Anything).Return([]byte{1, 2, 3}, nil)
+		hashMock := &mocks.HashMock{}
+		hashMock.On("Hash", mock.Anything).Return([]byte{4, 5, 6})
+		providerMock := &mocks.ProviderMock{}
+		providerMock.On("PeginConfiguration", mock.Anything).Return(peginConfigMock.Value)
+		providerMock.On("PegoutConfiguration", mock.Anything).Return(pegoutConfigMock.Value)
+		useCase := liquidity_provider.NewSetGeneralConfigUseCase(lpRepository, providerMock, providerMock, walletMock, hashMock.Hash)
+		err := useCase.Run(context.Background(), config.Value)
+		require.ErrorIs(t, err, lp.InvalidConfigurationError)
 	})
 }

--- a/pkg/liquidity_provider.go
+++ b/pkg/liquidity_provider.go
@@ -78,10 +78,17 @@ type GeneralConfigurationRequest struct {
 }
 
 type GeneralConfigurationDTO struct {
-	RskConfirmations     map[string]uint16 `json:"rskConfirmations" validate:"required,confirmations_map"`
-	BtcConfirmations     map[string]uint16 `json:"btcConfirmations" validate:"required,confirmations_map"`
-	PublicLiquidityCheck bool              `json:"publicLiquidityCheck" validate:""`
-	MaxLiquidity         string            `json:"maxLiquidity" validate:"required,numeric,positive_string"`
+	RskConfirmations     map[string]uint16  `json:"rskConfirmations" validate:"required,confirmations_map"`
+	BtcConfirmations     map[string]uint16  `json:"btcConfirmations" validate:"required,confirmations_map"`
+	PublicLiquidityCheck bool               `json:"publicLiquidityCheck" validate:""`
+	MaxLiquidity         string             `json:"maxLiquidity" validate:"required,numeric,positive_string"`
+	ExcessTolerance      ExcessToleranceDTO `json:"excessTolerance" validate:"required"`
+}
+
+type ExcessToleranceDTO struct {
+	IsFixed         bool     `json:"isFixed"`
+	PercentageValue *float64 `json:"percentageValue" validate:"required,numeric,gte=0,lte=100,max_decimal_places=2"`
+	FixedValue      string   `json:"fixedValue" validate:"required,numeric,excludes=-"`
 }
 
 type LoginRequest struct {
@@ -477,10 +484,22 @@ func FromGeneralConfigurationDTO(dto GeneralConfigurationDTO) (liquidity_provide
 	if !ok {
 		return liquidity_provider.GeneralConfiguration{}, fmt.Errorf("cannot deserialize max liquidity %s", dto.MaxLiquidity)
 	}
+	excessToleranceFixedValue, ok := new(big.Int).SetString(dto.ExcessTolerance.FixedValue, 10)
+	if !ok {
+		return liquidity_provider.GeneralConfiguration{}, fmt.Errorf("cannot deserialize excess tolerance fixed value %s", dto.ExcessTolerance.FixedValue)
+	}
+	if dto.ExcessTolerance.PercentageValue == nil {
+		return liquidity_provider.GeneralConfiguration{}, errors.New("excess tolerance percentage value is nil")
+	}
 	return liquidity_provider.GeneralConfiguration{
 		MaxLiquidity:         entities.NewBigWei(maxLiquidity),
 		RskConfirmations:     dto.RskConfirmations,
 		BtcConfirmations:     dto.BtcConfirmations,
 		PublicLiquidityCheck: dto.PublicLiquidityCheck,
+		ExcessTolerance: liquidity_provider.ExcessTolerance{
+			IsFixed:         dto.ExcessTolerance.IsFixed,
+			PercentageValue: utils.NewBigFloat64(*dto.ExcessTolerance.PercentageValue),
+			FixedValue:      entities.NewBigWei(excessToleranceFixedValue),
+		},
 	}, nil
 }


### PR DESCRIPTION
## What
Add excess tolerance configuration to general configuration

## Why
So the LP is able to set the max amount to gather before paying to the cold wallet

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [x] Management UI / API
- [ ] PegIn flow
- [ ] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2157)

## How to test
There's no new endpoint, but the tests for POST `/configuration` need to be updated
```
curl --location 'http://localhost:8080/configuration' \
--header 'X-Csrf-Token: <token>' \
--header 'Content-Type: application/json' \
--data '{
    "configuration": {
        "rskConfirmations": {
            "100000000000000000": 4,
            "2000000000000000000": 10,
            "400000000000000000": 5,
            "4000000000000000000": 40,
            "8000000000000000000": 80
        },
        "btcConfirmations": {
            "100000000000000000": 2,
            "2000000000000000000": 10,
            "400000000000000000": 6,
            "4000000000000000000": 20,
            "8000000000000000000": 40
        },
        "publicLiquidityCheck": true,
        "maxLiquidity": "8000000000000000000",
        "excessTolerance": {
            "isFixed": false,
            "fixedValue": "100",
            "percentageValue": 1
        }
    }
}'
```