### PR TITLE
FLY-2264 Pegout - Wrong amount message when not enough liquidity in /acceptQuote endpoint

### DIFF
--- a/internal/adapters/dataproviders/liquidity_provider.go
+++ b/internal/adapters/dataproviders/liquidity_provider.go
@@ -105,12 +105,10 @@ func (lp *LocalLiquidityProvider) HasPegoutLiquidity(ctx context.Context, requir
 	}
 	if availableLiquidity.Cmp(requiredLiquidity) >= 0 {
 		return nil
-	} else {
-		return fmt.Errorf(
-			"%w, missing %s satoshi",
-			usecases.NoLiquidityError,
-			requiredLiquidity.Sub(requiredLiquidity, availableLiquidity).ToSatoshi().String(),
-		)
+	}
+	return &usecases.InsufficientLiquidityError{
+		Available: availableLiquidity.Copy(),
+		Required:  requiredLiquidity.Copy(),
 	}
 }
 

--- a/internal/adapters/dataproviders/liquidity_provider_test.go
+++ b/internal/adapters/dataproviders/liquidity_provider_test.go
@@ -270,6 +270,11 @@ func TestLocalLiquidityProvider_HasPegoutLiquidity(t *testing.T) {
 		} else {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.expectedError)
+			require.ErrorIs(t, err, usecases.NoLiquidityError)
+			var insuf *usecases.InsufficientLiquidityError
+			require.ErrorAs(t, err, &insuf)
+			assert.NotNil(t, insuf.Available)
+			assert.NotNil(t, insuf.Required)
 		}
 	}
 	btcWallet.AssertExpectations(t)

--- a/internal/usecases/common.go
+++ b/internal/usecases/common.go
@@ -97,6 +97,22 @@ var (
 	NonPositiveConfirmationKeyError = errors.New("confirmation amount key must be positive")
 )
 
+// InsufficientLiquidityError is returned when available liquidity is below required.
+// It wraps NoLiquidityError for errors.Is compatibility.
+type InsufficientLiquidityError struct {
+	Available *entities.Wei
+	Required  *entities.Wei
+}
+
+func (e *InsufficientLiquidityError) Error() string {
+	missing := new(entities.Wei).Sub(e.Required.Copy(), e.Available.Copy())
+	return fmt.Errorf("%w, missing %s satoshi", NoLiquidityError, missing.ToSatoshi().String()).Error()
+}
+
+func (e *InsufficientLiquidityError) Is(target error) bool {
+	return target == NoLiquidityError
+}
+
 type RecommendedOperationResult struct {
 	RecommendedQuoteValue *entities.Wei
 	EstimatedCallFee      *entities.Wei

--- a/internal/usecases/pegout/accept_pegout_quote.go
+++ b/internal/usecases/pegout/accept_pegout_quote.go
@@ -2,6 +2,7 @@ package pegout
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
@@ -197,16 +198,41 @@ func (useCase *AcceptQuoteUseCase) checkLockingCap(ctx context.Context, trustedA
 }
 
 func (useCase *AcceptQuoteUseCase) calculateAndCheckLiquidity(ctx context.Context, pegoutQuote quote.PegoutQuote) (*entities.Wei, error) {
-	var err error
 	requiredLiquidity := new(entities.Wei)
-	errorArgs := usecases.NewErrorArgs()
-
 	requiredLiquidity.Add(pegoutQuote.Value, pegoutQuote.GasFee)
-	if err = useCase.pegoutLp.HasPegoutLiquidity(ctx, requiredLiquidity); err != nil {
-		errorArgs["amount"] = requiredLiquidity.String()
-		return nil, usecases.WrapUseCaseErrorArgs(usecases.AcceptPegoutQuoteId, usecases.NoLiquidityError, errorArgs)
+
+	err := useCase.pegoutLp.HasPegoutLiquidity(ctx, requiredLiquidity)
+	if err == nil {
+		return requiredLiquidity, nil
 	}
-	return requiredLiquidity, nil
+	if !errors.Is(err, usecases.NoLiquidityError) {
+		return nil, usecases.WrapUseCaseError(usecases.AcceptPegoutQuoteId, err)
+	}
+
+	available, availErr := useCase.pegoutLp.AvailablePegoutLiquidity(ctx)
+	var availableForArgs *entities.Wei
+	if availErr == nil {
+		availableForArgs = available
+	}
+	errorArgs := newPegoutAcceptNoLiquidityErrorArgs(pegoutQuote, requiredLiquidity, availableForArgs)
+	return nil, usecases.WrapUseCaseErrorArgs(usecases.AcceptPegoutQuoteId, err, errorArgs)
+}
+
+// newPegoutAcceptNoLiquidityErrorArgs builds API-facing context when accept fails for insufficient pegout liquidity.
+// available may be nil if it could not be read; missingLiquidity is omitted in that case.
+func newPegoutAcceptNoLiquidityErrorArgs(
+	q quote.PegoutQuote,
+	requiredLiquidity *entities.Wei,
+	available *entities.Wei,
+) usecases.ErrorArgs {
+	args := usecases.NewErrorArgs()
+	args["quoteValue"] = q.Value.String()
+	args["gasFee"] = q.GasFee.String()
+	args["requiredLiquidity"] = requiredLiquidity.String()
+	if available != nil && requiredLiquidity.Cmp(available) > 0 {
+		args["missingLiquidity"] = new(entities.Wei).Sub(requiredLiquidity, available).String()
+	}
+	return args
 }
 
 func (useCase *AcceptQuoteUseCase) publishQuote(

--- a/internal/usecases/pegout/accept_pegout_quote.go
+++ b/internal/usecases/pegout/accept_pegout_quote.go
@@ -209,10 +209,10 @@ func (useCase *AcceptQuoteUseCase) calculateAndCheckLiquidity(ctx context.Contex
 		return nil, usecases.WrapUseCaseError(usecases.AcceptPegoutQuoteId, err)
 	}
 
-	available, availErr := useCase.pegoutLp.AvailablePegoutLiquidity(ctx)
 	var availableForArgs *entities.Wei
-	if availErr == nil {
-		availableForArgs = available
+	var insuf *usecases.InsufficientLiquidityError
+	if errors.As(err, &insuf) {
+		availableForArgs = insuf.Available
 	}
 	errorArgs := newPegoutAcceptNoLiquidityErrorArgs(pegoutQuote, requiredLiquidity, availableForArgs)
 	return nil, usecases.WrapUseCaseErrorArgs(usecases.AcceptPegoutQuoteId, err, errorArgs)
@@ -230,7 +230,7 @@ func newPegoutAcceptNoLiquidityErrorArgs(
 	args["gasFee"] = q.GasFee.String()
 	args["requiredLiquidity"] = requiredLiquidity.String()
 	if available != nil && requiredLiquidity.Cmp(available) > 0 {
-		args["missingLiquidity"] = new(entities.Wei).Sub(requiredLiquidity, available).String()
+		args["missingLiquidity"] = new(entities.Wei).Sub(requiredLiquidity.Copy(), available.Copy()).String()
 	}
 	return args
 }

--- a/internal/usecases/pegout/accept_pegout_quote_test.go
+++ b/internal/usecases/pegout/accept_pegout_quote_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/go-playground/validator/v10"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
@@ -31,6 +32,31 @@ var acceptPegoutQuoteEip712Hash = "95c3ca51e1abd141bed5fb1c1802236aef4e5982ffc07
 var acceptPegoutQuoteHash = "c8d4ad8d5d717371b92950cbe43a6a4e891cf27bcd7603c988595866944bd9cf"
 var acceptPegoutQuoteHashSignature = "b062b09f5f3000f1092e606e90fa449e8527fb1bac20ff72897fd1d0a8aa3b18049d39d1956110992de0284e6d85223d4f69ed06e57184cad13abca7b421d6e41b"
 var ownerAccountAddress = "0x57f9F71E683E2A8ff3d2f394aE45C58b2d913A35"
+
+// pegoutQuoteForAcceptLiquidityFailure returns Value 50 + GasFee 15; used by no-liquidity accept tests.
+func pegoutQuoteForAcceptLiquidityFailure(now time.Time) quote.PegoutQuote {
+	return quote.PegoutQuote{
+		LbcAddress:            "0xabcd01",
+		LpRskAddress:          "0xabcd02",
+		BtcRefundAddress:      "hijk",
+		RskRefundAddress:      "0xabcd04",
+		LpBtcAddress:          "edfg",
+		CallFee:               entities.NewWei(10),
+		PenaltyFee:            entities.NewWei(1),
+		Nonce:                 1,
+		DepositAddress:        "address",
+		Value:                 entities.NewWei(50),
+		AgreementTimestamp:    uint32(now.Unix()),
+		DepositDateLimit:      uint32(now.Unix() + 600),
+		DepositConfirmations:  1,
+		TransferConfirmations: 1,
+		TransferTime:          600,
+		ExpireDate:            uint32(now.Unix() + 600),
+		ExpireBlock:           1,
+		GasFee:                entities.NewWei(15),
+		ChainId:               31,
+	}
+}
 
 func TestAcceptQuoteUseCase_Run_Paused(t *testing.T) {
 	quoteRepository := new(mocks.PegoutQuoteRepositoryMock)
@@ -437,29 +463,9 @@ func TestAcceptQuoteUseCase_Run_QuoteNotFound(t *testing.T) {
 }
 
 func TestAcceptQuoteUseCase_Run_NoLiquidity(t *testing.T) {
-	quoteHash := "0x654321"
+	const quoteHash = "0x654321"
 	now := time.Now()
-	quoteMock := quote.PegoutQuote{
-		LbcAddress:            "0xabcd01",
-		LpRskAddress:          "0xabcd02",
-		BtcRefundAddress:      "hijk",
-		RskRefundAddress:      "0xabcd04",
-		LpBtcAddress:          "edfg",
-		CallFee:               entities.NewWei(10),
-		PenaltyFee:            entities.NewWei(1),
-		Nonce:                 1,
-		DepositAddress:        "address",
-		Value:                 entities.NewWei(50),
-		AgreementTimestamp:    uint32(now.Unix()),
-		DepositDateLimit:      uint32(now.Unix() + 600),
-		DepositConfirmations:  1,
-		TransferConfirmations: 1,
-		TransferTime:          600,
-		ExpireDate:            uint32(now.Unix() + 600),
-		ExpireBlock:           1,
-		GasFee:                entities.NewWei(15),
-		ChainId:               31,
-	}
+	quoteMock := pegoutQuoteForAcceptLiquidityFailure(now)
 	quoteRepositoryMock := new(mocks.PegoutQuoteRepositoryMock)
 	quoteRepositoryMock.On("GetQuote", test.AnyCtx, quoteHash).Return(&quoteMock, nil).Once()
 	quoteRepositoryMock.On("GetRetainedQuote", test.AnyCtx, quoteHash).Return(nil, nil).Once()
@@ -467,6 +473,7 @@ func TestAcceptQuoteUseCase_Run_NoLiquidity(t *testing.T) {
 	pegoutContract.EXPECT().PausedStatus().Return(blockchain.PauseStatus{IsPaused: false}, nil)
 	lp := new(mocks.ProviderMock)
 	lp.On("HasPegoutLiquidity", test.AnyCtx, entities.NewWei(65)).Return(usecases.NoLiquidityError).Once()
+	lp.On("AvailablePegoutLiquidity", test.AnyCtx).Return(entities.NewWei(20), nil).Once()
 	eventBus := new(mocks.EventBusMock)
 	mutex := new(mocks.MutexMock)
 	mutex.On("Lock").Once()
@@ -483,6 +490,38 @@ func TestAcceptQuoteUseCase_Run_NoLiquidity(t *testing.T) {
 	eventBus.AssertNotCalled(t, "Publish")
 	assert.Empty(t, result)
 	require.ErrorIs(t, err, usecases.NoLiquidityError)
+	errMsg := err.Error()
+	require.Contains(t, errMsg, "quoteValue")
+	require.Contains(t, errMsg, "gasFee")
+	require.Contains(t, errMsg, "requiredLiquidity")
+	require.Contains(t, errMsg, "missingLiquidity")
+}
+
+func TestAcceptQuoteUseCase_Run_NoLiquidity_preservesProviderErrorMessage(t *testing.T) {
+	const quoteHash = "0x654321"
+	now := time.Now()
+	quoteMock := pegoutQuoteForAcceptLiquidityFailure(now)
+	liquidityErr := fmt.Errorf("%w, missing 7 satoshi", usecases.NoLiquidityError)
+	quoteRepositoryMock := new(mocks.PegoutQuoteRepositoryMock)
+	quoteRepositoryMock.On("GetQuote", test.AnyCtx, quoteHash).Return(&quoteMock, nil).Once()
+	quoteRepositoryMock.On("GetRetainedQuote", test.AnyCtx, quoteHash).Return(nil, nil).Once()
+	pegoutContract := new(mocks.PegoutContractMock)
+	pegoutContract.EXPECT().PausedStatus().Return(blockchain.PauseStatus{IsPaused: false}, nil)
+	lp := new(mocks.ProviderMock)
+	lp.On("HasPegoutLiquidity", test.AnyCtx, entities.NewWei(65)).Return(liquidityErr).Once()
+	lp.On("AvailablePegoutLiquidity", test.AnyCtx).Return(entities.NewWei(58), nil).Once()
+	eventBus := new(mocks.EventBusMock)
+	mutex := new(mocks.MutexMock)
+	mutex.On("Lock").Once()
+	mutex.On("Unlock").Once()
+	contracts := blockchain.RskContracts{PegOut: pegoutContract}
+	useCase := pegout.NewAcceptQuoteUseCase(quoteRepositoryMock, contracts, lp, lp, eventBus, mutex, trustedAccountRepository, signingHashFunction)
+	result, err := useCase.Run(context.Background(), quoteHash, "")
+	quoteRepositoryMock.AssertExpectations(t)
+	lp.AssertExpectations(t)
+	assert.Empty(t, result)
+	require.ErrorIs(t, err, usecases.NoLiquidityError)
+	require.Contains(t, err.Error(), "missing 7 satoshi")
 }
 
 func TestAcceptQuoteUseCase_Run_ErrorHandling(t *testing.T) {

--- a/internal/usecases/pegout/accept_pegout_quote_test.go
+++ b/internal/usecases/pegout/accept_pegout_quote_test.go
@@ -472,8 +472,10 @@ func TestAcceptQuoteUseCase_Run_NoLiquidity(t *testing.T) {
 	pegoutContract := new(mocks.PegoutContractMock)
 	pegoutContract.EXPECT().PausedStatus().Return(blockchain.PauseStatus{IsPaused: false}, nil)
 	lp := new(mocks.ProviderMock)
-	lp.On("HasPegoutLiquidity", test.AnyCtx, entities.NewWei(65)).Return(usecases.NoLiquidityError).Once()
-	lp.On("AvailablePegoutLiquidity", test.AnyCtx).Return(entities.NewWei(20), nil).Once()
+	lp.On("HasPegoutLiquidity", test.AnyCtx, entities.NewWei(65)).Return(&usecases.InsufficientLiquidityError{
+		Available: entities.NewWei(20),
+		Required:  entities.NewWei(65),
+	}).Once()
 	eventBus := new(mocks.EventBusMock)
 	mutex := new(mocks.MutexMock)
 	mutex.On("Lock").Once()
@@ -509,7 +511,6 @@ func TestAcceptQuoteUseCase_Run_NoLiquidity_preservesProviderErrorMessage(t *tes
 	pegoutContract.EXPECT().PausedStatus().Return(blockchain.PauseStatus{IsPaused: false}, nil)
 	lp := new(mocks.ProviderMock)
 	lp.On("HasPegoutLiquidity", test.AnyCtx, entities.NewWei(65)).Return(liquidityErr).Once()
-	lp.On("AvailablePegoutLiquidity", test.AnyCtx).Return(entities.NewWei(58), nil).Once()
 	eventBus := new(mocks.EventBusMock)
 	mutex := new(mocks.MutexMock)
 	mutex.On("Lock").Once()


### PR DESCRIPTION
## What
Pegout **`POST /pegout/acceptQuote`** liquidity failure (`NoLiquidityError`) now exposes clear context in the wrapped use-case error **`Args`**: **`quoteValue`**, **`gasFee`**, **`requiredLiquidity`**, and **`missingLiquidity`** (when a follow-up read of available liquidity succeeds). The old single **`amount`** field (always the required total) is removed so it is not mistaken for quote size or shortfall alone.

The use case **preserves the error returned by `HasPegoutLiquidity`** (instead of re-wrapping only the bare sentinel), so provider text such as **`missing … satoshi`** remains in the error string surfaced as **`details.error`** on **HTTP 409**. Errors from **`HasPegoutLiquidity`** that are **not** `NoLiquidityError` are propagated without being misclassified as a liquidity shortage.

## Why
[FLY-2264](https://rsklabs.atlassian.net/browse/FLY-2264): QA reported the accept-quote error was misleading—users could not reliably see **quote value** vs **missing** liquidity. Implementation aligns the server payload with that expectation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [x] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[FLY-2264](https://rsklabs.atlassian.net/browse/FLY-2264)

## How to test
- `go test ./internal/usecases/pegout/... -short` (includes `TestAcceptQuoteUseCase_Run_NoLiquidity` and `…_preservesProviderErrorMessage`).
- Optional: `go test -v ./internal/usecases/pegout -run NoLiquidity` and log `err.Error()` to confirm **`Args`** JSON and, in the provider-wrapped case, **`missing … satoshi`** in the same string (this is what the REST layer puts in **`details.error`** for **409** `"not enough liquidity"`).
- Staging / local LPS: reproduce insufficient pegout liquidity (e.g. accept a quote that locks BTC, then accept another) and confirm **409** body: **`message`** unchanged; **`details.error`** contains the new keys and no misleading lone **`amount`**.

## Reviewer Guidelines
- `calculateAndCheckLiquidity` delegates arg shaping to **`newPegoutAcceptNoLiquidityErrorArgs`**; on the no-liquidity path it may call **`AvailablePegoutLiquidity`** once more to fill **`missingLiquidity`**—acceptable tradeoff vs duplicating shortfall math.
- Confirm **backward compatibility** expectations for any client that parsed only **`amount`**.

## Screenshots (if applicable)
N/A (API error string / JSON).

## Additional Notes
Branched from **`v2.5.1`**. Public API shape unchanged at top level (**`message`** + **`details.error`** string); only the contents of that string / embedded **`Args`** JSON change for this failure mode.
