### PR TITLE
Fix refund regtest

### DIFF
--- a/internal/adapters/dataproviders/rootstock/common.go
+++ b/internal/adapters/dataproviders/rootstock/common.go
@@ -23,8 +23,11 @@ const (
 )
 
 // ErrShortRevertData is returned by ParseRevertReason when the revert payload
-// is shorter than a 4-byte ABI selector. This typically indicates a transient
-// bridge state rather than a named contract error.
+// is shorter than a 4-byte ABI selector, so the error cannot be decoded into a
+// named custom error (or revert string). This can happen for multiple reasons
+// (e.g. ABI decode failures, calling an address with no code, or other opaque
+// reverts), and should not be interpreted as a specific on-chain condition by
+// the parser.
 var ErrShortRevertData = errors.New("revert data shorter than ABI selector")
 
 var DefaultRetryParams = RetryParams{

--- a/internal/adapters/dataproviders/rootstock/common.go
+++ b/internal/adapters/dataproviders/rootstock/common.go
@@ -22,6 +22,11 @@ const (
 	rpcCallRetrySleep = 1 * time.Minute
 )
 
+// ErrShortRevertData is returned by ParseRevertReason when the revert payload
+// is shorter than a 4-byte ABI selector. This typically indicates a transient
+// bridge state rather than a named contract error.
+var ErrShortRevertData = errors.New("revert data shorter than ABI selector")
+
 var DefaultRetryParams = RetryParams{
 	Retries: rpcCallRetryMax,
 	Sleep:   rpcCallRetrySleep,
@@ -157,6 +162,10 @@ func ParseRevertReason(contractAbi *abi.ABI, err error) (*abi.Error, error) {
 
 	if reason, unpackErr := abi.UnpackRevert(revertDataBytes); unpackErr == nil {
 		return nil, fmt.Errorf("found generic error: %s", reason)
+	}
+
+	if len(revertDataBytes) < errorSelectorSize {
+		return nil, fmt.Errorf("%w: %w", ErrShortRevertData, dataError)
 	}
 
 	var selectorBytes [errorSelectorSize]byte

--- a/internal/adapters/dataproviders/rootstock/common_test.go
+++ b/internal/adapters/dataproviders/rootstock/common_test.go
@@ -154,3 +154,70 @@ func TestAwaitTxWithCtx(t *testing.T) {
 		assert.Nil(t, receipt)
 	})
 }
+
+func TestParseRevertReason(t *testing.T) {
+	t.Run("nil error returns nil", func(t *testing.T) {
+		result, err := rootstock.ParseRevertReason(Abis.PegOut, nil)
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+	t.Run("non-DataError returns error", func(t *testing.T) {
+		result, err := rootstock.ParseRevertReason(Abis.PegOut, assert.AnError)
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+	t.Run("DataError with non-string ErrorData returns error", func(t *testing.T) {
+		e := rskRpcErrorWithIntData{message: "revert", data: 42}
+		result, err := rootstock.ParseRevertReason(Abis.PegOut, e)
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+	t.Run("DataError with invalid hex returns error", func(t *testing.T) {
+		e := NewRskRpcError("revert", "0xZZ")
+		result, err := rootstock.ParseRevertReason(Abis.PegOut, e)
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+	t.Run("DataError with generic Error(string) ABI revert returns error", func(t *testing.T) {
+		// Error("test") ABI-encoded: selector 0x08c379a0 + offset + length + data
+		e := NewRskRpcError("revert", "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000047465737400000000000000000000000000000000000000000000000000000000")
+		result, err := rootstock.ParseRevertReason(Abis.PegOut, e)
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+	t.Run("DataError with empty data returns ErrShortRevertData", func(t *testing.T) {
+		e := NewRskRpcError("execution reverted", "0x")
+		result, err := rootstock.ParseRevertReason(Abis.PegOut, e)
+		require.ErrorIs(t, err, rootstock.ErrShortRevertData)
+		assert.Nil(t, result)
+	})
+	t.Run("DataError with data shorter than selector returns ErrShortRevertData", func(t *testing.T) {
+		e := NewRskRpcError("execution reverted", "0xaabbcc")
+		result, err := rootstock.ParseRevertReason(Abis.PegOut, e)
+		require.ErrorIs(t, err, rootstock.ErrShortRevertData)
+		assert.Nil(t, result)
+	})
+	t.Run("DataError with unknown 4-byte selector returns error", func(t *testing.T) {
+		e := NewRskRpcError("revert", "0xdeadbeef")
+		result, err := rootstock.ParseRevertReason(Abis.PegOut, e)
+		require.Error(t, err)
+		assert.Nil(t, result)
+	})
+	t.Run("DataError with known ABI error selector returns parsed error", func(t *testing.T) {
+		// NotEnoughConfirmations selector from the pegout ABI with valid ABI-encoded arguments
+		e := NewRskRpcError("transaction reverted", "0xd2506f8c00000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000002")
+		result, err := rootstock.ParseRevertReason(Abis.PegOut, e)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "NotEnoughConfirmations", result.Name)
+	})
+}
+
+// rskRpcErrorWithIntData is a DataError whose ErrorData returns a non-string value.
+type rskRpcErrorWithIntData struct {
+	message string
+	data    int
+}
+
+func (r rskRpcErrorWithIntData) Error() string         { return r.message }
+func (r rskRpcErrorWithIntData) ErrorData() interface{} { return r.data }

--- a/internal/adapters/dataproviders/rootstock/common_test.go
+++ b/internal/adapters/dataproviders/rootstock/common_test.go
@@ -219,5 +219,5 @@ type rskRpcErrorWithIntData struct {
 	data    int
 }
 
-func (r rskRpcErrorWithIntData) Error() string         { return r.message }
+func (r rskRpcErrorWithIntData) Error() string          { return r.message }
 func (r rskRpcErrorWithIntData) ErrorData() interface{} { return r.data }

--- a/internal/adapters/dataproviders/rootstock/pegout_contract.go
+++ b/internal/adapters/dataproviders/rootstock/pegout_contract.go
@@ -192,8 +192,8 @@ func (pegoutContract *pegoutContractImpl) RefundPegout(txConfig blockchain.Trans
 	)
 	parsedRevert, err := ParseRevertReason(pegoutContract.abis.PegOut, revert)
 	if errors.Is(err, ErrShortRevertData) {
-		log.Debugln("RefundPegout: bridge reverted with short data. retrying on next confirmation.")
-		return blockchain.TransactionReceipt{}, blockchain.WaitingForBridgeError
+		log.Debugln("RefundPegout: revert payload empty/short (unparseable); returning parse error (no WaitingForBridgeError mapping)")
+		return blockchain.TransactionReceipt{}, fmt.Errorf("error parsing refundPegout result: %w", err)
 	} else if err != nil && parsedRevert == nil {
 		return blockchain.TransactionReceipt{}, fmt.Errorf("error parsing refundPegout result: %w", err)
 	} else if parsedRevert != nil && (strings.EqualFold(notEnoughConfirmationsError, parsedRevert.Name) || strings.EqualFold(unableToGetConfirmations, parsedRevert.Name)) {

--- a/internal/adapters/dataproviders/rootstock/pegout_contract.go
+++ b/internal/adapters/dataproviders/rootstock/pegout_contract.go
@@ -191,10 +191,7 @@ func (pegoutContract *pegoutContractImpl) RefundPegout(txConfig blockchain.Trans
 		params.MerkleBranchHashes,
 	)
 	parsedRevert, err := ParseRevertReason(pegoutContract.abis.PegOut, revert)
-	if errors.Is(err, ErrShortRevertData) {
-		log.Debugln("RefundPegout: revert payload empty/short (unparseable); returning parse error (no WaitingForBridgeError mapping)")
-		return blockchain.TransactionReceipt{}, fmt.Errorf("error parsing refundPegout result: %w", err)
-	} else if err != nil && parsedRevert == nil {
+	if err != nil && parsedRevert == nil {
 		return blockchain.TransactionReceipt{}, fmt.Errorf("error parsing refundPegout result: %w", err)
 	} else if parsedRevert != nil && (strings.EqualFold(notEnoughConfirmationsError, parsedRevert.Name) || strings.EqualFold(unableToGetConfirmations, parsedRevert.Name)) {
 		log.Debugln("RefundPegout: bridge failed to validate BTC transaction. retrying on next confirmation.")

--- a/internal/adapters/dataproviders/rootstock/pegout_contract.go
+++ b/internal/adapters/dataproviders/rootstock/pegout_contract.go
@@ -191,7 +191,10 @@ func (pegoutContract *pegoutContractImpl) RefundPegout(txConfig blockchain.Trans
 		params.MerkleBranchHashes,
 	)
 	parsedRevert, err := ParseRevertReason(pegoutContract.abis.PegOut, revert)
-	if err != nil && parsedRevert == nil {
+	if errors.Is(err, ErrShortRevertData) {
+		log.Debugln("RefundPegout: bridge reverted with short data. retrying on next confirmation.")
+		return blockchain.TransactionReceipt{}, blockchain.WaitingForBridgeError
+	} else if err != nil && parsedRevert == nil {
 		return blockchain.TransactionReceipt{}, fmt.Errorf("error parsing refundPegout result: %w", err)
 	} else if parsedRevert != nil && (strings.EqualFold(notEnoughConfirmationsError, parsedRevert.Name) || strings.EqualFold(unableToGetConfirmations, parsedRevert.Name)) {
 		log.Debugln("RefundPegout: bridge failed to validate BTC transaction. retrying on next confirmation.")

--- a/internal/adapters/dataproviders/rootstock/pegout_contract_test.go
+++ b/internal/adapters/dataproviders/rootstock/pegout_contract_test.go
@@ -369,19 +369,23 @@ func TestPegoutContractImpl_RefundPegout(t *testing.T) {
 		callerMock.AssertExpectations(t)
 	})
 	t.Run("Error handling (empty revert data from bridge)", func(t *testing.T) {
-		contractMock := createBoundContractMock()
-		pegoutContract := rootstock.NewPegoutContractImpl(rootstock.NewRskClient(mockClient), test.AnyAddress, contractMock.contract, signerMock, rootstock.RetryParams{}, time.Duration(1), pegoutBinding, Abis)
+		contractBinding := &mocks.PegoutContractAdapterMock{}
+		callerMock := &mocks.ContractCallerBindingMock{}
+		pegoutContract := rootstock.NewPegoutContractImpl(rootstock.NewRskClient(mockClient), test.AnyAddress, contractBinding, signerMock, rootstock.RetryParams{}, time.Duration(1), Abis)
 		e := NewRskRpcError("execution reverted", "0x")
-		contractMock.caller.EXPECT().CallContract(
-			mock.Anything,
-			matchCallData(txData),
-			mock.Anything,
-		).Return(nil, e).Once()
+		contractBinding.EXPECT().Caller().Return(callerMock).Once()
+		callerMock.EXPECT().Call(mock.Anything, mock.Anything, "refundPegOut",
+			refundParams.QuoteHash, refundParams.BtcRawTx, refundParams.BtcBlockHeaderHash,
+			refundParams.MerkleBranchPath, refundParams.MerkleBranchHashes,
+		).Return(e).Once()
+
 		result, err := pegoutContract.RefundPegout(txConfig, refundParams)
-		require.ErrorIs(t, err, blockchain.WaitingForBridgeError)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "error parsing refundPegout result")
 		assert.Empty(t, result)
-		contractMock.caller.AssertExpectations(t)
-		contractMock.transactor.AssertNotCalled(t, "SendTransaction")
+		contractBinding.AssertExpectations(t)
+		contractBinding.AssertNotCalled(t, "RefundPegOut")
+		callerMock.AssertExpectations(t)
 	})
 	t.Run("Error handling (Call error)", func(t *testing.T) {
 		contractBinding := &mocks.PegoutContractAdapterMock{}

--- a/internal/adapters/dataproviders/rootstock/pegout_contract_test.go
+++ b/internal/adapters/dataproviders/rootstock/pegout_contract_test.go
@@ -368,6 +368,21 @@ func TestPegoutContractImpl_RefundPegout(t *testing.T) {
 		contractBinding.AssertNotCalled(t, "RefundPegOut")
 		callerMock.AssertExpectations(t)
 	})
+	t.Run("Error handling (empty revert data from bridge)", func(t *testing.T) {
+		contractMock := createBoundContractMock()
+		pegoutContract := rootstock.NewPegoutContractImpl(rootstock.NewRskClient(mockClient), test.AnyAddress, contractMock.contract, signerMock, rootstock.RetryParams{}, time.Duration(1), pegoutBinding, Abis)
+		e := NewRskRpcError("execution reverted", "0x")
+		contractMock.caller.EXPECT().CallContract(
+			mock.Anything,
+			matchCallData(txData),
+			mock.Anything,
+		).Return(nil, e).Once()
+		result, err := pegoutContract.RefundPegout(txConfig, refundParams)
+		require.ErrorIs(t, err, blockchain.WaitingForBridgeError)
+		assert.Empty(t, result)
+		contractMock.caller.AssertExpectations(t)
+		contractMock.transactor.AssertNotCalled(t, "SendTransaction")
+	})
 	t.Run("Error handling (Call error)", func(t *testing.T) {
 		contractBinding := &mocks.PegoutContractAdapterMock{}
 		callerMock := &mocks.ContractCallerBindingMock{}


### PR DESCRIPTION
## What
Panic in refund pegout flow

## Why
The reason behind this change.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [x] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2266)

## How to test
Check that LPS does not crash when  the RSK node returns an rpc.DataError whose ErrorData() 
 is "0x" (no payload, not even a 4-byte selector) 

## Reviewer Guidelines
Special things to take into consideration during review


## Screenshots (if applicable)
Add screenshots or GIFs to help explain your changes.


## Additional Notes
Add any other context about the pull request here. 