### PR TITLE
fix(FLY-2286): run MongoDB as single-node replica set in docker-compose

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -3,12 +3,12 @@ Go to the [`local` directory](./local) for a detailed explanation of the local s
 
 ## Deploy on Development Server with Testnet Config
 
-For testnet or mainnet environments, use the docker-compose files directly:
+For testnet or mainnet environments, use the docker-compose files directly (requires Docker Compose v2; legacy `docker-compose` v1 is not supported):
 
 ```bash
-docker-compose --env-file .env.testnet down &&
-docker-compose --env-file .env.testnet build --no-cache &&
-docker-compose --env-file .env.testnet up -d
+docker compose --env-file .env.testnet down &&
+docker compose --env-file .env.testnet build --no-cache &&
+docker compose --env-file .env.testnet up -d
 ```
 
 :::danger[Troubleshooting]

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   bitcoind:
     build:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -29,10 +29,27 @@ services:
         "-rpcallowip=0.0.0.0/0",
         "-rpcport=5555",
       ]
+  mongo-keyfile-init:
+    image: alpine:3.20
+    container_name: mongo-keyfile-init
+    restart: "no"
+    entrypoint:
+      - sh
+      - -c
+      - apk add --no-cache openssl >/dev/null && sh /keyfile-init.sh
+    volumes:
+      - ./mongo/keyfile-init.sh:/keyfile-init.sh:ro
+      - mongo_keyfile:/keyfile
+    networks:
+      - net_lps
   mongodb:
     image: mongo:4
     restart: on-failure
     container_name: mongo01
+    hostname: mongo01
+    depends_on:
+      mongo-keyfile-init:
+        condition: service_completed_successfully
     environment:
       - MONGO_INITDB_ROOT_USERNAME=$MONGODB_USER
       - MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD
@@ -41,10 +58,51 @@ services:
       - 27017:27017
     volumes:
       - ${MONGO_HOME:-./volumes/mongo}/logs:/data/db
+      - mongo_keyfile:/etc/mongo:ro
     expose:
       - 27017
     networks:
       - net_lps
+    command:
+      - mongod
+      - --replSet
+      - rs0
+      - --bind_ip_all
+      - --keyFile
+      - /etc/mongo/mongo-keyfile
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >-
+          mongo --quiet
+          -u "$$MONGO_INITDB_ROOT_USERNAME"
+          -p "$$MONGO_INITDB_ROOT_PASSWORD"
+          --authenticationDatabase admin
+          --eval 'rs.isMaster().ismaster' | grep -q true
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+  mongo-rs-init:
+    image: mongo:4
+    container_name: mongo-rs-init
+    restart: "no"
+    depends_on:
+      mongo-keyfile-init:
+        condition: service_completed_successfully
+      mongodb:
+        condition: service_started
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=$MONGODB_USER
+      - MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD
+      - MONGO_HOST=mongo01
+      - MONGO_PORT=27017
+      - REPLICA_SET=rs0
+    volumes:
+      - ./mongo/init-replica-set.sh:/init-replica-set.sh:ro
+    networks:
+      - net_lps
+    entrypoint: ["bash", "/init-replica-set.sh"]
   rskj:
     build:
       context: ./rskj
@@ -155,12 +213,17 @@ services:
       - /mnt/lps/db:/home/lps/db
       - /mnt/lps/logs:/home/lps/logs
     depends_on:
-      - mongodb
-      - bitcoind
+      mongodb:
+        condition: service_healthy
+      bitcoind:
+        condition: service_started
 
     networks:
       - net_lps
     command: ["liquidity-provider-server"]
+
+volumes:
+  mongo_keyfile:
 
 networks:
   net_lps:

--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -70,10 +70,27 @@ services:
       [
         "--${LPS_STAGE}",
       ]
+  mongo-keyfile-init:
+    image: alpine:3.20
+    container_name: mongo-keyfile-init
+    restart: "no"
+    entrypoint:
+      - sh
+      - -c
+      - apk add --no-cache openssl >/dev/null && sh /keyfile-init.sh
+    volumes:
+      - ../mongo/keyfile-init.sh:/keyfile-init.sh:ro
+      - mongo_keyfile:/keyfile
+    networks:
+      - net_lps
   mongodb:
     image: mongo:4
     restart: on-failure
     container_name: mongo01
+    hostname: mongo01
+    depends_on:
+      mongo-keyfile-init:
+        condition: service_completed_successfully
     environment:
       - MONGO_INITDB_ROOT_USERNAME=$MONGODB_USER
       - MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD
@@ -82,10 +99,54 @@ services:
       - 27017:27017
     volumes:
       - ${MONGO_HOME:-./volumes/mongo}/logs:/data/db
+      - mongo_keyfile:/etc/mongo:ro
     expose:
       - 27017
     networks:
       - net_lps
+    command:
+      - mongod
+      - --replSet
+      - rs0
+      - --bind_ip_all
+      - --keyFile
+      - /etc/mongo/mongo-keyfile
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >-
+          mongo --quiet
+          -u "$$MONGO_INITDB_ROOT_USERNAME"
+          -p "$$MONGO_INITDB_ROOT_PASSWORD"
+          --authenticationDatabase admin
+          --eval 'rs.isMaster().ismaster' | grep -q true
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+  mongo-rs-init:
+    image: mongo:4
+    container_name: mongo-rs-init
+    restart: "no"
+    depends_on:
+      mongo-keyfile-init:
+        condition: service_completed_successfully
+      mongodb:
+        condition: service_started
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=$MONGODB_USER
+      - MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD
+      - MONGO_HOST=mongo01
+      - MONGO_PORT=27017
+      - REPLICA_SET=rs0
+    volumes:
+      - ../mongo/init-replica-set.sh:/init-replica-set.sh:ro
+    networks:
+      - net_lps
+    entrypoint: ["bash", "/init-replica-set.sh"]
+
+volumes:
+  mongo_keyfile:
 
 networks:
   net_lps:

--- a/docker-compose/mainnet/README.md
+++ b/docker-compose/mainnet/README.md
@@ -6,6 +6,7 @@
   MongoDB.
 * In both installations you must have a `.env.mainnet` file with appropriate
   variables.
+* Requires Docker Compose v2 (`docker compose`); legacy `docker-compose` v1 is not supported.
 
 # In-place upgrade: standalone MongoDB → single-node replica set (rs0)
 

--- a/docker-compose/mainnet/README.md
+++ b/docker-compose/mainnet/README.md
@@ -1,6 +1,125 @@
 # Usage
-* docker-compose-block must be used on a separate vm where bitcoind is intalled via docker and 
-rskj node is installed locally
-* docker-compose must be used in a separate VM in order to run LPS + mongodb 
-* In both intallations you must have a .env.mainnet file with appropiate variables. 
 
+* `docker-compose-block.yml` must be used on a separate VM where bitcoind is
+  installed via docker and the rskj node is installed locally.
+* `docker-compose.yml` must be used in a separate VM in order to run LPS +
+  MongoDB.
+* In both installations you must have a `.env.mainnet` file with appropriate
+  variables.
+
+# In-place upgrade: standalone MongoDB → single-node replica set (rs0)
+
+`docker-compose.yml` now runs MongoDB as a single-node replica set named `rs0`,
+backed by the existing `${MONGO_HOME:-/mnt/mongo}/logs` dbpath. Internal
+authentication uses a keyfile generated into a docker-managed volume
+(`mongo_keyfile`) by the `mongo-keyfile-init` service; the host filesystem is
+not touched.
+
+This is required so the application driver can open a replica-set topology and
+multi-document transactions (used by `pegoutMongoRepository.UpdateRetainedQuotes`)
+succeed instead of erroring with `Transaction numbers are only allowed on a
+replica set member or mongos`.
+
+Two compose services handle setup:
+
+| Service               | Purpose                                                                 |
+|-----------------------|-------------------------------------------------------------------------|
+| `mongo-keyfile-init`  | One-shot. Generates `/etc/mongo/mongo-keyfile` (0400, owned by mongodb) inside the `mongo_keyfile` named volume. Idempotent. |
+| `mongo-rs-init`       | One-shot. Runs `rs.initiate({_id:"rs0", members:[{_id:0, host:"mongo01:27017"}]})` and waits for PRIMARY. Idempotent. |
+
+`mongodb` is healthy only after `rs.isMaster().ismaster == true`, so
+`docker compose up --wait` blocks until the set is PRIMARY before starting `lps`.
+
+## Procedure
+
+Run these commands on the LPS VM, in this order.
+
+1. **Stop application writers.** Mongo data must be quiescent before the
+   restart. The `lps` service is the only writer.
+
+   ```bash
+   docker compose --env-file .env.mainnet stop lps
+   ```
+
+2. **Back up the existing dbpath.** Take a cold backup of
+   `${MONGO_HOME:-/mnt/mongo}/logs` before flipping any flags. This is the only
+   recovery path if anything goes wrong.
+
+   ```bash
+   docker compose --env-file .env.mainnet stop mongodb
+   tar -czf "mongo-pre-replset-$(date +%F-%H%M).tgz" \
+     -C "${MONGO_HOME:-/mnt/mongo}" logs
+   ```
+
+3. **Pull the new compose changes and bring up the mongo stack.** The
+   `mongo-keyfile-init` and `mongo-rs-init` services are picked up
+   automatically; the existing dbpath is reused as-is.
+
+   ```bash
+   docker compose --env-file .env.mainnet up -d --wait --wait-timeout 300 \
+     mongo-keyfile-init mongodb mongo-rs-init
+   ```
+
+   What happens:
+   - `mongo-keyfile-init` generates the keyfile (or reuses an existing one) and
+     exits 0.
+   - `mongodb` restarts with `--replSet rs0 --keyFile /etc/mongo/mongo-keyfile`
+     against the same dbpath. Existing collections and the existing root user
+     in the `admin` db are preserved.
+   - `mongo-rs-init` runs `rs.initiate(...)` (or detects an already-initialized
+     set on subsequent runs) and waits for PRIMARY.
+   - The `mongodb` healthcheck flips to `healthy` once `ismaster == true`.
+
+4. **Verify the replica set.**
+
+   ```bash
+   docker compose --env-file .env.mainnet exec mongodb \
+     mongo --quiet \
+     -u "$MONGODB_USER" -p "$MONGODB_PASSWORD" \
+     --authenticationDatabase admin \
+     --eval 'JSON.stringify(rs.status().members.map(m => ({name: m.name, stateStr: m.stateStr})))'
+   ```
+
+   Expected:
+
+   ```
+   [{"name":"mongo01:27017","stateStr":"PRIMARY"}]
+   ```
+
+5. **Resume LPS.** No env or URI change is required — the Go driver
+   auto-discovers the replica set from `isMaster` and opens replica-set
+   topology with the existing connection string.
+
+   ```bash
+   docker compose --env-file .env.mainnet up -d --wait lps
+   curl -fsS http://localhost:8080/health
+   ```
+
+   Expected:
+
+   ```
+   {"status":"ok","services":{"db":"ok","rsk":"ok","btc":"ok"}}
+   ```
+
+## Notes
+
+- **Member host name.** `mongo01` is the replica-set member host advertised by
+  `isMaster`. The application container resolves it through the
+  `net_lps` network. Connecting from outside the docker network with a
+  replica-set-aware driver requires either a `127.0.0.1 mongo01` hosts entry or
+  `directConnection=true` in the URI; both are workarounds for ad-hoc shell
+  access only.
+- **The keyfile.** Lives in the `mongo_keyfile` named docker volume, not on
+  the host. Generated once on first `mongo-keyfile-init` run and reused
+  thereafter. `docker compose down` (without `-v`) keeps it; `docker volume rm`
+  or `docker compose down -v` deletes it — after which `mongodb` will fail to
+  start until `mongo-keyfile-init` re-runs.
+- **Going back.** Removing `--replSet rs0` from `mongodb.command` and restarting
+  reverts to standalone mode against the same dbpath. The replica-set
+  metadata in `local.system.replset` is ignored when `--replSet` is absent,
+  but is left in place; if you also want to wipe it, drop the `local` db
+  while running without `--replSet`.
+- **Future cluster expansion.** Adding more members later is a non-breaking
+  `rs.add("host:27017")` from PRIMARY. Members joining will need the same
+  keyfile contents; mount the `mongo_keyfile` volume on each, or distribute
+  the same generated keyfile to each node's dbpath.

--- a/docker-compose/mainnet/docker-compose.yml
+++ b/docker-compose/mainnet/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   mongo-keyfile-init:
     image: alpine:3.20

--- a/docker-compose/mainnet/docker-compose.yml
+++ b/docker-compose/mainnet/docker-compose.yml
@@ -1,9 +1,26 @@
 version: "3"
 services:
+  mongo-keyfile-init:
+    image: alpine:3.20
+    container_name: mongo-keyfile-init
+    restart: "no"
+    entrypoint:
+      - sh
+      - -c
+      - apk add --no-cache openssl >/dev/null && sh /keyfile-init.sh
+    volumes:
+      - ../mongo/keyfile-init.sh:/keyfile-init.sh:ro
+      - mongo_keyfile:/keyfile
+    networks:
+      - net_lps
   mongodb:
     image: mongo:4
     restart: on-failure
     container_name: mongo01
+    hostname: mongo01
+    depends_on:
+      mongo-keyfile-init:
+        condition: service_completed_successfully
     environment:
       - MONGO_INITDB_ROOT_USERNAME=$MONGODB_USER
       - MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD
@@ -12,10 +29,51 @@ services:
       - 27017:27017
     volumes:
       - ${MONGO_HOME:-/mnt/mongo}/logs:/data/db
+      - mongo_keyfile:/etc/mongo:ro
     expose:
       - 27017
     networks:
       - net_lps
+    command:
+      - mongod
+      - --replSet
+      - rs0
+      - --bind_ip_all
+      - --keyFile
+      - /etc/mongo/mongo-keyfile
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >-
+          mongo --quiet
+          -u "$$MONGO_INITDB_ROOT_USERNAME"
+          -p "$$MONGO_INITDB_ROOT_PASSWORD"
+          --authenticationDatabase admin
+          --eval 'rs.isMaster().ismaster' | grep -q true
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+  mongo-rs-init:
+    image: mongo:4
+    container_name: mongo-rs-init
+    restart: "no"
+    depends_on:
+      mongo-keyfile-init:
+        condition: service_completed_successfully
+      mongodb:
+        condition: service_started
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=$MONGODB_USER
+      - MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD
+      - MONGO_HOST=mongo01
+      - MONGO_PORT=27017
+      - REPLICA_SET=rs0
+    volumes:
+      - ../mongo/init-replica-set.sh:/init-replica-set.sh:ro
+    networks:
+      - net_lps
+    entrypoint: ["bash", "/init-replica-set.sh"]
   lps:
     build:
       context: ../
@@ -106,6 +164,9 @@ services:
     volumes:
       - ${LPS_HOME:-/mnt/lps/db}:/home/lps/db
       - ${LPS_HOME:-/mnt/lps/logs}:/home/lps/logs
+    depends_on:
+      mongodb:
+        condition: service_healthy
     networks:
       - net_lps
     command: ["liquidity-provider-server"]
@@ -128,6 +189,9 @@ services:
       [
         "--${LPS_STAGE}",
       ]
+
+volumes:
+  mongo_keyfile:
 
 networks:
   net_lps:

--- a/docker-compose/mongo/init-replica-set.sh
+++ b/docker-compose/mongo/init-replica-set.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Initiates the single-node replica set rs0 against the mongodb container.
+# Idempotent: if the replica set is already configured, the script only
+# waits for PRIMARY and exits. Safe to run on every `docker compose up`.
+
+HOST=${MONGO_HOST:-mongo01}
+PORT=${MONGO_PORT:-27017}
+RS=${REPLICA_SET:-rs0}
+USER=${MONGO_INITDB_ROOT_USERNAME:?MONGO_INITDB_ROOT_USERNAME is required}
+PASS=${MONGO_INITDB_ROOT_PASSWORD:?MONGO_INITDB_ROOT_PASSWORD is required}
+
+mongo_eval() {
+  mongo --host "$HOST" --port "$PORT" --quiet \
+    -u "$USER" -p "$PASS" --authenticationDatabase admin \
+    --eval "$1"
+}
+
+echo "Waiting for MongoDB at $HOST:$PORT to accept authenticated commands..."
+# On a fresh data volume the mongo entrypoint creates the root user during
+# its bootstrap phase, then re-execs mongod with our --replSet command. This
+# loop covers that whole window.
+until mongo_eval 'db.adminCommand({ ping: 1 }).ok' >/dev/null 2>&1; do
+  sleep 2
+done
+
+echo "MongoDB is reachable. Checking replica set state..."
+RS_OK=$(mongo_eval 'try { rs.status().ok } catch (e) { print(0) }' 2>/dev/null | tr -d '[:space:]' || echo 0)
+
+if [ "$RS_OK" = "1" ]; then
+  echo "Replica set $RS already initialized."
+else
+  echo "Initializing replica set $RS with member $HOST:$PORT..."
+  mongo_eval "rs.initiate({_id: '$RS', members: [{_id: 0, host: '$HOST:$PORT'}]})"
+fi
+
+echo "Waiting for $HOST:$PORT to become PRIMARY..."
+until [ "$(mongo_eval 'rs.isMaster().ismaster' 2>/dev/null | tr -d '[:space:]')" = "true" ]; do
+  sleep 2
+done
+
+echo "Replica set $RS is ready and PRIMARY is $HOST:$PORT."

--- a/docker-compose/mongo/keyfile-init.sh
+++ b/docker-compose/mongo/keyfile-init.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+set -eu
+
+# Generates the MongoDB internal-auth keyfile used by --keyFile when running
+# as a replica set. Idempotent: if the keyfile already exists, only the
+# strict ownership and permissions mongod requires are re-applied.
+#
+# The keyfile is stored on a Docker-managed named volume that this service
+# and the mongodb service share. It is never written to the host filesystem.
+
+KEYFILE=/keyfile/mongo-keyfile
+MONGO_UID=999
+MONGO_GID=999
+
+install -d -m 0700 "$(dirname "$KEYFILE")"
+
+if [ -s "$KEYFILE" ]; then
+  echo "Keyfile already present at $KEYFILE; reusing."
+else
+  echo "Generating MongoDB keyfile at $KEYFILE..."
+  openssl rand -base64 756 > "$KEYFILE"
+fi
+
+chown "$MONGO_UID:$MONGO_GID" "$KEYFILE" "$(dirname "$KEYFILE")"
+chmod 0400 "$KEYFILE"
+
+echo "Keyfile ready:"
+ls -l "$KEYFILE"

--- a/test/lp-swap/docker-compose.lps.yml
+++ b/test/lp-swap/docker-compose.lps.yml
@@ -8,7 +8,8 @@ services:
         COMMIT_TAG: "${COMMIT_TAG}"
     image: lps:latest
     depends_on:
-    - mongodb
+      mongodb:
+        condition: service_healthy
     volumes:
       - ./:/mnt
     environment:
@@ -91,9 +92,25 @@ services:
     networks:
       - lp-swap-network
     command: ["liquidity-provider-server"]
+  mongo-keyfile-init:
+    image: alpine:3.20
+    restart: "no"
+    entrypoint:
+      - sh
+      - -c
+      - apk add --no-cache openssl >/dev/null && sh /keyfile-init.sh
+    volumes:
+      - ../../docker-compose/mongo/keyfile-init.sh:/keyfile-init.sh:ro
+      - mongo_keyfile:/keyfile
+    networks:
+      - lp-swap-network
   mongodb:
     image: mongo:4
     restart: on-failure
+    hostname: mongodb
+    depends_on:
+      mongo-keyfile-init:
+        condition: service_completed_successfully
     environment:
       - MONGO_INITDB_ROOT_USERNAME=flyover-user
       - MONGO_INITDB_ROOT_PASSWORD=flyover-password
@@ -102,8 +119,51 @@ services:
       - "27017-27018:27017"
     expose:
       - 27017
+    volumes:
+      - mongo_keyfile:/etc/mongo:ro
     networks:
       - lp-swap-network
+    command:
+      - mongod
+      - --replSet
+      - rs0
+      - --bind_ip_all
+      - --keyFile
+      - /etc/mongo/mongo-keyfile
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >-
+          mongo --quiet
+          -u "$$MONGO_INITDB_ROOT_USERNAME"
+          -p "$$MONGO_INITDB_ROOT_PASSWORD"
+          --authenticationDatabase admin
+          --eval 'rs.isMaster().ismaster' | grep -q true
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+  mongo-rs-init:
+    image: mongo:4
+    restart: "no"
+    depends_on:
+      mongo-keyfile-init:
+        condition: service_completed_successfully
+      mongodb:
+        condition: service_started
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=flyover-user
+      - MONGO_INITDB_ROOT_PASSWORD=flyover-password
+      - MONGO_HOST=mongodb
+      - MONGO_PORT=27017
+      - REPLICA_SET=rs0
+    volumes:
+      - ../../docker-compose/mongo/init-replica-set.sh:/init-replica-set.sh:ro
+    networks:
+      - lp-swap-network
+    entrypoint: ["bash", "/init-replica-set.sh"]
+volumes:
+  mongo_keyfile:
 networks:
   lp-swap-network:
     driver: "bridge"


### PR DESCRIPTION
## What
UpdateRetainedQuotes() in internal/adapters/dataproviders/database/mongo/pegout.go:237 uses session.WithTransaction(), but MongoDB runs as a standalone in our compose setup, so multi-document transactions silently don't work.

## Why
Enables multi-document transactions (e.g. UpdateRetainedQuotes) locally by running mongo with --replSet rs0, auto-initiating rs.initiate() via init container with keyfile auth, and updating compose files plus mainnet README.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [X] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2286)

## How to test
Start local environment with old docker compose then follow 
mainnet README instructions to upgrade mongodb  container.
Check that pegout refund works fully as well as other lps functionality.

## Reviewer Guidelines
Special things to take into consideration during review


## Screenshots (if applicable)
Add screenshots or GIFs to help explain your changes.


## Additional Notes
Add any other context about the pull request here. 