### PR TITLE
Fly2263: fix Mongo session context bug

### DIFF
--- a/internal/adapters/dataproviders/database/mongo/pegout.go
+++ b/internal/adapters/dataproviders/database/mongo/pegout.go
@@ -243,28 +243,26 @@ func (repo *pegoutMongoRepository) UpdateRetainedQuotes(ctx context.Context, ret
 	if err != nil {
 		return err
 	}
-	collection := repo.conn.Collection(RetainedPegoutQuoteCollection)
-	result, err := session.WithTransaction(dbCtx, func(sessionContext mongo.SessionContext) (any, error) {
+	//nolint:contextcheck
+	_, err = session.WithTransaction(dbCtx, func(sessionContext mongo.SessionContext) (any, error) {
+		collection := repo.conn.Collection(RetainedPegoutQuoteCollection)
 		var count int64 = 0
 		for _, retainedQuote := range retainedQuotes {
 			filter := bson.D{primitive.E{Key: "quote_hash", Value: retainedQuote.QuoteHash}}
 			updateStatement := bson.D{primitive.E{Key: "$set", Value: retainedQuote}}
-			updateResult, updateErr := collection.UpdateOne(dbCtx, filter, updateStatement)
+			updateResult, updateErr := collection.UpdateOne(sessionContext, filter, updateStatement)
 			if updateErr != nil {
-				return int64(0), updateErr
+				return nil, updateErr
 			}
 			count += updateResult.ModifiedCount
 		}
-		return count, nil
+		if count != int64(len(retainedQuotes)) {
+			return nil, fmt.Errorf("mismatch on updated documents. Expected %d, updated %d", len(retainedQuotes), count)
+		}
+		return nil, nil
 	})
 	if err != nil {
 		return err
-	}
-	parsedResult, ok := result.(int64)
-	if !ok {
-		return errors.New("unexpected result type")
-	} else if parsedResult != int64(len(retainedQuotes)) {
-		return fmt.Errorf("mismatch on updated documents. Expected %d, updated %d", len(retainedQuotes), result)
 	}
 	logDbInteraction(Update, retainedQuotes)
 	return nil

--- a/internal/adapters/dataproviders/database/mongo/pegout_test.go
+++ b/internal/adapters/dataproviders/database/mongo/pegout_test.go
@@ -2,6 +2,7 @@ package mongo_test
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -692,11 +693,11 @@ func TestPegoutMongoRepository_UpdateRetainedQuotes(t *testing.T) {
 			Run(func(args mock.Arguments) {
 				fn, ok := args.Get(1).(func(mongoDb.SessionContext) (any, error))
 				require.True(t, ok)
-				count, err := fn(mongoDb.NewSessionContext(context.Background(), mongoDb.SessionFromContext(context.Background())))
-				require.NoError(t, err)
-				assert.Equal(t, int64(len(retainedQuotes)), count)
+				result, cbErr := fn(mongoDb.NewSessionContext(context.Background(), mongoDb.SessionFromContext(context.Background())))
+				require.NoError(t, cbErr)
+				assert.Nil(t, result)
 			}).
-			Return(any(int64(len(retainedQuotes))), nil)
+			Return(nil, nil)
 		for _, q := range retainedQuotes {
 			collection.On("UpdateOne", mock.Anything,
 				bson.D{primitive.E{Key: "quote_hash", Value: q.QuoteHash}},
@@ -735,11 +736,11 @@ func TestPegoutMongoRepository_UpdateRetainedQuotes(t *testing.T) {
 			Run(func(args mock.Arguments) {
 				fn, ok := args.Get(1).(func(mongoDb.SessionContext) (any, error))
 				require.True(t, ok)
-				count, err := fn(mongoDb.NewSessionContext(context.Background(), mongoDb.SessionFromContext(context.Background())))
-				require.Error(t, err)
-				assert.Equal(t, int64(0), count)
+				result, cbErr := fn(mongoDb.NewSessionContext(context.Background(), mongoDb.SessionFromContext(context.Background())))
+				require.Error(t, cbErr)
+				assert.Nil(t, result)
 			}).
-			Return(int64(0), assert.AnError)
+			Return(nil, assert.AnError)
 
 		collection.On("UpdateOne", mock.Anything, mock.Anything, mock.Anything).Return(&mongoDb.UpdateResult{ModifiedCount: 1}, nil).Once()
 		collection.On("UpdateOne", mock.Anything, mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
@@ -753,15 +754,26 @@ func TestPegoutMongoRepository_UpdateRetainedQuotes(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run("Update count mismatch", func(t *testing.T) {
-		client, _ := getClientAndCollectionMocks(mongo.RetainedPegoutQuoteCollection)
+		client, collection := getClientAndCollectionMocks(mongo.RetainedPegoutQuoteCollection)
 		session := &mocks.SessionBindingMock{}
 		client.On("StartSession").Return(session, nil).Once()
 		session.On("EndSession", mock.Anything).Return().Once()
-		session.On("WithTransaction", mock.Anything, mock.Anything).Return(any(int64(len(retainedQuotes)-1)), nil)
+		session.On("WithTransaction", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				fn, ok := args.Get(1).(func(mongoDb.SessionContext) (any, error))
+				require.True(t, ok)
+				result, cbErr := fn(mongoDb.NewSessionContext(context.Background(), mongoDb.SessionFromContext(context.Background())))
+				require.Error(t, cbErr)
+				assert.Nil(t, result)
+			}).
+			Return(nil, errors.New("mismatch on updated documents. Expected 2, updated 1"))
+		collection.On("UpdateOne", mock.Anything, mock.Anything, mock.Anything).Return(&mongoDb.UpdateResult{ModifiedCount: 1}, nil).Once()
+		collection.On("UpdateOne", mock.Anything, mock.Anything, mock.Anything).Return(&mongoDb.UpdateResult{ModifiedCount: 0}, nil).Once()
 		conn := mongo.NewConnection(client, time.Duration(1))
 		repo := mongo.NewPegoutMongoRepository(conn)
 		defer test.AssertNoLog(t)()
 		err := repo.UpdateRetainedQuotes(context.Background(), retainedQuotes)
+		collection.AssertExpectations(t)
 		client.AssertExpectations(t)
 		session.AssertExpectations(t)
 		require.ErrorContains(t, err, "mismatch on updated documents. Expected 2, updated 1")


### PR DESCRIPTION
## What

Fix a bug in UpdateRetainedQuotes where MongoDB UpdateOne calls inside a WithTransaction block were using the outer dbCtx instead of the transaction's sessionContext. This meant the write operations were not actually bound to the session, breaking atomicity — if one update failed, previously executed updates in the same call would not be rolled back.

The fix moves collection acquisition inside the callback and passes sessionContext to each UpdateOne call, ensuring all operations run within the same MongoDB transaction. The result handling was also simplified: the updated-document count check now happens inside the callback (returning an error directly) instead of being passed out through an interface{} return and type-asserted after the fact. 

A //nolint:contextcheck directive is added because contextcheck does not correctly trace mongo.SessionContext → context.Context through the implicit interface conversion, producing a false positive despite the context being properly propagated.

## Why

Improve quality

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [x] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2263)

