### PR TITLE
fly2189: Fix financial API bug on /reports/transactions

### DIFF
--- a/internal/adapters/dataproviders/database/mongo/pegin.go
+++ b/internal/adapters/dataproviders/database/mongo/pegin.go
@@ -12,7 +12,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const (
@@ -37,6 +36,13 @@ type StoredPeginQuote struct {
 type StoredPeginCreationData struct {
 	quote.PeginCreationData `bson:",inline"`
 	Hash                    string `json:"hash" bson:"hash"`
+}
+
+// peginQuoteWithRetainedAggDoc decodes pegin quote aggregation rows after $lookup and $unwind on "retained"
+// (e.g. ListQuotesByDateRange, GetQuotesWithRetainedByStateAndDate).
+type peginQuoteWithRetainedAggDoc struct {
+	StoredPeginQuote `bson:",inline"`
+	Retained         quote.RetainedPeginQuote `bson:"retained"`
 }
 
 func (repo *peginMongoRepository) InsertQuote(ctx context.Context, createdQuote quote.CreatedPeginQuote) error {
@@ -313,120 +319,108 @@ func (repo *peginMongoRepository) ListQuotesByDateRange(ctx context.Context, sta
 	dbCtx, cancel := context.WithTimeout(ctx, repo.conn.timeout)
 	defer cancel()
 
-	// Fetch quotes with pagination
-	storedQuotes, err := repo.fetchQuotesByDateRange(dbCtx, startDate, endDate, page, perPage)
+	dateMatch := repo.listQuotesByDateRangeDateMatch(startDate, endDate)
+	total, err := repo.countQuotesWithRetainedInDateRange(dbCtx, dateMatch)
 	if err != nil {
 		return nil, 0, err
 	}
-
-	if len(storedQuotes) == 0 {
-		result := make([]quote.PeginQuoteWithRetained, 0)
-		logDbInteraction(Read, result)
-		return result, 0, nil
+	if total == 0 {
+		empty := make([]quote.PeginQuoteWithRetained, 0)
+		logDbInteraction(Read, empty)
+		return empty, 0, nil
 	}
 
-	// Build initial result structure with quotes
-	result, quoteHashes := repo.buildQuoteResults(storedQuotes)
+	dataPipeline := append(repo.listQuotesByDateRangePipelinePrefix(dateMatch),
+		bson.D{{Key: "$unwind", Value: "$retained"}},
+		bson.D{{Key: "$sort", Value: bson.D{{Key: "agreement_timestamp", Value: SortAscending}}}},
+	)
+	if page > 0 && perPage > 0 {
+		skip := int64((page - 1) * perPage)
+		dataPipeline = append(dataPipeline,
+			bson.D{{Key: "$skip", Value: skip}},
+			bson.D{{Key: "$limit", Value: int64(perPage)}},
+		)
+	}
 
-	// Fetch and merge retained quotes
-	if err := repo.mergeRetainedQuotes(dbCtx, result, quoteHashes); err != nil {
-		return result, len(result), err
+	dataCursor, err := repo.conn.Collection(PeginQuoteCollection).Aggregate(dbCtx, dataPipeline)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer dataCursor.Close(dbCtx)
+
+	var result []quote.PeginQuoteWithRetained
+	for dataCursor.Next(dbCtx) {
+		var doc peginQuoteWithRetainedAggDoc
+		if err := dataCursor.Decode(&doc); err != nil {
+			return nil, 0, err
+		}
+		doc.Retained.FillZeroValues()
+		result = append(result, quote.PeginQuoteWithRetained{
+			Quote:         doc.PeginQuote,
+			RetainedQuote: doc.Retained,
+		})
+	}
+	if err := dataCursor.Err(); err != nil {
+		return nil, 0, err
 	}
 
 	logDbInteraction(Read, len(result))
-	return result, len(result), nil
+	return result, total, nil
 }
 
-func (repo *peginMongoRepository) fetchQuotesByDateRange(ctx context.Context, startDate, endDate time.Time, page, perPage int) ([]StoredPeginQuote, error) {
-	quoteFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
+func (repo *peginMongoRepository) listQuotesByDateRangeDateMatch(startDate, endDate time.Time) bson.D {
+	return bson.D{{Key: "agreement_timestamp", Value: bson.D{
 		{Key: "$gte", Value: startDate.Unix()},
 		{Key: "$lte", Value: endDate.Unix()},
 	}}}
-
-	findOpts := repo.buildFindOptions(page, perPage)
-
-	quoteCursor, err := repo.conn.Collection(PeginQuoteCollection).Find(ctx, quoteFilter, findOpts)
-	if err != nil {
-		return nil, err
-	}
-
-	var storedQuotes []StoredPeginQuote
-	if err = quoteCursor.All(ctx, &storedQuotes); err != nil {
-		return nil, err
-	}
-
-	return storedQuotes, nil
 }
 
-func (repo *peginMongoRepository) buildFindOptions(page, perPage int) *options.FindOptions {
-	findOpts := options.Find().SetSort(bson.D{{Key: "agreement_timestamp", Value: SortAscending}})
-
-	// Apply pagination if page and perPage are provided (not 0)
-	// When page=0 and perPage=0, return all results
-	if page > 0 && perPage > 0 {
-		skip := (page - 1) * perPage
-		findOpts.SetSkip(int64(skip)).SetLimit(int64(perPage))
-	}
-
-	return findOpts
+func (repo *peginMongoRepository) listQuotesByDateRangeLookupStage() bson.D {
+	return bson.D{{Key: "$lookup", Value: bson.D{
+		{Key: "from", Value: RetainedPeginQuoteCollection},
+		{Key: "localField", Value: "hash"},
+		{Key: "foreignField", Value: "quote_hash"},
+		{Key: "as", Value: "retained"},
+	}}}
 }
 
-func (repo *peginMongoRepository) buildQuoteResults(storedQuotes []StoredPeginQuote) ([]quote.PeginQuoteWithRetained, []string) {
-	result := make([]quote.PeginQuoteWithRetained, len(storedQuotes))
-	quoteHashes := make([]string, len(storedQuotes))
-
-	for i, stored := range storedQuotes {
-		quoteHashes[i] = stored.Hash
-		result[i] = quote.PeginQuoteWithRetained{
-			Quote:         stored.PeginQuote,
-			RetainedQuote: quote.RetainedPeginQuote{},
-		}
-	}
-
-	return result, quoteHashes
+func (repo *peginMongoRepository) listQuotesByDateRangeHasRetainedMatch() bson.D {
+	return bson.D{{Key: "$match", Value: bson.D{
+		{Key: "retained.0", Value: bson.D{{Key: "$exists", Value: true}}},
+	}}}
 }
 
-func (repo *peginMongoRepository) mergeRetainedQuotes(ctx context.Context, result []quote.PeginQuoteWithRetained, quoteHashes []string) error {
-	retainedQuotes, err := repo.fetchRetainedQuotes(ctx, quoteHashes)
-	if err != nil {
-		return err
+// listQuotesByDateRangePipelinePrefix is shared by the count and data aggregations so both apply the same filters.
+func (repo *peginMongoRepository) listQuotesByDateRangePipelinePrefix(dateMatch bson.D) mongo.Pipeline {
+	return mongo.Pipeline{
+		{{Key: "$match", Value: dateMatch}},
+		repo.listQuotesByDateRangeLookupStage(),
+		repo.listQuotesByDateRangeHasRetainedMatch(),
 	}
-
-	// Create hash to index mapping for efficient lookup
-	hashToIndex := make(map[string]int, len(quoteHashes))
-	for i, hash := range quoteHashes {
-		hashToIndex[hash] = i
-	}
-
-	// Merge retained quotes into result
-	for _, retainedQuote := range retainedQuotes {
-		if idx, exists := hashToIndex[retainedQuote.QuoteHash]; exists {
-			result[idx].RetainedQuote = retainedQuote
-		}
-	}
-
-	return nil
 }
 
-func (repo *peginMongoRepository) fetchRetainedQuotes(ctx context.Context, quoteHashes []string) ([]quote.RetainedPeginQuote, error) {
-	retainedCursor, err := repo.conn.Collection(RetainedPeginQuoteCollection).Find(
-		ctx,
-		bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: quoteHashes}}}},
+func (repo *peginMongoRepository) countQuotesWithRetainedInDateRange(ctx context.Context, dateMatch bson.D) (int, error) {
+	pipeline := append(repo.listQuotesByDateRangePipelinePrefix(dateMatch),
+		bson.D{{Key: "$count", Value: "total"}},
 	)
+	cursor, err := repo.conn.Collection(PeginQuoteCollection).Aggregate(ctx, pipeline)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
+	defer cursor.Close(ctx)
 
-	var retainedQuotes []quote.RetainedPeginQuote
-	if err = retainedCursor.All(ctx, &retainedQuotes); err != nil {
-		return nil, err
+	var out struct {
+		Total int `bson:"total"`
 	}
-
-	for i := range retainedQuotes {
-		retainedQuotes[i].FillZeroValues()
+	if cursor.Next(ctx) {
+		if err := cursor.Decode(&out); err != nil {
+			return 0, err
+		}
 	}
-
-	return retainedQuotes, nil
+	if err := cursor.Err(); err != nil {
+		return 0, err
+	}
+	return out.Total, nil
 }
 
 func (repo *peginMongoRepository) GetRetainedQuotesForAddress(ctx context.Context, address string, states ...quote.PeginState) ([]quote.RetainedPeginQuote, error) {
@@ -523,10 +517,7 @@ func (repo *peginMongoRepository) GetQuotesWithRetainedByStateAndDate(ctx contex
 
 	result := make([]quote.PeginQuoteWithRetained, 0)
 	for cursor.Next(dbCtx) {
-		var doc struct {
-			StoredPeginQuote `bson:",inline"`
-			Retained         quote.RetainedPeginQuote `bson:"retained"`
-		}
+		var doc peginQuoteWithRetainedAggDoc
 		if err := cursor.Decode(&doc); err != nil {
 			return nil, err
 		}

--- a/internal/adapters/dataproviders/database/mongo/pegin.go
+++ b/internal/adapters/dataproviders/database/mongo/pegin.go
@@ -319,108 +319,84 @@ func (repo *peginMongoRepository) ListQuotesByDateRange(ctx context.Context, sta
 	dbCtx, cancel := context.WithTimeout(ctx, repo.conn.timeout)
 	defer cancel()
 
-	dateMatch := repo.listQuotesByDateRangeDateMatch(startDate, endDate)
-	total, err := repo.countQuotesWithRetainedInDateRange(dbCtx, dateMatch)
+	cursor, err := repo.conn.Collection(PeginQuoteCollection).Aggregate(dbCtx, buildPeginListByDateRangePipeline(startDate, endDate, page, perPage))
 	if err != nil {
 		return nil, 0, err
 	}
-	if total == 0 {
-		empty := make([]quote.PeginQuoteWithRetained, 0)
-		logDbInteraction(Read, empty)
-		return empty, 0, nil
-	}
+	defer cursor.Close(dbCtx)
 
-	dataPipeline := append(repo.listQuotesByDateRangePipelinePrefix(dateMatch),
-		bson.D{{Key: "$unwind", Value: "$retained"}},
-		bson.D{{Key: "$sort", Value: bson.D{{Key: "agreement_timestamp", Value: SortAscending}}}},
-	)
-	if page > 0 && perPage > 0 {
-		skip := int64((page - 1) * perPage)
-		dataPipeline = append(dataPipeline,
-			bson.D{{Key: "$skip", Value: skip}},
-			bson.D{{Key: "$limit", Value: int64(perPage)}},
-		)
+	// $facet always produces exactly one document whose fields are the branch names,
+	// so the cursor will have at most one row.
+	var facetResult struct {
+		Metadata []struct {
+			Total int `bson:"total"`
+		} `bson:"metadata"`
+		Data []peginQuoteWithRetainedAggDoc `bson:"data"`
 	}
-
-	dataCursor, err := repo.conn.Collection(PeginQuoteCollection).Aggregate(dbCtx, dataPipeline)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer dataCursor.Close(dbCtx)
-
-	var result []quote.PeginQuoteWithRetained
-	for dataCursor.Next(dbCtx) {
-		var doc peginQuoteWithRetainedAggDoc
-		if err := dataCursor.Decode(&doc); err != nil {
+	if cursor.Next(dbCtx) {
+		if err := cursor.Decode(&facetResult); err != nil {
 			return nil, 0, err
 		}
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	// Metadata is a slice because $count inside $facet always returns an array
+	total := 0
+	if len(facetResult.Metadata) > 0 {
+		total = facetResult.Metadata[0].Total
+	}
+
+	result := make([]quote.PeginQuoteWithRetained, 0, len(facetResult.Data))
+	for _, doc := range facetResult.Data {
 		doc.Retained.FillZeroValues()
 		result = append(result, quote.PeginQuoteWithRetained{
 			Quote:         doc.PeginQuote,
 			RetainedQuote: doc.Retained,
 		})
 	}
-	if err := dataCursor.Err(); err != nil {
-		return nil, 0, err
-	}
 
 	logDbInteraction(Read, len(result))
 	return result, total, nil
 }
 
-func (repo *peginMongoRepository) listQuotesByDateRangeDateMatch(startDate, endDate time.Time) bson.D {
-	return bson.D{{Key: "agreement_timestamp", Value: bson.D{
-		{Key: "$gte", Value: startDate.Unix()},
-		{Key: "$lte", Value: endDate.Unix()},
-	}}}
-}
+func buildPeginListByDateRangePipeline(startDate, endDate time.Time, page, perPage int) mongo.Pipeline {
+	pagedRowsPipeline := mongo.Pipeline{
+		{{Key: "$unwind", Value: "$retained"}},
+		{{Key: "$sort", Value: bson.D{{Key: "agreement_timestamp", Value: SortAscending}}}},
+	}
+	if page > 0 && perPage > 0 {
+		skip := int64((page - 1) * perPage)
+		pagedRowsPipeline = append(pagedRowsPipeline,
+			bson.D{{Key: "$skip", Value: skip}},
+			bson.D{{Key: "$limit", Value: int64(perPage)}},
+		)
+	}
 
-func (repo *peginMongoRepository) listQuotesByDateRangeLookupStage() bson.D {
-	return bson.D{{Key: "$lookup", Value: bson.D{
-		{Key: "from", Value: RetainedPeginQuoteCollection},
-		{Key: "localField", Value: "hash"},
-		{Key: "foreignField", Value: "quote_hash"},
-		{Key: "as", Value: "retained"},
-	}}}
-}
-
-func (repo *peginMongoRepository) listQuotesByDateRangeHasRetainedMatch() bson.D {
-	return bson.D{{Key: "$match", Value: bson.D{
-		{Key: "retained.0", Value: bson.D{{Key: "$exists", Value: true}}},
-	}}}
-}
-
-// listQuotesByDateRangePipelinePrefix is shared by the count and data aggregations so both apply the same filters.
-func (repo *peginMongoRepository) listQuotesByDateRangePipelinePrefix(dateMatch bson.D) mongo.Pipeline {
 	return mongo.Pipeline{
-		{{Key: "$match", Value: dateMatch}},
-		repo.listQuotesByDateRangeLookupStage(),
-		repo.listQuotesByDateRangeHasRetainedMatch(),
+		{{Key: "$match", Value: bson.D{{Key: "agreement_timestamp", Value: bson.D{
+			{Key: "$gte", Value: startDate.Unix()},
+			{Key: "$lte", Value: endDate.Unix()},
+		}}}}},
+		{{Key: "$lookup", Value: bson.D{
+			{Key: "from", Value: RetainedPeginQuoteCollection},
+			{Key: "localField", Value: "hash"},
+			{Key: "foreignField", Value: "quote_hash"},
+			{Key: "as", Value: "retained"},
+		}}},
+		// Drop quotes with no retained record (i.e. quotes that were never accepted).
+		{{Key: "$match", Value: bson.D{
+			{Key: "retained.0", Value: bson.D{{Key: "$exists", Value: true}}},
+		}}},
+		// Single round-trip: count the full result set and return the requested page simultaneously.
+		{{Key: "$facet", Value: bson.D{
+			{Key: "metadata", Value: mongo.Pipeline{
+				{{Key: "$count", Value: "total"}},
+			}},
+			{Key: "data", Value: pagedRowsPipeline},
+		}}},
 	}
-}
-
-func (repo *peginMongoRepository) countQuotesWithRetainedInDateRange(ctx context.Context, dateMatch bson.D) (int, error) {
-	pipeline := append(repo.listQuotesByDateRangePipelinePrefix(dateMatch),
-		bson.D{{Key: "$count", Value: "total"}},
-	)
-	cursor, err := repo.conn.Collection(PeginQuoteCollection).Aggregate(ctx, pipeline)
-	if err != nil {
-		return 0, err
-	}
-	defer cursor.Close(ctx)
-
-	var out struct {
-		Total int `bson:"total"`
-	}
-	if cursor.Next(ctx) {
-		if err := cursor.Decode(&out); err != nil {
-			return 0, err
-		}
-	}
-	if err := cursor.Err(); err != nil {
-		return 0, err
-	}
-	return out.Total, nil
 }
 
 func (repo *peginMongoRepository) GetRetainedQuotesForAddress(ctx context.Context, address string, states ...quote.PeginState) ([]quote.RetainedPeginQuote, error) {

--- a/internal/adapters/dataproviders/database/mongo/pegin_test.go
+++ b/internal/adapters/dataproviders/database/mongo/pegin_test.go
@@ -603,11 +603,16 @@ func TestPeginMongoRepository_GetQuotes(t *testing.T) {
 	})
 }
 
+// peginListQuotesByDateRangeAggRow matches the aggregation document after $lookup and $unwind on "retained".
+type peginListQuotesByDateRangeAggRow struct {
+	mongo.StoredPeginQuote `bson:",inline"`
+	Retained               quote.RetainedPeginQuote `bson:"retained"`
+}
+
 // nolint:funlen, maintidx
 func TestPeginMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 
-	// Test data setup
 	testHash1 := "8d1ba2cb559a6ebe41f19131602467e1d939682d651b2a91e55b86bc664a6819"
 	testHash2 := "9e2cb3dc668b7fcf52f20242713578f2e1a4793e762c3b82f66c97ed775b7920"
 
@@ -630,255 +635,162 @@ func TestPeginMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	t.Run("Successfully list quotes with pagination and retained quotes", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
+		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(2)
 
-		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPeginQuoteCollection).Return(retainedCollection).Times(1)
-
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		peginCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote1, testStoredQuote2}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash1, testHash2}}}}}
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
-			Return(mongoDb.NewCursorFromDocuments([]any{testRetainedPeginQuote, testRetainedQuote2}, nil, nil)).Once()
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 2}}, nil, nil)).Once()
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{
+				peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote1, Retained: testRetainedPeginQuote},
+				peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote2, Retained: testRetainedQuote2},
+			}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
-
 		defer assertDbInteractionLog(t, "READ interaction with db: 2")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.NoError(t, err)
 		assert.Equal(t, 2, count)
 		require.Len(t, result, 2)
-
-		// Verify first quote
 		assert.Equal(t, testPeginQuote, result[0].Quote)
 		assert.Equal(t, testRetainedPeginQuote, result[0].RetainedQuote)
-
-		// Verify second quote
 		assert.Equal(t, testPeginQuote, result[1].Quote)
 		assert.Equal(t, testRetainedQuote2, result[1].RetainedQuote)
-
 		peginCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 
 	t.Run("Successfully list quotes without pagination", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
+		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(2)
 
-		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPeginQuoteCollection).Return(retainedCollection).Times(1)
-
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		// When page=0 and perPage=0, no pagination should be applied
-		peginCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote1}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash1}}}}}
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
-			Return(mongoDb.NewCursorFromDocuments([]any{testRetainedPeginQuote}, nil, nil)).Once()
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{
+				peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote1, Retained: testRetainedPeginQuote},
+			}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
-
 		defer assertDbInteractionLog(t, "READ interaction with db: 1")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 0, 0)
-
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 		require.Len(t, result, 1)
 		assert.Equal(t, testPeginQuote, result[0].Quote)
 		assert.Equal(t, testRetainedPeginQuote, result[0].RetainedQuote)
-
 		peginCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 
 	t.Run("Successfully return empty result", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-
 		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
 
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		peginCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
 			Return(mongoDb.NewCursorFromDocuments([]any{}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
-
 		defer assertDbInteractionLog(t, "READ interaction with db: []")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
-		assert.Empty(t, result)
-
+		require.Empty(t, result)
 		peginCollection.AssertExpectations(t)
 	})
 
-	t.Run("Successfully list quotes without retained quotes", func(t *testing.T) {
+	t.Run("Returns empty when quotes have no retained row", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
-
 		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPeginQuoteCollection).Return(retainedCollection).Times(1)
 
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		peginCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote1}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash1}}}}}
-		// Return empty cursor for retained quotes
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
-			Return(mongoDb.NewCursorFromDocuments([]any{}, nil, nil)).Once()
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 0}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
-
-		defer assertDbInteractionLog(t, "READ interaction with db: 1")()
+		defer assertDbInteractionLog(t, "READ interaction with db: []")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.NoError(t, err)
-		assert.Equal(t, 1, count)
-		require.Len(t, result, 1)
-		assert.Equal(t, testPeginQuote, result[0].Quote)
-		// RetainedQuote should be empty struct since no retained quote was found
-		assert.Equal(t, quote.RetainedPeginQuote{}, result[0].RetainedQuote)
-
+		assert.Equal(t, 0, count)
+		require.Empty(t, result)
 		peginCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 
-	t.Run("Error when fetching quotes from database", func(t *testing.T) {
+	t.Run("Error on count aggregation", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-
 		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
 
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		peginCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
 			Return(nil, assert.AnError).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
-
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.Error(t, err)
+		assert.Equal(t, assert.AnError, err)
 		assert.Equal(t, 0, count)
 		assert.Nil(t, result)
-
 		peginCollection.AssertExpectations(t)
 	})
 
-	t.Run("Error when fetching retained quotes", func(t *testing.T) {
+	t.Run("Error on data aggregation after successful count", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
+		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(2)
 
-		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPeginQuoteCollection).Return(retainedCollection).Times(1)
-
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		peginCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote1}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash1}}}}}
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
 			Return(nil, assert.AnError).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
-
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.Error(t, err)
-		assert.Equal(t, 1, count) // Should still return the count from quotes even if retained quotes fail
-		require.Len(t, result, 1) // Should return the partial result
-
+		assert.Equal(t, assert.AnError, err)
+		assert.Equal(t, 0, count)
+		assert.Nil(t, result)
 		peginCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 
 	t.Run("Successfully handle pagination edge cases", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
+		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(2)
 
-		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPeginQuoteCollection).Return(retainedCollection).Times(1)
-
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		// Test page 2 with perPage 1 (should skip 1 and limit 1)
-		peginCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote2}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash2}}}}}
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
-			Return(mongoDb.NewCursorFromDocuments([]any{}, nil, nil)).Once()
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 2}}, nil, nil)).Once()
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{
+				peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote2, Retained: testRetainedQuote2},
+			}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
-
 		defer assertDbInteractionLog(t, "READ interaction with db: 1")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 2, 1)
-
 		require.NoError(t, err)
-		assert.Equal(t, 1, count)
+		assert.Equal(t, 2, count)
 		require.Len(t, result, 1)
-
+		assert.Equal(t, testPeginQuote, result[0].Quote)
+		assert.Equal(t, testRetainedQuote2, result[0].RetainedQuote)
 		peginCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 
 	t.Run("Should fill zero values for retained pegin quotes with missing gas fields", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
+		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(2)
 
-		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPeginQuoteCollection).Return(retainedCollection).Times(1)
-
-		// Create old database record with missing gas fields (represented as BSON document)
 		oldRetainedDocument := bson.D{
 			{Key: "quote_hash", Value: testHash1},
 			{Key: "deposit_address", Value: "test_deposit_address"},
@@ -888,41 +800,32 @@ func TestPeginMongoRepository_ListQuotesByDateRange(t *testing.T) {
 			{Key: "call_for_user_gas_used", Value: uint64(21000)},
 			{Key: "register_pegin_gas_used", Value: uint64(22000)},
 			{Key: "owner_account_address", Value: "0x123"},
-			// Note: CallForUserGasPrice and RegisterPeginGasPrice are missing (nil)
 		}
+		storedBytes, errMarshal := bson.Marshal(testStoredQuote1)
+		require.NoError(t, errMarshal)
+		var row bson.M
+		require.NoError(t, bson.Unmarshal(storedBytes, &row))
+		row["retained"] = oldRetainedDocument
 
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		peginCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote1}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash1}}}}}
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
-			Return(mongoDb.NewCursorFromDocuments([]any{oldRetainedDocument}, nil, nil)).Once()
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
+		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{row}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
-
 		defer assertDbInteractionLog(t, "READ interaction with db: 1")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 		require.Len(t, result, 1)
 		assert.Equal(t, testPeginQuote, result[0].Quote)
-
-		// Verify that FillZeroValues() was applied - gas prices should be zero Wei instead of nil
 		assert.NotNil(t, result[0].RetainedQuote.CallForUserGasPrice)
 		assert.NotNil(t, result[0].RetainedQuote.RegisterPeginGasPrice)
 		assert.Equal(t, entities.NewWei(0), result[0].RetainedQuote.CallForUserGasPrice)
 		assert.Equal(t, entities.NewWei(0), result[0].RetainedQuote.RegisterPeginGasPrice)
-
 		peginCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 }
 

--- a/internal/adapters/dataproviders/database/mongo/pegin_test.go
+++ b/internal/adapters/dataproviders/database/mongo/pegin_test.go
@@ -635,15 +635,16 @@ func TestPeginMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	t.Run("Successfully list quotes with pagination and retained quotes", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(2)
+		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
 
 		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 2}}, nil, nil)).Once()
-		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{
-				peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote1, Retained: testRetainedPeginQuote},
-				peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote2, Retained: testRetainedQuote2},
-			}, nil, nil)).Once()
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{
+				"metadata": bson.A{bson.M{"total": 2}},
+				"data": bson.A{
+					peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote1, Retained: testRetainedPeginQuote},
+					peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote2, Retained: testRetainedQuote2},
+				},
+			}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
@@ -663,14 +664,15 @@ func TestPeginMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	t.Run("Successfully list quotes without pagination", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(2)
+		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
 
 		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
-		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{
-				peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote1, Retained: testRetainedPeginQuote},
-			}, nil, nil)).Once()
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{
+				"metadata": bson.A{bson.M{"total": 1}},
+				"data": bson.A{
+					peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote1, Retained: testRetainedPeginQuote},
+				},
+			}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
@@ -691,11 +693,14 @@ func TestPeginMongoRepository_ListQuotesByDateRange(t *testing.T) {
 		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
 
 		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{}, nil, nil)).Once()
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{
+				"metadata": bson.A{},
+				"data":     bson.A{},
+			}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
-		defer assertDbInteractionLog(t, "READ interaction with db: []")()
+		defer assertDbInteractionLog(t, "READ interaction with db: 0")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
 		require.NoError(t, err)
@@ -704,50 +709,11 @@ func TestPeginMongoRepository_ListQuotesByDateRange(t *testing.T) {
 		peginCollection.AssertExpectations(t)
 	})
 
-	t.Run("Returns empty when quotes have no retained row", func(t *testing.T) {
+	t.Run("Error on aggregation", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
 		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
 
-		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 0}}, nil, nil)).Once()
-
-		conn := mongo.NewConnection(client, time.Duration(1))
-		repo := mongo.NewPeginMongoRepository(conn)
-		defer assertDbInteractionLog(t, "READ interaction with db: []")()
-
-		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-		require.NoError(t, err)
-		assert.Equal(t, 0, count)
-		require.Empty(t, result)
-		peginCollection.AssertExpectations(t)
-	})
-
-	t.Run("Error on count aggregation", func(t *testing.T) {
-		client, db := getClientAndDatabaseMocks()
-		peginCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
-
-		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(nil, assert.AnError).Once()
-
-		conn := mongo.NewConnection(client, time.Duration(1))
-		repo := mongo.NewPeginMongoRepository(conn)
-		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-		require.Error(t, err)
-		assert.Equal(t, assert.AnError, err)
-		assert.Equal(t, 0, count)
-		assert.Nil(t, result)
-		peginCollection.AssertExpectations(t)
-	})
-
-	t.Run("Error on data aggregation after successful count", func(t *testing.T) {
-		client, db := getClientAndDatabaseMocks()
-		peginCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(2)
-
-		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
 		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
 			Return(nil, assert.AnError).Once()
 
@@ -764,14 +730,15 @@ func TestPeginMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	t.Run("Successfully handle pagination edge cases", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(2)
+		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
 
 		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 2}}, nil, nil)).Once()
-		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{
-				peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote2, Retained: testRetainedQuote2},
-			}, nil, nil)).Once()
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{
+				"metadata": bson.A{bson.M{"total": 2}},
+				"data": bson.A{
+					peginListQuotesByDateRangeAggRow{StoredPeginQuote: testStoredQuote2, Retained: testRetainedQuote2},
+				},
+			}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)
@@ -789,7 +756,7 @@ func TestPeginMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	t.Run("Should fill zero values for retained pegin quotes with missing gas fields", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		peginCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(2)
+		db.EXPECT().Collection(mongo.PeginQuoteCollection).Return(peginCollection).Times(1)
 
 		oldRetainedDocument := bson.D{
 			{Key: "quote_hash", Value: testHash1},
@@ -808,9 +775,10 @@ func TestPeginMongoRepository_ListQuotesByDateRange(t *testing.T) {
 		row["retained"] = oldRetainedDocument
 
 		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
-		peginCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{row}, nil, nil)).Once()
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{
+				"metadata": bson.A{bson.M{"total": 1}},
+				"data":     bson.A{row},
+			}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPeginMongoRepository(conn)

--- a/internal/adapters/dataproviders/database/mongo/pegout.go
+++ b/internal/adapters/dataproviders/database/mongo/pegout.go
@@ -430,108 +430,84 @@ func (repo *pegoutMongoRepository) ListQuotesByDateRange(ctx context.Context, st
 	dbCtx, cancel := context.WithTimeout(ctx, repo.conn.timeout)
 	defer cancel()
 
-	dateMatch := repo.listQuotesByDateRangeDateMatch(startDate, endDate)
-	total, err := repo.countQuotesWithRetainedInDateRange(dbCtx, dateMatch)
+	cursor, err := repo.conn.Collection(PegoutQuoteCollection).Aggregate(dbCtx, buildPegoutListByDateRangePipeline(startDate, endDate, page, perPage))
 	if err != nil {
 		return nil, 0, err
 	}
-	if total == 0 {
-		empty := make([]quote.PegoutQuoteWithRetained, 0)
-		logDbInteraction(Read, empty)
-		return empty, 0, nil
-	}
+	defer cursor.Close(dbCtx)
 
-	dataPipeline := append(repo.listQuotesByDateRangePipelinePrefix(dateMatch),
-		bson.D{{Key: "$unwind", Value: "$retained"}},
-		bson.D{{Key: "$sort", Value: bson.D{{Key: "agreement_timestamp", Value: SortAscending}}}},
-	)
-	if page > 0 && perPage > 0 {
-		skip := int64((page - 1) * perPage)
-		dataPipeline = append(dataPipeline,
-			bson.D{{Key: "$skip", Value: skip}},
-			bson.D{{Key: "$limit", Value: int64(perPage)}},
-		)
+	// $facet always produces exactly one document whose fields are the branch names,
+	// so the cursor will have at most one row.
+	var facetResult struct {
+		Metadata []struct {
+			Total int `bson:"total"`
+		} `bson:"metadata"`
+		Data []pegoutQuoteWithRetainedAggDoc `bson:"data"`
 	}
-
-	dataCursor, err := repo.conn.Collection(PegoutQuoteCollection).Aggregate(dbCtx, dataPipeline)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer dataCursor.Close(dbCtx)
-
-	var result []quote.PegoutQuoteWithRetained
-	for dataCursor.Next(dbCtx) {
-		var doc pegoutQuoteWithRetainedAggDoc
-		if err := dataCursor.Decode(&doc); err != nil {
+	if cursor.Next(dbCtx) {
+		if err := cursor.Decode(&facetResult); err != nil {
 			return nil, 0, err
 		}
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	// Metadata is a slice because $count inside $facet always returns an array
+	total := 0
+	if len(facetResult.Metadata) > 0 {
+		total = facetResult.Metadata[0].Total
+	}
+
+	result := make([]quote.PegoutQuoteWithRetained, 0, len(facetResult.Data))
+	for _, doc := range facetResult.Data {
 		doc.Retained.FillZeroValues()
 		result = append(result, quote.PegoutQuoteWithRetained{
 			Quote:         doc.PegoutQuote,
 			RetainedQuote: doc.Retained,
 		})
 	}
-	if err := dataCursor.Err(); err != nil {
-		return nil, 0, err
-	}
 
 	logDbInteraction(Read, len(result))
 	return result, total, nil
 }
 
-func (repo *pegoutMongoRepository) listQuotesByDateRangeDateMatch(startDate, endDate time.Time) bson.D {
-	return bson.D{{Key: "agreement_timestamp", Value: bson.D{
-		{Key: "$gte", Value: startDate.Unix()},
-		{Key: "$lte", Value: endDate.Unix()},
-	}}}
-}
+func buildPegoutListByDateRangePipeline(startDate, endDate time.Time, page, perPage int) mongo.Pipeline {
+	pagedRowsPipeline := mongo.Pipeline{
+		{{Key: "$unwind", Value: "$retained"}},
+		{{Key: "$sort", Value: bson.D{{Key: "agreement_timestamp", Value: SortAscending}}}},
+	}
+	if page > 0 && perPage > 0 {
+		skip := int64((page - 1) * perPage)
+		pagedRowsPipeline = append(pagedRowsPipeline,
+			bson.D{{Key: "$skip", Value: skip}},
+			bson.D{{Key: "$limit", Value: int64(perPage)}},
+		)
+	}
 
-func (repo *pegoutMongoRepository) listQuotesByDateRangeLookupStage() bson.D {
-	return bson.D{{Key: "$lookup", Value: bson.D{
-		{Key: "from", Value: RetainedPegoutQuoteCollection},
-		{Key: "localField", Value: "hash"},
-		{Key: "foreignField", Value: "quote_hash"},
-		{Key: "as", Value: "retained"},
-	}}}
-}
-
-func (repo *pegoutMongoRepository) listQuotesByDateRangeHasRetainedMatch() bson.D {
-	return bson.D{{Key: "$match", Value: bson.D{
-		{Key: "retained.0", Value: bson.D{{Key: "$exists", Value: true}}},
-	}}}
-}
-
-// listQuotesByDateRangePipelinePrefix is shared by the count and data aggregations so both apply the same filters.
-func (repo *pegoutMongoRepository) listQuotesByDateRangePipelinePrefix(dateMatch bson.D) mongo.Pipeline {
 	return mongo.Pipeline{
-		{{Key: "$match", Value: dateMatch}},
-		repo.listQuotesByDateRangeLookupStage(),
-		repo.listQuotesByDateRangeHasRetainedMatch(),
+		{{Key: "$match", Value: bson.D{{Key: "agreement_timestamp", Value: bson.D{
+			{Key: "$gte", Value: startDate.Unix()},
+			{Key: "$lte", Value: endDate.Unix()},
+		}}}}},
+		{{Key: "$lookup", Value: bson.D{
+			{Key: "from", Value: RetainedPegoutQuoteCollection},
+			{Key: "localField", Value: "hash"},
+			{Key: "foreignField", Value: "quote_hash"},
+			{Key: "as", Value: "retained"},
+		}}},
+		// Drop quotes with no retained record (i.e. quotes that were never accepted).
+		{{Key: "$match", Value: bson.D{
+			{Key: "retained.0", Value: bson.D{{Key: "$exists", Value: true}}},
+		}}},
+		// Single round-trip: count the full result set and return the requested page simultaneously.
+		{{Key: "$facet", Value: bson.D{
+			{Key: "metadata", Value: mongo.Pipeline{
+				{{Key: "$count", Value: "total"}},
+			}},
+			{Key: "data", Value: pagedRowsPipeline},
+		}}},
 	}
-}
-
-func (repo *pegoutMongoRepository) countQuotesWithRetainedInDateRange(ctx context.Context, dateMatch bson.D) (int, error) {
-	pipeline := append(repo.listQuotesByDateRangePipelinePrefix(dateMatch),
-		bson.D{{Key: "$count", Value: "total"}},
-	)
-	cursor, err := repo.conn.Collection(PegoutQuoteCollection).Aggregate(ctx, pipeline)
-	if err != nil {
-		return 0, err
-	}
-	defer cursor.Close(ctx)
-
-	var out struct {
-		Total int `bson:"total"`
-	}
-	if cursor.Next(ctx) {
-		if err := cursor.Decode(&out); err != nil {
-			return 0, err
-		}
-	}
-	if err := cursor.Err(); err != nil {
-		return 0, err
-	}
-	return out.Total, nil
 }
 
 func (repo *pegoutMongoRepository) GetRetainedQuotesForAddress(ctx context.Context, address string, states ...quote.PegoutState) ([]quote.RetainedPegoutQuote, error) {

--- a/internal/adapters/dataproviders/database/mongo/pegout.go
+++ b/internal/adapters/dataproviders/database/mongo/pegout.go
@@ -39,6 +39,13 @@ type pegoutMongoRepository struct {
 	conn *Connection
 }
 
+// pegoutQuoteWithRetainedAggDoc decodes pegout quote aggregation rows after $lookup and $unwind on "retained"
+// (e.g. ListQuotesByDateRange, GetQuotesWithRetainedByStateAndDate).
+type pegoutQuoteWithRetainedAggDoc struct {
+	StoredPegoutQuote `bson:",inline"`
+	Retained          quote.RetainedPegoutQuote `bson:"retained"`
+}
+
 func NewPegoutMongoRepository(conn *Connection) quote.PegoutQuoteRepository {
 	return &pegoutMongoRepository{conn: conn}
 }
@@ -423,120 +430,108 @@ func (repo *pegoutMongoRepository) ListQuotesByDateRange(ctx context.Context, st
 	dbCtx, cancel := context.WithTimeout(ctx, repo.conn.timeout)
 	defer cancel()
 
-	// Fetch quotes with pagination
-	storedQuotes, err := repo.fetchQuotesByDateRange(dbCtx, startDate, endDate, page, perPage)
+	dateMatch := repo.listQuotesByDateRangeDateMatch(startDate, endDate)
+	total, err := repo.countQuotesWithRetainedInDateRange(dbCtx, dateMatch)
 	if err != nil {
 		return nil, 0, err
 	}
-
-	if len(storedQuotes) == 0 {
-		result := make([]quote.PegoutQuoteWithRetained, 0)
-		logDbInteraction(Read, result)
-		return result, 0, nil
+	if total == 0 {
+		empty := make([]quote.PegoutQuoteWithRetained, 0)
+		logDbInteraction(Read, empty)
+		return empty, 0, nil
 	}
 
-	// Build initial result structure with quotes
-	result, quoteHashes := repo.buildQuoteResults(storedQuotes)
+	dataPipeline := append(repo.listQuotesByDateRangePipelinePrefix(dateMatch),
+		bson.D{{Key: "$unwind", Value: "$retained"}},
+		bson.D{{Key: "$sort", Value: bson.D{{Key: "agreement_timestamp", Value: SortAscending}}}},
+	)
+	if page > 0 && perPage > 0 {
+		skip := int64((page - 1) * perPage)
+		dataPipeline = append(dataPipeline,
+			bson.D{{Key: "$skip", Value: skip}},
+			bson.D{{Key: "$limit", Value: int64(perPage)}},
+		)
+	}
 
-	// Fetch and merge retained quotes
-	if err := repo.mergeRetainedQuotes(dbCtx, result, quoteHashes); err != nil {
-		return result, len(result), err
+	dataCursor, err := repo.conn.Collection(PegoutQuoteCollection).Aggregate(dbCtx, dataPipeline)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer dataCursor.Close(dbCtx)
+
+	var result []quote.PegoutQuoteWithRetained
+	for dataCursor.Next(dbCtx) {
+		var doc pegoutQuoteWithRetainedAggDoc
+		if err := dataCursor.Decode(&doc); err != nil {
+			return nil, 0, err
+		}
+		doc.Retained.FillZeroValues()
+		result = append(result, quote.PegoutQuoteWithRetained{
+			Quote:         doc.PegoutQuote,
+			RetainedQuote: doc.Retained,
+		})
+	}
+	if err := dataCursor.Err(); err != nil {
+		return nil, 0, err
 	}
 
 	logDbInteraction(Read, len(result))
-	return result, len(result), nil
+	return result, total, nil
 }
 
-func (repo *pegoutMongoRepository) fetchQuotesByDateRange(ctx context.Context, startDate, endDate time.Time, page, perPage int) ([]StoredPegoutQuote, error) {
-	quoteFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
+func (repo *pegoutMongoRepository) listQuotesByDateRangeDateMatch(startDate, endDate time.Time) bson.D {
+	return bson.D{{Key: "agreement_timestamp", Value: bson.D{
 		{Key: "$gte", Value: startDate.Unix()},
 		{Key: "$lte", Value: endDate.Unix()},
 	}}}
-
-	findOpts := repo.buildFindOptions(page, perPage)
-
-	quoteCursor, err := repo.conn.Collection(PegoutQuoteCollection).Find(ctx, quoteFilter, findOpts)
-	if err != nil {
-		return nil, err
-	}
-
-	var storedQuotes []StoredPegoutQuote
-	if err = quoteCursor.All(ctx, &storedQuotes); err != nil {
-		return nil, err
-	}
-
-	return storedQuotes, nil
 }
 
-func (repo *pegoutMongoRepository) buildFindOptions(page, perPage int) *options.FindOptions {
-	findOpts := options.Find().SetSort(bson.D{{Key: "agreement_timestamp", Value: SortAscending}})
-
-	// Apply pagination if page and perPage are provided (not 0)
-	// When page=0 and perPage=0, return all results (backward compatibility)
-	if page > 0 && perPage > 0 {
-		skip := (page - 1) * perPage
-		findOpts.SetSkip(int64(skip)).SetLimit(int64(perPage))
-	}
-
-	return findOpts
+func (repo *pegoutMongoRepository) listQuotesByDateRangeLookupStage() bson.D {
+	return bson.D{{Key: "$lookup", Value: bson.D{
+		{Key: "from", Value: RetainedPegoutQuoteCollection},
+		{Key: "localField", Value: "hash"},
+		{Key: "foreignField", Value: "quote_hash"},
+		{Key: "as", Value: "retained"},
+	}}}
 }
 
-func (repo *pegoutMongoRepository) buildQuoteResults(storedQuotes []StoredPegoutQuote) ([]quote.PegoutQuoteWithRetained, []string) {
-	result := make([]quote.PegoutQuoteWithRetained, len(storedQuotes))
-	quoteHashes := make([]string, len(storedQuotes))
-
-	for i, stored := range storedQuotes {
-		quoteHashes[i] = stored.Hash
-		result[i] = quote.PegoutQuoteWithRetained{
-			Quote:         stored.PegoutQuote,
-			RetainedQuote: quote.RetainedPegoutQuote{},
-		}
-	}
-
-	return result, quoteHashes
+func (repo *pegoutMongoRepository) listQuotesByDateRangeHasRetainedMatch() bson.D {
+	return bson.D{{Key: "$match", Value: bson.D{
+		{Key: "retained.0", Value: bson.D{{Key: "$exists", Value: true}}},
+	}}}
 }
 
-func (repo *pegoutMongoRepository) mergeRetainedQuotes(ctx context.Context, result []quote.PegoutQuoteWithRetained, quoteHashes []string) error {
-	retainedQuotes, err := repo.fetchRetainedQuotes(ctx, quoteHashes)
-	if err != nil {
-		return err
+// listQuotesByDateRangePipelinePrefix is shared by the count and data aggregations so both apply the same filters.
+func (repo *pegoutMongoRepository) listQuotesByDateRangePipelinePrefix(dateMatch bson.D) mongo.Pipeline {
+	return mongo.Pipeline{
+		{{Key: "$match", Value: dateMatch}},
+		repo.listQuotesByDateRangeLookupStage(),
+		repo.listQuotesByDateRangeHasRetainedMatch(),
 	}
-
-	// Create hash to index mapping for efficient lookup
-	hashToIndex := make(map[string]int, len(quoteHashes))
-	for i, hash := range quoteHashes {
-		hashToIndex[hash] = i
-	}
-
-	// Merge retained quotes into result
-	for _, retainedQuote := range retainedQuotes {
-		if idx, exists := hashToIndex[retainedQuote.QuoteHash]; exists {
-			result[idx].RetainedQuote = retainedQuote
-		}
-	}
-
-	return nil
 }
 
-func (repo *pegoutMongoRepository) fetchRetainedQuotes(ctx context.Context, quoteHashes []string) ([]quote.RetainedPegoutQuote, error) {
-	retainedCursor, err := repo.conn.Collection(RetainedPegoutQuoteCollection).Find(
-		ctx,
-		bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: quoteHashes}}}},
+func (repo *pegoutMongoRepository) countQuotesWithRetainedInDateRange(ctx context.Context, dateMatch bson.D) (int, error) {
+	pipeline := append(repo.listQuotesByDateRangePipelinePrefix(dateMatch),
+		bson.D{{Key: "$count", Value: "total"}},
 	)
+	cursor, err := repo.conn.Collection(PegoutQuoteCollection).Aggregate(ctx, pipeline)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
+	defer cursor.Close(ctx)
 
-	var retainedQuotes []quote.RetainedPegoutQuote
-	if err = retainedCursor.All(ctx, &retainedQuotes); err != nil {
-		return nil, err
+	var out struct {
+		Total int `bson:"total"`
 	}
-
-	for i := range retainedQuotes {
-		retainedQuotes[i].FillZeroValues()
+	if cursor.Next(ctx) {
+		if err := cursor.Decode(&out); err != nil {
+			return 0, err
+		}
 	}
-
-	return retainedQuotes, nil
+	if err := cursor.Err(); err != nil {
+		return 0, err
+	}
+	return out.Total, nil
 }
 
 func (repo *pegoutMongoRepository) GetRetainedQuotesForAddress(ctx context.Context, address string, states ...quote.PegoutState) ([]quote.RetainedPegoutQuote, error) {
@@ -658,10 +653,7 @@ func (repo *pegoutMongoRepository) GetQuotesWithRetainedByStateAndDate(ctx conte
 
 	result := make([]quote.PegoutQuoteWithRetained, 0)
 	for cursor.Next(dbCtx) {
-		var doc struct {
-			StoredPegoutQuote `bson:",inline"`
-			Retained          quote.RetainedPegoutQuote `bson:"retained"`
-		}
+		var doc pegoutQuoteWithRetainedAggDoc
 		if err := cursor.Decode(&doc); err != nil {
 			return nil, err
 		}

--- a/internal/adapters/dataproviders/database/mongo/pegout_test.go
+++ b/internal/adapters/dataproviders/database/mongo/pegout_test.go
@@ -848,11 +848,16 @@ func TestPegoutMongoRepository_GetQuotes(t *testing.T) {
 	})
 }
 
+// pegoutListQuotesByDateRangeAggRow matches the aggregation document after $lookup and $unwind on "retained".
+type pegoutListQuotesByDateRangeAggRow struct {
+	mongo.StoredPegoutQuote `bson:",inline"`
+	Retained                quote.RetainedPegoutQuote `bson:"retained"`
+}
+
 // nolint:funlen, maintidx
 func TestPegoutMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 
-	// Test data setup
 	testHash1 := "8d1ba2cb559a6ebe41f19131602467e1d939682d651b2a91e55b86bc664a6819"
 	testHash2 := "27d70ec2bc2c3154dc9a5b53b118a755441b22bc1c8ccde967ed33609970c25f"
 
@@ -875,30 +880,21 @@ func TestPegoutMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	t.Run("Successfully list quotes with pagination and retained quotes", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
+		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(2)
 
-		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPegoutQuoteCollection).Return(retainedCollection).Times(1)
-
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		pegoutCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote1, testStoredQuote2}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash1, testHash2}}}}}
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
-			Return(mongoDb.NewCursorFromDocuments([]any{testRetainedQuote1, testRetainedPegoutQuote}, nil, nil)).Once()
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 2}}, nil, nil)).Once()
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{
+				pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote1, Retained: testRetainedQuote1},
+				pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote2, Retained: testRetainedPegoutQuote},
+			}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
-
 		defer assertDbInteractionLog(t, "READ interaction with db: 2")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.NoError(t, err)
 		assert.Equal(t, 2, count)
 		require.Len(t, result, 2)
@@ -906,218 +902,140 @@ func TestPegoutMongoRepository_ListQuotesByDateRange(t *testing.T) {
 		assert.Equal(t, testRetainedQuote1, result[0].RetainedQuote)
 		assert.Equal(t, testPegoutQuote, result[1].Quote)
 		assert.Equal(t, testRetainedPegoutQuote, result[1].RetainedQuote)
-
 		pegoutCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 
 	t.Run("Successfully list quotes without pagination", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
+		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(2)
 
-		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPegoutQuoteCollection).Return(retainedCollection).Times(1)
-
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		pegoutCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote1}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash1}}}}}
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
-			Return(mongoDb.NewCursorFromDocuments([]any{}, nil, nil)).Once()
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{
+				pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote1, Retained: testRetainedQuote1},
+			}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
-
 		defer assertDbInteractionLog(t, "READ interaction with db: 1")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 0, 0)
-
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 		require.Len(t, result, 1)
 		assert.Equal(t, testPegoutQuote, result[0].Quote)
-		assert.Equal(t, quote.RetainedPegoutQuote{}, result[0].RetainedQuote)
-
+		assert.Equal(t, testRetainedQuote1, result[0].RetainedQuote)
 		pegoutCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 
 	t.Run("Successfully return empty result", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-
 		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
 
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		pegoutCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
 			Return(mongoDb.NewCursorFromDocuments([]any{}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
-
 		defer assertDbInteractionLog(t, "READ interaction with db: []")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
 		require.Empty(t, result)
-
 		pegoutCollection.AssertExpectations(t)
 	})
 
-	t.Run("Successfully list quotes without retained quotes", func(t *testing.T) {
+	t.Run("Returns empty when quotes have no retained row", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
-
 		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPegoutQuoteCollection).Return(retainedCollection).Times(1)
 
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		pegoutCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote1}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash1}}}}}
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
-			Return(mongoDb.NewCursorFromDocuments([]any{}, nil, nil)).Once()
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 0}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
-
-		defer assertDbInteractionLog(t, "READ interaction with db: 1")()
+		defer assertDbInteractionLog(t, "READ interaction with db: []")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.NoError(t, err)
-		assert.Equal(t, 1, count)
-		require.Len(t, result, 1)
-		assert.Equal(t, testPegoutQuote, result[0].Quote)
-		assert.Equal(t, quote.RetainedPegoutQuote{}, result[0].RetainedQuote)
-
+		assert.Equal(t, 0, count)
+		require.Empty(t, result)
 		pegoutCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 
-	t.Run("Error when fetching quotes from database", func(t *testing.T) {
+	t.Run("Error on count aggregation", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-
 		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
 
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		pegoutCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
 			Return(nil, assert.AnError).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
-
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.Error(t, err)
 		assert.Equal(t, assert.AnError, err)
 		assert.Equal(t, 0, count)
 		assert.Nil(t, result)
-
 		pegoutCollection.AssertExpectations(t)
 	})
 
-	t.Run("Error when fetching retained quotes", func(t *testing.T) {
+	t.Run("Error on data aggregation after successful count", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
+		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(2)
 
-		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPegoutQuoteCollection).Return(retainedCollection).Times(1)
-
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		pegoutCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote1}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash1}}}}}
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
 			Return(nil, assert.AnError).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
-
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.Error(t, err)
 		assert.Equal(t, assert.AnError, err)
-		assert.Equal(t, 1, count)
-		require.Len(t, result, 1)
-
+		assert.Equal(t, 0, count)
+		assert.Nil(t, result)
 		pegoutCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 
 	t.Run("Successfully handle pagination edge cases", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
+		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(2)
 
-		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPegoutQuoteCollection).Return(retainedCollection).Times(1)
-
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		pegoutCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote1}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash1}}}}}
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
-			Return(mongoDb.NewCursorFromDocuments([]any{}, nil, nil)).Once()
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 2}}, nil, nil)).Once()
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{
+				pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote2, Retained: testRetainedPegoutQuote},
+			}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
-
 		defer assertDbInteractionLog(t, "READ interaction with db: 1")()
 
-		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 1)
-
+		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 2, 1)
 		require.NoError(t, err)
-		assert.Equal(t, 1, count)
+		assert.Equal(t, 2, count)
 		require.Len(t, result, 1)
-
+		assert.Equal(t, testPegoutQuote, result[0].Quote)
+		assert.Equal(t, testRetainedPegoutQuote, result[0].RetainedQuote)
 		pegoutCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 
 	t.Run("Should fill zero values for retained pegout quotes with missing gas fields", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-		retainedCollection := &mocks.CollectionBindingMock{}
+		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(2)
 
-		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
-		db.EXPECT().Collection(mongo.RetainedPegoutQuoteCollection).Return(retainedCollection).Times(1)
-
-		// Create old database record with missing gas fields (represented as BSON document)
 		oldRetainedDocument := bson.D{
 			{Key: "quote_hash", Value: testHash1},
 			{Key: "deposit_address", Value: "test_deposit_address"},
@@ -1127,43 +1045,34 @@ func TestPegoutMongoRepository_ListQuotesByDateRange(t *testing.T) {
 			{Key: "bridge_refund_gas_used", Value: uint64(21000)},
 			{Key: "refund_pegout_gas_used", Value: uint64(21000)},
 			{Key: "owner_account_address", Value: "0x123"},
-			// Note: BridgeRefundGasPrice, RefundPegoutGasPrice, and SendPegoutBtcFee are missing (nil)
 		}
+		storedBytes, errMarshal := bson.Marshal(testStoredQuote1)
+		require.NoError(t, errMarshal)
+		var row bson.M
+		require.NoError(t, bson.Unmarshal(storedBytes, &row))
+		row["retained"] = oldRetainedDocument
 
-		expectedFilter := bson.D{{Key: "agreement_timestamp", Value: bson.D{
-			{Key: "$gte", Value: startDate.Unix()},
-			{Key: "$lte", Value: endDate.Unix()},
-		}}}
-
-		pegoutCollection.On("Find", mock.Anything, expectedFilter, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{testStoredQuote1}, nil, nil)).Once()
-
-		retainedFilter := bson.D{{Key: "quote_hash", Value: bson.D{{Key: "$in", Value: []string{testHash1}}}}}
-		retainedCollection.On("Find", mock.Anything, retainedFilter).
-			Return(mongoDb.NewCursorFromDocuments([]any{oldRetainedDocument}, nil, nil)).Once()
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
+		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
+			Return(mongoDb.NewCursorFromDocuments([]any{row}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
-
 		defer assertDbInteractionLog(t, "READ interaction with db: 1")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-
 		require.NoError(t, err)
 		assert.Equal(t, 1, count)
 		require.Len(t, result, 1)
 		assert.Equal(t, testPegoutQuote, result[0].Quote)
-
-		// Verify that FillZeroValues() was applied - gas prices should be zero Wei instead of nil
 		assert.NotNil(t, result[0].RetainedQuote.BridgeRefundGasPrice)
 		assert.NotNil(t, result[0].RetainedQuote.RefundPegoutGasPrice)
 		assert.NotNil(t, result[0].RetainedQuote.SendPegoutBtcFee)
 		assert.Equal(t, entities.NewWei(0), result[0].RetainedQuote.BridgeRefundGasPrice)
 		assert.Equal(t, entities.NewWei(0), result[0].RetainedQuote.RefundPegoutGasPrice)
 		assert.Equal(t, entities.NewWei(0), result[0].RetainedQuote.SendPegoutBtcFee)
-
 		pegoutCollection.AssertExpectations(t)
-		retainedCollection.AssertExpectations(t)
 	})
 }
 

--- a/internal/adapters/dataproviders/database/mongo/pegout_test.go
+++ b/internal/adapters/dataproviders/database/mongo/pegout_test.go
@@ -880,15 +880,16 @@ func TestPegoutMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	t.Run("Successfully list quotes with pagination and retained quotes", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(2)
+		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
 
 		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 2}}, nil, nil)).Once()
-		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{
-				pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote1, Retained: testRetainedQuote1},
-				pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote2, Retained: testRetainedPegoutQuote},
-			}, nil, nil)).Once()
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{
+				"metadata": bson.A{bson.M{"total": 2}},
+				"data": bson.A{
+					pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote1, Retained: testRetainedQuote1},
+					pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote2, Retained: testRetainedPegoutQuote},
+				},
+			}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
@@ -908,14 +909,15 @@ func TestPegoutMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	t.Run("Successfully list quotes without pagination", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(2)
+		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
 
 		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
-		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{
-				pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote1, Retained: testRetainedQuote1},
-			}, nil, nil)).Once()
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{
+				"metadata": bson.A{bson.M{"total": 1}},
+				"data": bson.A{
+					pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote1, Retained: testRetainedQuote1},
+				},
+			}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
@@ -936,11 +938,14 @@ func TestPegoutMongoRepository_ListQuotesByDateRange(t *testing.T) {
 		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
 
 		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{}, nil, nil)).Once()
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{
+				"metadata": bson.A{},
+				"data":     bson.A{},
+			}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
-		defer assertDbInteractionLog(t, "READ interaction with db: []")()
+		defer assertDbInteractionLog(t, "READ interaction with db: 0")()
 
 		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
 		require.NoError(t, err)
@@ -949,50 +954,11 @@ func TestPegoutMongoRepository_ListQuotesByDateRange(t *testing.T) {
 		pegoutCollection.AssertExpectations(t)
 	})
 
-	t.Run("Returns empty when quotes have no retained row", func(t *testing.T) {
+	t.Run("Error on aggregation", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
 		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
 
-		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 0}}, nil, nil)).Once()
-
-		conn := mongo.NewConnection(client, time.Duration(1))
-		repo := mongo.NewPegoutMongoRepository(conn)
-		defer assertDbInteractionLog(t, "READ interaction with db: []")()
-
-		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-		require.NoError(t, err)
-		assert.Equal(t, 0, count)
-		require.Empty(t, result)
-		pegoutCollection.AssertExpectations(t)
-	})
-
-	t.Run("Error on count aggregation", func(t *testing.T) {
-		client, db := getClientAndDatabaseMocks()
-		pegoutCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
-
-		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(nil, assert.AnError).Once()
-
-		conn := mongo.NewConnection(client, time.Duration(1))
-		repo := mongo.NewPegoutMongoRepository(conn)
-		result, count, err := repo.ListQuotesByDateRange(context.Background(), startDate, endDate, 1, 10)
-		require.Error(t, err)
-		assert.Equal(t, assert.AnError, err)
-		assert.Equal(t, 0, count)
-		assert.Nil(t, result)
-		pegoutCollection.AssertExpectations(t)
-	})
-
-	t.Run("Error on data aggregation after successful count", func(t *testing.T) {
-		client, db := getClientAndDatabaseMocks()
-		pegoutCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(2)
-
-		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
 		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
 			Return(nil, assert.AnError).Once()
 
@@ -1009,14 +975,15 @@ func TestPegoutMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	t.Run("Successfully handle pagination edge cases", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(2)
+		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
 
 		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 2}}, nil, nil)).Once()
-		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{
-				pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote2, Retained: testRetainedPegoutQuote},
-			}, nil, nil)).Once()
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{
+				"metadata": bson.A{bson.M{"total": 2}},
+				"data": bson.A{
+					pegoutListQuotesByDateRangeAggRow{StoredPegoutQuote: testStoredQuote2, Retained: testRetainedPegoutQuote},
+				},
+			}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
@@ -1034,7 +1001,7 @@ func TestPegoutMongoRepository_ListQuotesByDateRange(t *testing.T) {
 	t.Run("Should fill zero values for retained pegout quotes with missing gas fields", func(t *testing.T) {
 		client, db := getClientAndDatabaseMocks()
 		pegoutCollection := &mocks.CollectionBindingMock{}
-		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(2)
+		db.EXPECT().Collection(mongo.PegoutQuoteCollection).Return(pegoutCollection).Times(1)
 
 		oldRetainedDocument := bson.D{
 			{Key: "quote_hash", Value: testHash1},
@@ -1053,9 +1020,10 @@ func TestPegoutMongoRepository_ListQuotesByDateRange(t *testing.T) {
 		row["retained"] = oldRetainedDocument
 
 		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{"total": 1}}, nil, nil)).Once()
-		pegoutCollection.On("Aggregate", mock.Anything, mock.Anything).
-			Return(mongoDb.NewCursorFromDocuments([]any{row}, nil, nil)).Once()
+			Return(mongoDb.NewCursorFromDocuments([]any{bson.M{
+				"metadata": bson.A{bson.M{"total": 1}},
+				"data":     bson.A{row},
+			}}, nil, nil)).Once()
 
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)

--- a/internal/usecases/reports/get_transactions.go
+++ b/internal/usecases/reports/get_transactions.go
@@ -99,21 +99,13 @@ func (useCase *GetTransactionsUseCase) getPeginTransactions(ctx context.Context,
 
 	transactions := make([]TransactionItem, 0, len(quotePairs))
 	for _, pair := range quotePairs {
-		// Skip quotes that have not been accepted
-		if pair.RetainedQuote.QuoteHash == "" {
-			totalCount--
-			continue
-		}
-
-		transaction := TransactionItem{
+		transactions = append(transactions, TransactionItem{
 			QuoteHash: pair.RetainedQuote.QuoteHash,
 			Amount:    pair.Quote.Value,
 			CallFee:   pair.Quote.CallFee,
 			GasFee:    pair.Quote.GasFee,
 			Status:    string(pair.RetainedQuote.State),
-		}
-
-		transactions = append(transactions, transaction)
+		})
 	}
 
 	return transactions, totalCount, nil
@@ -127,21 +119,13 @@ func (useCase *GetTransactionsUseCase) getPegoutTransactions(ctx context.Context
 
 	transactions := make([]TransactionItem, 0, len(quotePairs))
 	for _, pair := range quotePairs {
-		// Skip quotes that have not been accepted
-		if pair.RetainedQuote.QuoteHash == "" {
-			totalCount--
-			continue
-		}
-
-		transaction := TransactionItem{
+		transactions = append(transactions, TransactionItem{
 			QuoteHash: pair.RetainedQuote.QuoteHash,
 			Amount:    pair.Quote.Value,
 			CallFee:   pair.Quote.CallFee,
 			GasFee:    pair.Quote.GasFee,
 			Status:    string(pair.RetainedQuote.State),
-		}
-
-		transactions = append(transactions, transaction)
+		})
 	}
 
 	return transactions, totalCount, nil


### PR DESCRIPTION
## What
The endpoint /reports/transactions was returning a completely broken response. This PR fixes that endpoint.

## Why
Improve app quality

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [x] Management UI / API
- [ ] PegIn flow
- [ ] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2189)

## How to test
Since this probably won't be deployed in dev at the moment of testing I recommend this:
- Install https://www.mongodb.com/try/download/database-tools and make it work in local
- Start the local env.
- Connect to VPN
- Create a copy of the full flyover DB on dev to local by running:
```
mongodump --uri='mongodb://root:root@flyover-01-dev.aws-us-east-1.flyover.rif.technology/?authSource=admin' --db=flyover --out=./dump
mongorestore --uri='mongodb://root:root@localhost:27017/?authSource=admin' ./dump
```
-Go to /management and authenticate using the dev credentials
-Run the test. Examples:
http://localhost:8080/reports/transactions?type=pegout&startDate=2025-01-01&endDate=2026-01-29&page=4&perPage=5
http://localhost:8080/reports/transactions?type=pegout&startDate=2025-01-01&endDate=2026-01-29&page=1&perPage=50
http://localhost:8080/reports/transactions?type=pegin&startDate=2025-01-01&endDate=2026-01-29&page=4&perPage=5

Pay special attention to pagination metadata

## Reviewer Guidelines
The issue here was related with the way the repo object for pegin and pegout were managing the query. Most of the changes where made in the repo layer. Remember that this endpoint is supposed to take into account only the accepted quotes, so if a quote does not have a corresponding object in retainedQuote, in the DB, the endpoint must ignore it.
