### PR TITLE
fix: Fly2171/ remove bridge minimum validation from recommended pegout

### DIFF
--- a/internal/adapters/entrypoints/rest/handlers/recommended_pegout.go
+++ b/internal/adapters/entrypoints/rest/handlers/recommended_pegout.go
@@ -3,14 +3,15 @@ package handlers
 import (
 	"context"
 	"errors"
+	"math/big"
+	"net/http"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/pkg"
-	"math/big"
-	"net/http"
 )
 
 type RecommendedPegoutUseCase interface {
@@ -53,7 +54,6 @@ func NewRecommendedPegoutHandler(useCase RecommendedPegoutUseCase) http.HandlerF
 		result, err := useCase.Run(r.Context(), entities.NewBigWei(parsedAmount), parsedDestinationType)
 
 		if errors.Is(err, usecases.NoLiquidityError) ||
-			errors.Is(err, usecases.TxBelowMinimumError) ||
 			errors.Is(err, liquidity_provider.AmountOutOfRangeError) {
 			jsonErr := rest.NewErrorResponse(err.Error(), true)
 			rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)

--- a/internal/adapters/entrypoints/rest/handlers/recommended_pegout_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/recommended_pegout_test.go
@@ -1,6 +1,10 @@
 package handlers_test
 
 import (
+	"net/http"
+	"net/url"
+	"testing"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest/handlers"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
@@ -9,9 +13,6 @@ import (
 	"github.com/rsksmart/liquidity-provider-server/test/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"net/http"
-	"net/url"
-	"testing"
 )
 
 func TestNewRecommendedPegoutHandler(t *testing.T) {
@@ -56,12 +57,6 @@ func TestNewRecommendedPegoutHandler(t *testing.T) {
 	t.Run("should return 400 if there is no liquidity for the recommended amount", func(t *testing.T) {
 		useCase := new(mocks.RecommendedPegoutUseCaseMock)
 		useCase.EXPECT().Run(mock.Anything, mock.Anything, mock.Anything).Return(usecases.RecommendedOperationResult{}, usecases.NoLiquidityError)
-		handler := handlers.NewRecommendedPegoutHandler(useCase)
-		assert.HTTPStatusCode(t, handler, http.MethodGet, path, queryFull, http.StatusBadRequest)
-	})
-	t.Run("should return 400 if the recommended amount is below the bridge minimum", func(t *testing.T) {
-		useCase := new(mocks.RecommendedPegoutUseCaseMock)
-		useCase.EXPECT().Run(mock.Anything, mock.Anything, mock.Anything).Return(usecases.RecommendedOperationResult{}, usecases.TxBelowMinimumError)
 		handler := handlers.NewRecommendedPegoutHandler(useCase)
 		assert.HTTPStatusCode(t, handler, http.MethodGet, path, queryFull, http.StatusBadRequest)
 	})

--- a/internal/usecases/pegout/recommended_pegout.go
+++ b/internal/usecases/pegout/recommended_pegout.go
@@ -3,12 +3,13 @@ package pegout
 import (
 	"context"
 	"fmt"
+	"math/big"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/utils"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
-	"math/big"
 )
 
 type RecommendedPegoutUseCase struct {
@@ -196,9 +197,5 @@ func (useCase *RecommendedPegoutUseCase) validateRecommendedValue(
 		return usecases.WrapUseCaseError(usecases.RecommendedPegoutId, usecases.NoLiquidityError)
 	}
 
-	if err = usecases.ValidateMinLockValue(usecases.RecommendedPegoutId, useCase.contracts.Bridge, entities.NewBigWei(result)); err != nil {
-		err = fmt.Errorf("recommended amount %s is below the minimum lock value: %w", entities.NewBigWei(result).String(), err)
-		return err
-	}
 	return nil
 }

--- a/internal/usecases/pegout/recommended_pegout_test.go
+++ b/internal/usecases/pegout/recommended_pegout_test.go
@@ -2,6 +2,8 @@ package pegout_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
@@ -13,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // nolint:funlen
@@ -105,15 +106,29 @@ func TestRecommendedPegoutUseCase_Run(t *testing.T) {
 		require.ErrorIs(t, err, usecases.NoLiquidityError)
 		assert.Empty(t, result)
 	})
-	t.Run("should validate recommended amount is over bridge minimum", func(t *testing.T) {
+	t.Run("should succeed when recommended amount is below bridge minimum", func(t *testing.T) {
 		btc.On("GetZeroAddress", mock.Anything).Return(blockchain.BitcoinTestnetP2PKHZeroAddress, nil).Once()
 		highMinimumBridge := new(mocks.BridgeMock)
 		highMinimumBridge.On("GetMinimumLockTxValue").Return(new(entities.Wei).Add(entities.NewWei(1), createdQuote.PegoutQuote.Total()), nil)
-		contracts.Bridge = highMinimumBridge
-		useCase := pegout.NewRecommendedPegoutUseCase(lp, contracts, rpc, btcWallet, utils.Scale, test.AnyRskAddress)
+		modifiedContracts := blockchain.RskContracts{PegOut: pegoutContract, Bridge: highMinimumBridge}
+		useCase := pegout.NewRecommendedPegoutUseCase(lp, modifiedContracts, rpc, btcWallet, utils.Scale, test.AnyRskAddress)
 		result, err = useCase.Run(context.Background(), createdQuote.PegoutQuote.Total(), blockchain.BtcAddressTypeP2PKH)
-		require.ErrorIs(t, err, usecases.TxBelowMinimumError)
-		assert.Empty(t, result)
+		// Should succeed despite being below bridge minimum
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+		assert.Equal(t, createdQuote.PegoutQuote.Value, result.RecommendedQuoteValue)
+	})
+	t.Run("should succeed when recommended amount equals bridge minimum", func(t *testing.T) {
+		btc.On("GetZeroAddress", mock.Anything).Return(blockchain.BitcoinTestnetP2PKHZeroAddress, nil).Once()
+		// Set bridge minimum equal to the recommended amount
+		equalMinimumBridge := new(mocks.BridgeMock)
+		equalMinimumBridge.On("GetMinimumLockTxValue").Return(createdQuote.PegoutQuote.Total(), nil)
+		modifiedContracts := blockchain.RskContracts{PegOut: pegoutContract, Bridge: equalMinimumBridge}
+		useCase := pegout.NewRecommendedPegoutUseCase(lp, modifiedContracts, rpc, btcWallet, utils.Scale, test.AnyRskAddress)
+		result, err = useCase.Run(context.Background(), createdQuote.PegoutQuote.Total(), blockchain.BtcAddressTypeP2PKH)
+		require.NoError(t, err)
+		assert.NotEmpty(t, result)
+		assert.Equal(t, createdQuote.PegoutQuote.Value, result.RecommendedQuoteValue)
 	})
 }
 


### PR DESCRIPTION
## What
Currently the LPS validates that the recommended amount of a pegout is above the bridge minimum. This is a validation that makes sense for pegin but not for pegout. This PR removes that validation.

## Why
Remove unnecessary validations

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [x] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[FLY-2171](https://rsklabs.atlassian.net/browse/FLY-2171)

## How to test
-Start the LPS in local env
-Authenticate in the management console.
-Configure a minimum of pegout below the minimum of the bridge. Typically the bridge minimum in local env is 0.005.
-Call the recommended pegout with a low value like 
[GET /pegout/recommended?amount=3000000000000000&destination_type=p2pkh](http://localhost:8080/pegout/recommended?amount=3000000000000000&destination_type=p2pkh)
-The endpoint should not return error.

## Screenshots
<img width="1596" height="452" alt="image" src="https://github.com/user-attachments/assets/7e9b88ab-a29b-4af8-8e9e-f04d84fcecf8" />
