### PR TITLE
fix(FLY-2101): fix misleading /pegin/recommended validation error

### DIFF
--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       context: ../rskj
       args:
         UID: "${LPS_UID}"
-        RSKJ_VERSION: "${RSKJ_VERSION}"
+        RSKJ_VERSION: "${RSKJ_VERSION:-8.1.0~noble}"
     pull_policy: build
     image: rskj:latest
     container_name: rskj01

--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       context: ../rskj
       args:
         UID: "${LPS_UID}"
+        RSKJ_VERSION: "${RSKJ_VERSION}"
     pull_policy: build
     image: rskj:latest
     container_name: rskj01

--- a/internal/adapters/entrypoints/rest/handlers/recommended_pegin.go
+++ b/internal/adapters/entrypoints/rest/handlers/recommended_pegin.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"math/big"
+	"net/http"
+	"strings"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/pkg"
-	"math/big"
-	"net/http"
-	"strings"
 )
 
 type RecommendedPeginUseCase interface {
@@ -65,19 +66,37 @@ func NewRecommendedPeginHandler(useCase RecommendedPeginUseCase) http.HandlerFun
 		}
 
 		result, err := useCase.Run(r.Context(), entities.NewBigWei(parsedAmount), destinationAddress, parsedData)
-
-		if errors.Is(err, usecases.NoLiquidityError) ||
-			errors.Is(err, usecases.TxBelowMinimumError) ||
-			errors.Is(err, liquidity_provider.AmountOutOfRangeError) {
-			jsonErr := rest.NewErrorResponse(err.Error(), true)
-			rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
-			return
-		} else if err != nil {
-			jsonErr := rest.NewErrorResponseWithDetails(UnknownErrorMessage, rest.DetailsFromError(err), false)
-			rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
+		if handleRecommendedPeginError(w, err) {
 			return
 		}
 		response := pkg.ToRecommendedOperationDTO(result)
 		rest.JsonResponseWithBody(w, http.StatusOK, &response)
 	}
+}
+
+func handleRecommendedPeginError(w http.ResponseWriter, err error) bool {
+	var effectiveTooLowErr *usecases.EffectiveAmountTooLowError
+	if errors.As(err, &effectiveTooLowErr) {
+		details := rest.ErrorDetails{
+			"effectiveAmount":    effectiveTooLowErr.EffectiveAmount,
+			"minEffectiveAmount": effectiveTooLowErr.MinEffectiveAmount,
+			"suggestedAmount":    effectiveTooLowErr.SuggestedAmount,
+		}
+		jsonErr := rest.NewErrorResponseWithDetails(effectiveTooLowErr.Error(), details, true)
+		rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
+		return true
+	}
+	if errors.Is(err, usecases.NoLiquidityError) ||
+		errors.Is(err, usecases.TxBelowMinimumError) ||
+		errors.Is(err, liquidity_provider.AmountOutOfRangeError) {
+		jsonErr := rest.NewErrorResponse(err.Error(), true)
+		rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
+		return true
+	}
+	if err != nil {
+		jsonErr := rest.NewErrorResponseWithDetails(UnknownErrorMessage, rest.DetailsFromError(err), false)
+		rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
+		return true
+	}
+	return false
 }

--- a/internal/adapters/entrypoints/rest/handlers/recommended_pegin_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/recommended_pegin_test.go
@@ -1,6 +1,10 @@
 package handlers_test
 
 import (
+	"net/http"
+	"net/url"
+	"testing"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest/handlers"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
@@ -9,9 +13,6 @@ import (
 	"github.com/rsksmart/liquidity-provider-server/test/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"net/http"
-	"net/url"
-	"testing"
 )
 
 // nolint:funlen
@@ -98,6 +99,22 @@ func TestNewRecommendedPeginHandler(t *testing.T) {
 		useCase.EXPECT().Run(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(usecases.RecommendedOperationResult{}, liquidity_provider.AmountOutOfRangeError)
 		handler := handlers.NewRecommendedPeginHandler(useCase)
 		assert.HTTPStatusCode(t, handler, http.MethodGet, path, queryFull, http.StatusBadRequest)
+	})
+	t.Run("should return 400 with structured details when effective amount is too low after fees", func(t *testing.T) {
+		effectiveErr := usecases.NewEffectiveAmountTooLowError(
+			entities.NewWei(5999310330477010),
+			entities.NewWei(6000000000000000),
+			entities.NewWei(6000689669522990),
+		)
+		useCase := new(mocks.RecommendedPeginUseCaseMock)
+		// Return the error wrapped as the use case produces it, to exercise the errors.As unwrap path in the handler.
+		useCase.EXPECT().Run(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(usecases.RecommendedOperationResult{}, usecases.WrapUseCaseError(usecases.RecommendedPeginId, effectiveErr))
+		handler := handlers.NewRecommendedPeginHandler(useCase)
+		assert.HTTPStatusCode(t, handler, http.MethodGet, path, queryFull, http.StatusBadRequest)
+		assert.HTTPBodyContains(t, handler, http.MethodGet, path, queryFull, "Amount too low")
+		assert.HTTPBodyContains(t, handler, http.MethodGet, path, queryFull, `"effectiveAmount":5999310330477010`)
+		assert.HTTPBodyContains(t, handler, http.MethodGet, path, queryFull, `"minEffectiveAmount":6000000000000000`)
+		assert.HTTPBodyContains(t, handler, http.MethodGet, path, queryFull, `"suggestedAmount":6000689669522990`)
 	})
 	t.Run("should return 400 if there is no liquidity for the recommended amount", func(t *testing.T) {
 		useCase := new(mocks.RecommendedPeginUseCaseMock)

--- a/internal/usecases/common.go
+++ b/internal/usecases/common.go
@@ -99,6 +99,28 @@ var (
 	NonPositiveConfirmationKeyError = errors.New("confirmation amount key must be positive")
 )
 
+type EffectiveAmountTooLowError struct {
+	EffectiveAmount    *entities.Wei
+	MinEffectiveAmount *entities.Wei
+	SuggestedAmount    *entities.Wei
+}
+
+func NewEffectiveAmountTooLowError(effectiveAmount, minEffectiveAmount, suggestedAmount *entities.Wei) *EffectiveAmountTooLowError {
+	return &EffectiveAmountTooLowError{
+		EffectiveAmount:    effectiveAmount,
+		MinEffectiveAmount: minEffectiveAmount,
+		SuggestedAmount:    suggestedAmount,
+	}
+}
+
+func (e *EffectiveAmountTooLowError) Error() string {
+	return fmt.Sprintf(
+		"Amount too low: after fees your effective amount is %s, but it must be at least %s.",
+		e.EffectiveAmount.String(),
+		e.MinEffectiveAmount.String(),
+	)
+}
+
 type RecommendedOperationResult struct {
 	RecommendedQuoteValue *entities.Wei
 	EstimatedCallFee      *entities.Wei

--- a/internal/usecases/pegin/recommended_pegin.go
+++ b/internal/usecases/pegin/recommended_pegin.go
@@ -74,15 +74,15 @@ func (useCase *RecommendedPeginUseCase) Run(
 	// It is an estimate because gas is re-estimated against the original user amount, not the
 	// suggested one, so the follow-up request may yield a slightly different fee.
 	// requiredNet = ceil(MinValue * totalPercentages / scale)
-	// suggestedAmount = gasFee + fixedFee + requiredNet
+	// minimumAcceptable = gasFee + fixedFee + requiredNet
 	minValue := config.MinValue.AsBigInt()
 	requiredNet := new(big.Int).Mul(minValue, totalPercentages)
 	requiredNet.Add(requiredNet, new(big.Int).Sub(big.NewInt(useCase.scale), big.NewInt(1)))
 	requiredNet.Quo(requiredNet, big.NewInt(useCase.scale))
-	suggestedAmount := new(big.Int).Add(gasFeeEstimation, fixedCallFeeEstimation)
-	suggestedAmount.Add(suggestedAmount, requiredNet)
+	minimumAcceptable := new(big.Int).Add(gasFeeEstimation, fixedCallFeeEstimation)
+	minimumAcceptable.Add(minimumAcceptable, requiredNet)
 
-	if err = useCase.validateRecommendedValue(ctx, config, result, suggestedAmount); err != nil {
+	if err = useCase.validateRecommendedValue(ctx, config, result, minimumAcceptable); err != nil {
 		return usecases.RecommendedOperationResult{}, err
 	}
 
@@ -140,17 +140,21 @@ func (useCase *RecommendedPeginUseCase) validateRecommendedValue(
 	ctx context.Context,
 	config liquidity_provider.PeginConfiguration,
 	result *big.Int,
-	suggestedAmount *big.Int,
+	minimumAcceptable *big.Int,
 ) error {
 	minValue := config.MinValue.AsBigInt()
-	if result.Cmp(minValue) < 0 {
-		if suggestedAmount.Cmp(config.MaxValue.AsBigInt()) > 0 {
-			return usecases.WrapUseCaseError(usecases.RecommendedPeginId,
-				fmt.Errorf("no valid input amount exists within provider range: %w", liquidity_provider.AmountOutOfRangeError),
-			)
-		}
+	if result.Cmp(minValue) < 0 && minimumAcceptable.Cmp(config.MaxValue.AsBigInt()) > 0 {
 		return usecases.WrapUseCaseError(usecases.RecommendedPeginId,
-			usecases.NewEffectiveAmountTooLowError(entities.NewBigWei(result), config.MinValue.Copy(), entities.NewBigWei(suggestedAmount)),
+			fmt.Errorf(
+				"suggested minimum amount %s exceeds provider max %s with current fee estimates: %w",
+				entities.NewBigWei(minimumAcceptable).String(),
+				config.MaxValue.String(),
+				liquidity_provider.AmountOutOfRangeError,
+			),
+		)
+	} else if result.Cmp(minValue) < 0 {
+		return usecases.WrapUseCaseError(usecases.RecommendedPeginId,
+			usecases.NewEffectiveAmountTooLowError(entities.NewBigWei(result), config.MinValue.Copy(), entities.NewBigWei(minimumAcceptable)),
 		)
 	}
 

--- a/internal/usecases/pegin/recommended_pegin.go
+++ b/internal/usecases/pegin/recommended_pegin.go
@@ -70,7 +70,19 @@ func (useCase *RecommendedPeginUseCase) Run(
 	scaledBase := new(big.Int).Mul(big.NewInt(useCase.scale), result)
 	result.Quo(scaledBase, totalPercentages)
 
-	if err = useCase.validateRecommendedValue(ctx, config, result); err != nil {
+	// Compute a best-effort minimum raw input that should produce result >= MinValue after fees.
+	// It is an estimate because gas is re-estimated against the original user amount, not the
+	// suggested one, so the follow-up request may yield a slightly different fee.
+	// requiredNet = ceil(MinValue * totalPercentages / scale)
+	// suggestedAmount = gasFee + fixedFee + requiredNet
+	minValue := config.MinValue.AsBigInt()
+	requiredNet := new(big.Int).Mul(minValue, totalPercentages)
+	requiredNet.Add(requiredNet, new(big.Int).Sub(big.NewInt(useCase.scale), big.NewInt(1)))
+	requiredNet.Quo(requiredNet, big.NewInt(useCase.scale))
+	suggestedAmount := new(big.Int).Add(gasFeeEstimation, fixedCallFeeEstimation)
+	suggestedAmount.Add(suggestedAmount, requiredNet)
+
+	if err = useCase.validateRecommendedValue(ctx, config, result, suggestedAmount); err != nil {
 		return usecases.RecommendedOperationResult{}, err
 	}
 
@@ -128,21 +140,26 @@ func (useCase *RecommendedPeginUseCase) validateRecommendedValue(
 	ctx context.Context,
 	config liquidity_provider.PeginConfiguration,
 	result *big.Int,
+	suggestedAmount *big.Int,
 ) error {
-	var err error
-
-	if err = config.ValidateAmount(entities.NewBigWei(result)); err != nil {
-		err = fmt.Errorf("recommended amount %s is out of range: %w", entities.NewBigWei(result).String(), err)
-		return usecases.WrapUseCaseError(usecases.RecommendedPeginId, err)
+	minValue := config.MinValue.AsBigInt()
+	if result.Cmp(minValue) < 0 {
+		if suggestedAmount.Cmp(config.MaxValue.AsBigInt()) > 0 {
+			return usecases.WrapUseCaseError(usecases.RecommendedPeginId,
+				fmt.Errorf("no valid input amount exists within provider range: %w", liquidity_provider.AmountOutOfRangeError),
+			)
+		}
+		return usecases.WrapUseCaseError(usecases.RecommendedPeginId,
+			usecases.NewEffectiveAmountTooLowError(entities.NewBigWei(result), config.MinValue.Copy(), entities.NewBigWei(suggestedAmount)),
+		)
 	}
 
-	if err = useCase.peginProvider.HasPeginLiquidity(ctx, entities.NewBigWei(result)); err != nil {
+	if err := useCase.peginProvider.HasPeginLiquidity(ctx, entities.NewBigWei(result)); err != nil {
 		return usecases.WrapUseCaseError(usecases.RecommendedPeginId, usecases.NoLiquidityError)
 	}
 
-	if err = usecases.ValidateMinLockValue(usecases.RecommendedPeginId, useCase.contracts.Bridge, entities.NewBigWei(result)); err != nil {
-		err = fmt.Errorf("recommended amount %s is below the minimum lock value: %w", entities.NewBigWei(result).String(), err)
-		return err
+	if err := usecases.ValidateMinLockValue(usecases.RecommendedPeginId, useCase.contracts.Bridge, entities.NewBigWei(result)); err != nil {
+		return fmt.Errorf("recommended amount %s is below the minimum lock value: %w", entities.NewBigWei(result).String(), err)
 	}
 	return nil
 }

--- a/internal/usecases/pegin/recommended_pegin_test.go
+++ b/internal/usecases/pegin/recommended_pegin_test.go
@@ -2,6 +2,10 @@ package pegin_test
 
 import (
 	"context"
+	"math"
+	"math/big"
+	"testing"
+
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
@@ -13,8 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"math"
-	"testing"
 )
 
 // nolint:funlen
@@ -92,14 +94,32 @@ func TestRecommendedPeginUseCase_Run(t *testing.T) {
 		modifiedConfig.MaxValue = modifiedConfig.MinValue
 		modifiedLimitLp := new(mocks.ProviderMock)
 		modifiedLimitLp.On("PeginConfiguration", mock.Anything).Return(modifiedConfig)
-		modifiedLimitLp.On("GeneralConfiguration", mock.Anything).Return(getGeneralConfiguration())
-		modifiedLimitLp.On("RskAddress").Return(test.AnyRskAddress)
-		modifiedLimitLp.On("BtcAddress").Return(test.AnyBtcAddress)
-		modifiedLimitLp.On("HasPeginLiquidity", mock.Anything, mock.Anything).Return(nil)
 		useCase := pegin.NewRecommendedPeginUseCase(modifiedLimitLp, contracts, rpc, utils.Scale)
-		result, err = useCase.Run(context.Background(), createdQuote.PeginQuote.Total(), test.AnyRskAddress, data)
+		// Input equals MinValue=MaxValue: passes first validation but result after fee deduction is < MinValue
+		// and the suggested amount exceeds MaxValue, so no valid input exists in the provider range.
+		result, err = useCase.Run(context.Background(), modifiedConfig.MinValue, test.AnyRskAddress, data)
 		require.ErrorIs(t, err, liquidity_provider.AmountOutOfRangeError)
 		assert.Empty(t, result)
+		modifiedLimitLp.AssertNotCalled(t, "HasPeginLiquidity")
+	})
+	t.Run("should return EffectiveAmountTooLowError with exact suggested amount when userBalance equals MinValue", func(t *testing.T) {
+		// MinValue=1000, gasFee=20000*100=2000000, fixedFee=100, feePercentage=1.25%, scale=10000
+		// scaledCallFeePercentage=125, totalPercentages=10125
+		// result = floor((1000-2000000-100)*10000/10125) = -1974419
+		// requiredNet = ceil(1000*10125/10000) = 1013
+		// suggestedAmount = 2000000+100+1013 = 2001113
+		useCase := pegin.NewRecommendedPeginUseCase(lp, contracts, rpc, utils.Scale)
+		result, err = useCase.Run(context.Background(), entities.NewWei(1000), test.AnyRskAddress, data)
+		var effectiveErr *usecases.EffectiveAmountTooLowError
+		require.ErrorAs(t, err, &effectiveErr)
+		assert.Empty(t, result)
+		assert.Equal(t, entities.NewWei(1000), effectiveErr.MinEffectiveAmount)
+		assert.Equal(t, entities.NewBigWei(big.NewInt(-1974419)), effectiveErr.EffectiveAmount)
+		assert.Equal(t, entities.NewWei(2001113), effectiveErr.SuggestedAmount)
+		// Verify re-running with the suggested amount succeeds and result >= MinValue
+		successResult, successErr := useCase.Run(context.Background(), effectiveErr.SuggestedAmount, test.AnyRskAddress, data)
+		require.NoError(t, successErr)
+		assert.GreaterOrEqual(t, successResult.RecommendedQuoteValue.Cmp(entities.NewWei(1000)), 0)
 	})
 	t.Run("should validate liquidity is enough for recommended amount", func(t *testing.T) {
 		noLiquidityLp := new(mocks.ProviderMock)

--- a/internal/usecases/pegin/recommended_pegin_test.go
+++ b/internal/usecases/pegin/recommended_pegin_test.go
@@ -105,9 +105,9 @@ func TestRecommendedPeginUseCase_Run(t *testing.T) {
 	t.Run("should return EffectiveAmountTooLowError with exact suggested amount when userBalance equals MinValue", func(t *testing.T) {
 		// MinValue=1000, gasFee=20000*100=2000000, fixedFee=100, feePercentage=1.25%, scale=10000
 		// scaledCallFeePercentage=125, totalPercentages=10125
-		// result = floor((1000-2000000-100)*10000/10125) = -1974419
+		// result = trunc((1000-2000000-100)*10000/10125) = -1974419
 		// requiredNet = ceil(1000*10125/10000) = 1013
-		// suggestedAmount = 2000000+100+1013 = 2001113
+		// minimumAcceptable = 2000000+100+1013 = 2001113
 		useCase := pegin.NewRecommendedPeginUseCase(lp, contracts, rpc, utils.Scale)
 		result, err = useCase.Run(context.Background(), entities.NewWei(1000), test.AnyRskAddress, data)
 		var effectiveErr *usecases.EffectiveAmountTooLowError


### PR DESCRIPTION
## What
Unclear error message and misleading range validation in /pegin/recommended endpoint

## Why
When executing the /pegin/recommended endpoint with an amount parameter equal to the lower bound of the valid range (6000000000000000), the API returns a 400 Bad Request with the following message:
{
  "message": "RecommendedPegin: recommended amount 5999310330477010 is out of range: amount out of range [6000000000000000, 1000000000000000000]",
  "details": {},
  "timestamp": 1762793364,
  "recoverable": true
}
This message is confusing because the user provides a valid amount (equal to the minimum allowed), but the API still rejects it due to internal fee deductions that reduce the effective amount below the minimum threshold.
As a result, users are unable to determine what amount would actually be accepted, and the current message does not clearly explain why the request fails.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [x] Management UI / API
- [ ] PegIn flow
- [ ] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2101)

## How to test
Run corresponding unit  tests.
Use regtest env for:
### 1. Happy path - 1 RBTC, clearly within range
echo "=== 1. Happy path (1 RBTC) ==="
curl -s 'http://localhost:8080/pegin/recommended?amount=1000000000000000000' | jq .

### 2. Below MinValue (0.1 RBTC < 0.6 RBTC min) → AmountOutOfRangeError
echo "=== 2. Below MinValue (0.1 RBTC) ==="
curl -s 'http://localhost:8080/pegin/recommended?amount=100000000000000000' | jq .

### 3. Exactly at MinValue (0.6 RBTC) → after fees result < MinValue → EffectiveAmountTooLowError
echo "=== 3. At MinValue (0.6 RBTC) ==="
curl -s 'http://localhost:8080/pegin/recommended?amount=600000000000000000' | jq .

### 4. Above MaxValue (20 RBTC > 10 RBTC max) → AmountOutOfRangeError
echo "=== 4. Above MaxValue (20 RBTC) ==="
curl -s 'http://localhost:8080/pegin/recommended?amount=20000000000000000000' | jq .
2>&1

## Reviewer Guidelines
Special things to take into consideration during review


## Screenshots (if applicable)
Add screenshots or GIFs to help explain your changes.


## Additional Notes
Add any other context about the pull request here. 