### PR TITLE
chore: upgrade MongoDB image to 8.0 (FLY-2290)

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -30,7 +30,7 @@ services:
         "-rpcport=5555",
       ]
   mongodb:
-    image: mongo:4
+    image: mongo:8.0
     restart: on-failure
     container_name: mongo01
     environment:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       test:
         - "CMD-SHELL"
         - >-
-          mongo --quiet
+          mongosh --quiet
           -u "$$MONGO_INITDB_ROOT_USERNAME"
           -p "$$MONGO_INITDB_ROOT_PASSWORD"
           --authenticationDatabase admin
@@ -83,7 +83,7 @@ services:
       retries: 30
       start_period: 60s
   mongo-rs-init:
-    image: mongo:4
+    image: mongo:8.0
     container_name: mongo-rs-init
     restart: "no"
     depends_on:

--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -71,7 +71,7 @@ services:
         "--${LPS_STAGE}",
       ]
   mongodb:
-    image: mongo:4
+    image: mongo:8.0
     restart: on-failure
     container_name: mongo01
     environment:

--- a/docker-compose/local/docker-compose.yml
+++ b/docker-compose/local/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       test:
         - "CMD-SHELL"
         - >-
-          mongo --quiet
+          mongosh --quiet
           -u "$$MONGO_INITDB_ROOT_USERNAME"
           -p "$$MONGO_INITDB_ROOT_PASSWORD"
           --authenticationDatabase admin
@@ -125,7 +125,7 @@ services:
       retries: 30
       start_period: 60s
   mongo-rs-init:
-    image: mongo:4
+    image: mongo:8.0
     container_name: mongo-rs-init
     restart: "no"
     depends_on:

--- a/docker-compose/mainnet/README.md
+++ b/docker-compose/mainnet/README.md
@@ -4,3 +4,36 @@ rskj node is installed locally
 * docker-compose must be used in a separate VM in order to run LPS + mongodb 
 * In both intallations you must have a .env.mainnet file with appropiate variables. 
 
+## MongoDB 8.0 upgrade (recommended procedure)
+
+The `mongodb` service in this compose file is pinned to `mongo:8.0`. MongoDB does
+not support skipping major versions on an existing data directory, so any
+deployment that still has a `mongo:4` volume on disk must migrate the data
+before pulling the new image. The exact mechanics depend on how the production
+database is operated (volume mounts, managed service, snapshot tooling), so the
+steps below are a reference outline for the operator to adapt:
+
+1. **Quiesce writers.** Stop the `lps` service / container so no new documents
+   are written during the migration window.
+2. **Dump the database.** Run `mongodump --gzip --archive=<path>.archive`
+   against the running `mongo:4` instance and copy the archive to a safe
+   location outside the data volume.
+3. **Retire the old data directory.** Stop the `mongodb` service and either
+   delete the existing data volume or move it aside so the new image starts on
+   a clean directory. Keep the moved-aside copy until the upgrade has been
+   validated, in addition to the archive from step 2.
+4. **Start MongoDB 8.0 on an empty volume.** Bring up the `mongodb` service
+   like in this compose file. Confirm `db.version()` reports `8.0.x` and that
+   `featureCompatibilityVersion` is `8.0`.
+5. **Restore the dump.** Run `mongorestore --gzip --archive=<path>.archive`
+   against the new instance. A cross-version warning from `4.4` to `8.0` is
+   expected; verify the restored collection counts match the pre-upgrade
+   audit.
+6. **Resume writers.** Start the `lps` service again and check the application
+   health endpoint and logs for a clean MongoDB connection and a successful
+   schema migration check.
+
+Roll back by reverting the compose image tag to the previous version, removing
+the 8.0 data directory, and restoring either the moved-aside volume (byte
+identical) or the `mongodump` archive (portable) into a `mongo:4` instance.
+

--- a/docker-compose/mainnet/README.md
+++ b/docker-compose/mainnet/README.md
@@ -8,53 +8,110 @@
   variables.
 * Requires Docker Compose v2 (`docker compose`); legacy `docker-compose` v1 is not supported.
 
-# In-place upgrade: standalone MongoDB → single-node replica set (rs0)
+# Combined upgrade: `mongo:4` standalone → `mongo:8.0` single-node replica set (rs0)
 
-`docker-compose.yml` now runs MongoDB as a single-node replica set named `rs0`,
-backed by the existing `${MONGO_HOME:-/mnt/mongo}/logs` dbpath. Internal
-authentication uses a keyfile generated into a docker-managed volume
-(`mongo_keyfile`) by the `mongo-keyfile-init` service; the host filesystem is
-not touched.
+`docker-compose.yml` now pins `mongodb` to `mongo:8.0` **and** runs it as a
+single-node replica set named `rs0`, with internal authentication via a keyfile
+generated into a docker-managed volume (`mongo_keyfile`).
 
-This is required so the application driver can open a replica-set topology and
-multi-document transactions (used by `pegoutMongoRepository.UpdateRetainedQuotes`)
-succeed instead of erroring with `Transaction numbers are only allowed on a
-replica set member or mongos`.
+Production deployments currently running `mongo:4` standalone must perform both
+changes in a single maintenance window:
 
-Two compose services handle setup:
+- **Major version 4 → 8.** MongoDB does not allow skipping major versions on an
+  existing WiredTiger data directory. The new `mongo:8.0` binary refuses to
+  open a `mongo:4` dbpath; an in-place FCV chain (4.4 → 5.0 → 6.0 → 7.0 → 8.0)
+  is technically possible but requires five sequential image swaps with
+  `setFeatureCompatibilityVersion` between each. We use **dump and restore**
+  instead — one image swap, no FCV gymnastics.
+- **Standalone → replica set.** Required so the Go driver can open a
+  replica-set topology and multi-document transactions used by
+  `pegoutMongoRepository.UpdateRetainedQuotes` succeed instead of erroring with
+  `Transaction numbers are only allowed on a replica set member or mongos`.
 
-| Service               | Purpose                                                                 |
-|-----------------------|-------------------------------------------------------------------------|
-| `mongo-keyfile-init`  | One-shot. Generates `/etc/mongo/mongo-keyfile` (0400, owned by mongodb) inside the `mongo_keyfile` named volume. Idempotent. |
-| `mongo-rs-init`       | One-shot. Runs `rs.initiate({_id:"rs0", members:[{_id:0, host:"mongo01:27017"}]})` and waits for PRIMARY. Idempotent. |
+The two transformations land together on a **fresh empty dbpath** seeded by
+`mongorestore` from a pre-upgrade `mongodump` archive. The old `mongo:4` volume
+is moved aside (not deleted) and serves as the byte-identical rollback.
 
-`mongodb` is healthy only after `rs.isMaster().ismaster == true`, so
-`docker compose up --wait` blocks until the set is PRIMARY before starting `lps`.
+Two compose services handle the new topology:
+
+| Service               | Image       | Purpose                                                                 |
+|-----------------------|-------------|-------------------------------------------------------------------------|
+| `mongo-keyfile-init`  | `alpine:3.20` | One-shot. Generates `/etc/mongo/mongo-keyfile` (0400, owned by mongodb) inside the `mongo_keyfile` named volume. Idempotent. |
+| `mongo-rs-init`       | `mongo:8.0` | One-shot. Runs `rs.initiate({_id:"rs0", members:[{_id:0, host:"mongo01:27017"}]})` and waits for PRIMARY via `mongosh`. Idempotent. |
+
+`mongodb` is healthy only after `rs.isMaster().ismaster == true` (probed with
+`mongosh` in the healthcheck), so `docker compose up --wait` blocks until the
+set is PRIMARY before starting `lps`.
+
+## Pre-flight
+
+Before the maintenance window:
+
+- Confirm you can `mongodump` from the production `mongo:4` instance with the
+  credentials in `.env.mainnet` (`MONGODB_USER` / `MONGODB_PASSWORD`).
+- Make sure there is enough free space on the LPS VM to hold both the moved-aside
+  `mongo:4` dbpath and a `mongodump --gzip` archive of the same database.
+- Have the previous (pre-this-PR) compose file on hand in case rollback is needed.
 
 ## Procedure
 
-Run these commands on the LPS VM, in this order.
+Run these commands on the LPS VM, in this order. Replace `<TS>` with a UTC
+timestamp captured at the start of the window (e.g. `$(date -u +%Y%m%dT%H%M%SZ)`)
+and reuse it throughout — every artifact gets the same suffix so rollback is
+unambiguous.
 
-1. **Stop application writers.** Mongo data must be quiescent before the
-   restart. The `lps` service is the only writer.
+1. **Quiesce writers.** Mongo data must be quiescent before `mongodump`
+   starts. `lps` is the only writer.
 
    ```bash
    docker compose --env-file .env.mainnet stop lps
+   docker ps --filter name=lps01 --format '{{.Names}} {{.Status}}'   # expect empty
    ```
 
-2. **Back up the existing dbpath.** Take a cold backup of
-   `${MONGO_HOME:-/mnt/mongo}/logs` before flipping any flags. This is the only
-   recovery path if anything goes wrong.
+2. **Take a `mongodump` archive from the running `mongo:4` instance.** This is
+   the portable, version-independent rollback artifact. Keep it on the LPS VM
+   filesystem, **not** inside the mongo data volume.
+
+   ```bash
+   TS=$(date -u +%Y%m%dT%H%M%SZ); echo "$TS"
+   mkdir -p ./backups
+
+   docker compose --env-file .env.mainnet exec mongodb \
+     mongodump \
+     -u "$MONGODB_USER" -p "$MONGODB_PASSWORD" \
+     --authenticationDatabase admin \
+     --db flyover \
+     --archive=/data/db/flyover-${TS}.archive --gzip
+
+   docker cp mongo01:/data/db/flyover-${TS}.archive ./backups/flyover-${TS}.archive
+   sha256sum ./backups/flyover-${TS}.archive          # record this hash
+   ```
+
+3. **Stop the old `mongo:4` container and archive the dbpath.** Move
+   (do not delete) `${MONGO_HOME:-/mnt/mongo}/logs` aside; that directory is
+   the byte-identical fallback rollback if the `mongodump` archive itself turns
+   out to be unusable.
 
    ```bash
    docker compose --env-file .env.mainnet stop mongodb
-   tar -czf "mongo-pre-replset-$(date +%F-%H%M).tgz" \
-     -C "${MONGO_HOME:-/mnt/mongo}" logs
+   docker compose --env-file .env.mainnet rm -f mongodb
+
+   sudo mv "${MONGO_HOME:-/mnt/mongo}/logs" "${MONGO_HOME:-/mnt/mongo}/logs.bak-${TS}"
+   ls -ld "${MONGO_HOME:-/mnt/mongo}/logs.bak-"*
    ```
 
-3. **Pull the new compose changes and bring up the mongo stack.** The
-   `mongo-keyfile-init` and `mongo-rs-init` services are picked up
-   automatically; the existing dbpath is reused as-is.
+   Additionally, take a tarball of the moved-aside dbpath if your operations
+   policy requires off-host backup:
+
+   ```bash
+   sudo tar -czf "./backups/mongo-volume-${TS}.tgz" \
+     -C "${MONGO_HOME:-/mnt/mongo}" "logs.bak-${TS}"
+   ```
+
+4. **Pull the new compose changes and bring up the new mongo stack on an
+   empty dbpath.** The new compose file (`mongo:8.0` + `--replSet rs0
+   --keyFile`) creates an empty `${MONGO_HOME:-/mnt/mongo}/logs` and lets
+   `mongo-keyfile-init` and `mongo-rs-init` finish the topology setup.
 
    ```bash
    docker compose --env-file .env.mainnet up -d --wait --wait-timeout 300 \
@@ -62,20 +119,29 @@ Run these commands on the LPS VM, in this order.
    ```
 
    What happens:
-   - `mongo-keyfile-init` generates the keyfile (or reuses an existing one) and
-     exits 0.
-   - `mongodb` restarts with `--replSet rs0 --keyFile /etc/mongo/mongo-keyfile`
-     against the same dbpath. Existing collections and the existing root user
-     in the `admin` db are preserved.
-   - `mongo-rs-init` runs `rs.initiate(...)` (or detects an already-initialized
-     set on subsequent runs) and waits for PRIMARY.
+   - `mongo-keyfile-init` generates `/etc/mongo/mongo-keyfile` in the
+     `mongo_keyfile` named volume and exits 0.
+   - `mongodb` starts on a fresh empty dbpath, runs the standard `mongo:8.0`
+     entrypoint that creates the root user from `MONGO_INITDB_ROOT_*`, then
+     re-execs `mongod --replSet rs0 --bind_ip_all --keyFile
+     /etc/mongo/mongo-keyfile`.
+   - `mongo-rs-init` calls `rs.initiate(...)` via `mongosh` and waits for
+     PRIMARY. On reruns (e.g. `docker compose up` after a restart) it detects
+     the existing set and only waits for PRIMARY, which makes the step
+     idempotent.
    - The `mongodb` healthcheck flips to `healthy` once `ismaster == true`.
 
-4. **Verify the replica set.**
+5. **Verify the new server.** Confirm both the version jump and the topology.
 
    ```bash
    docker compose --env-file .env.mainnet exec mongodb \
-     mongo --quiet \
+     mongosh --quiet \
+     -u "$MONGODB_USER" -p "$MONGODB_PASSWORD" \
+     --authenticationDatabase admin \
+     --eval 'JSON.stringify({version: db.version(), fcv: db.adminCommand({getParameter:1, featureCompatibilityVersion:1}).featureCompatibilityVersion.version})'
+
+   docker compose --env-file .env.mainnet exec mongodb \
+     mongosh --quiet \
      -u "$MONGODB_USER" -p "$MONGODB_PASSWORD" \
      --authenticationDatabase admin \
      --eval 'JSON.stringify(rs.status().members.map(m => ({name: m.name, stateStr: m.stateStr})))'
@@ -84,12 +150,56 @@ Run these commands on the LPS VM, in this order.
    Expected:
 
    ```
+   {"version":"8.0.x","fcv":{"version":"8.0"}}
    [{"name":"mongo01:27017","stateStr":"PRIMARY"}]
    ```
 
-5. **Resume LPS.** No env or URI change is required — the Go driver
+   The `flyover` database should be empty at this point — restore happens
+   next:
+
+   ```bash
+   docker compose --env-file .env.mainnet exec mongodb \
+     mongosh --quiet \
+     -u "$MONGODB_USER" -p "$MONGODB_PASSWORD" \
+     --authenticationDatabase admin \
+     --eval 'db.getSiblingDB("flyover").getCollectionNames()'   # expect []
+   ```
+
+6. **Restore the dump into MongoDB 8.0.** A cross-version warning (4.4 → 8.0)
+   is expected and harmless.
+
+   ```bash
+   docker cp ./backups/flyover-${TS}.archive mongo01:/data/db/restore.archive
+
+   docker compose --env-file .env.mainnet exec mongodb \
+     mongorestore \
+     -u "$MONGODB_USER" -p "$MONGODB_PASSWORD" \
+     --authenticationDatabase admin \
+     --archive=/data/db/restore.archive --gzip --drop
+
+   docker compose --env-file .env.mainnet exec mongodb \
+     rm -f /data/db/restore.archive
+   ```
+
+   Re-run the count query and compare every collection against your
+   pre-upgrade audit:
+
+   ```bash
+   docker compose --env-file .env.mainnet exec mongodb \
+     mongosh --quiet \
+     -u "$MONGODB_USER" -p "$MONGODB_PASSWORD" \
+     --authenticationDatabase admin flyover \
+     --eval 'db.getCollectionNames().forEach(c => print(c + " " + db.getCollection(c).countDocuments({})));'
+   ```
+
+   Every collection must have the same document count as before step 1. If
+   any count is missing or wrong, **stop and roll back** — do not start
+   `lps`.
+
+7. **Resume LPS.** No env or URI change is required — the Go driver
    auto-discovers the replica set from `isMaster` and opens replica-set
-   topology with the existing connection string.
+   topology with the existing `MONGODB_HOST` / `MONGODB_PORT` connection
+   string.
 
    ```bash
    docker compose --env-file .env.mainnet up -d --wait lps
@@ -101,6 +211,52 @@ Run these commands on the LPS VM, in this order.
    ```
    {"status":"ok","services":{"db":"ok","rsk":"ok","btc":"ok"}}
    ```
+
+   In the LPS logs, expect:
+   - `Connecting to MongoDB`
+   - `Database already at version 1, no migrations needed` (the restored
+     `schema_migrations` row carries forward)
+   - the standard index-creation lines on `depositEvents.tx_hash`,
+     `trustedAccounts`, `batchPegOutEvents.transaction_hash`
+   - `Connected to MongoDB`
+
+   Drive a small canary pegin and pegout quote through the API before
+   declaring the window complete.
+
+## Rollback
+
+If anything between steps 4 and 7 fails irrecoverably, roll back to the
+pre-upgrade `mongo:4` standalone state.
+
+```bash
+# 1. stop the new 8.0 stack
+docker compose --env-file .env.mainnet stop lps mongo-rs-init mongodb
+docker compose --env-file .env.mainnet rm -f mongo-rs-init mongodb
+
+# 2. drop the new (now-tainted) data dir and restore the moved-aside 4.4 volume
+sudo rm -rf "${MONGO_HOME:-/mnt/mongo}/logs"
+sudo mv "${MONGO_HOME:-/mnt/mongo}/logs.bak-${TS}" "${MONGO_HOME:-/mnt/mongo}/logs"
+
+# 3. revert docker-compose.yml to the previous version (mongo:4, no --replSet,
+#    no keyfile, no mongo-keyfile-init / mongo-rs-init services). Then:
+docker compose --env-file .env.mainnet up -d --wait mongodb
+docker compose --env-file .env.mainnet up -d --wait lps
+```
+
+Second fallback — if the moved-aside `logs.bak-<TS>` directory is also
+unusable, restore the `mongodump` archive into a fresh `mongo:4` instance:
+
+```bash
+docker run --rm -d --name mongo-rollback \
+  -e MONGO_INITDB_ROOT_USERNAME=$MONGODB_USER \
+  -e MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD \
+  -v "${MONGO_HOME:-/mnt/mongo}/logs:/data/db" \
+  mongo:4
+docker cp ./backups/flyover-${TS}.archive mongo-rollback:/tmp/restore.archive
+docker exec mongo-rollback mongorestore \
+  -u "$MONGODB_USER" -p "$MONGODB_PASSWORD" --authenticationDatabase admin \
+  --archive=/tmp/restore.archive --gzip
+```
 
 ## Notes
 
@@ -115,45 +271,15 @@ Run these commands on the LPS VM, in this order.
   thereafter. `docker compose down` (without `-v`) keeps it; `docker volume rm`
   or `docker compose down -v` deletes it — after which `mongodb` will fail to
   start until `mongo-keyfile-init` re-runs.
-- **Going back.** Removing `--replSet rs0` from `mongodb.command` and restarting
-  reverts to standalone mode against the same dbpath. The replica-set
-  metadata in `local.system.replset` is ignored when `--replSet` is absent,
-  but is left in place; if you also want to wipe it, drop the `local` db
-  while running without `--replSet`.
+- **Shell.** `mongo:8.0` ships `mongosh` only; the legacy `mongo` shell is
+  gone. Every `docker exec`/healthcheck example above uses `mongosh`.
+- **Why no in-place FCV chain.** Stepping the existing volume through 4.4 → 5.0
+  → 6.0 → 7.0 → 8.0 would also work, but each step requires its own image swap
+  and `setFeatureCompatibilityVersion` cycle. Dump and restore is one swap and
+  produces a clean WiredTiger data directory written by 8.0 from scratch,
+  which is also what the rehearsal in
+  `.vscode/my-doc/tasks/FLY-2290/prod-upgrade-regtest.md` validates.
 - **Future cluster expansion.** Adding more members later is a non-breaking
   `rs.add("host:27017")` from PRIMARY. Members joining will need the same
   keyfile contents; mount the `mongo_keyfile` volume on each, or distribute
   the same generated keyfile to each node's dbpath.
-
-# MongoDB 8.0 upgrade (recommended procedure)
-
-The `mongodb` service in this compose file is pinned to `mongo:8.0`. MongoDB does
-not support skipping major versions on an existing data directory, so any
-deployment that still has a `mongo:4` volume on disk must migrate the data
-before pulling the new image. The exact mechanics depend on how the production
-database is operated (volume mounts, managed service, snapshot tooling), so the
-steps below are a reference outline for the operator to adapt:
-
-1. **Quiesce writers.** Stop the `lps` service / container so no new documents
-   are written during the migration window.
-2. **Dump the database.** Run `mongodump --gzip --archive=<path>.archive`
-   against the running `mongo:4` instance and copy the archive to a safe
-   location outside the data volume.
-3. **Retire the old data directory.** Stop the `mongodb` service and either
-   delete the existing data volume or move it aside so the new image starts on
-   a clean directory. Keep the moved-aside copy until the upgrade has been
-   validated, in addition to the archive from step 2.
-4. **Start MongoDB 8.0 on an empty volume.** Bring up the `mongodb` service
-   like in this compose file. Confirm `db.version()` reports `8.0.x` and that
-   `featureCompatibilityVersion` is `8.0`.
-5. **Restore the dump.** Run `mongorestore --gzip --archive=<path>.archive`
-   against the new instance. A cross-version warning from `4.4` to `8.0` is
-   expected; verify the restored collection counts match the pre-upgrade
-   audit.
-6. **Resume writers.** Start the `lps` service again and check the application
-   health endpoint and logs for a clean MongoDB connection and a successful
-   schema migration check.
-
-Roll back by reverting the compose image tag to the previous version, removing
-the 8.0 data directory, and restoring either the moved-aside volume (byte
-identical) or the `mongodump` archive (portable) into a `mongo:4` instance.

--- a/docker-compose/mainnet/docker-compose.yml
+++ b/docker-compose/mainnet/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   mongodb:
-    image: mongo:4
+    image: mongo:8.0
     restart: on-failure
     container_name: mongo01
     environment:

--- a/docker-compose/mainnet/docker-compose.yml
+++ b/docker-compose/mainnet/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       test:
         - "CMD-SHELL"
         - >-
-          mongo --quiet
+          mongosh --quiet
           -u "$$MONGO_INITDB_ROOT_USERNAME"
           -p "$$MONGO_INITDB_ROOT_PASSWORD"
           --authenticationDatabase admin
@@ -54,7 +54,7 @@ services:
       retries: 30
       start_period: 60s
   mongo-rs-init:
-    image: mongo:4
+    image: mongo:8.0
     container_name: mongo-rs-init
     restart: "no"
     depends_on:

--- a/docker-compose/mongo/init-replica-set.sh
+++ b/docker-compose/mongo/init-replica-set.sh
@@ -12,7 +12,7 @@ USER=${MONGO_INITDB_ROOT_USERNAME:?MONGO_INITDB_ROOT_USERNAME is required}
 PASS=${MONGO_INITDB_ROOT_PASSWORD:?MONGO_INITDB_ROOT_PASSWORD is required}
 
 mongo_eval() {
-  mongo --host "$HOST" --port "$PORT" --quiet \
+  mongosh --host "$HOST" --port "$PORT" --quiet \
     -u "$USER" -p "$PASS" --authenticationDatabase admin \
     --eval "$1"
 }

--- a/test/lp-swap/docker-compose.lps.yml
+++ b/test/lp-swap/docker-compose.lps.yml
@@ -134,7 +134,7 @@ services:
       test:
         - "CMD-SHELL"
         - >-
-          mongo --quiet
+          mongosh --quiet
           -u "$$MONGO_INITDB_ROOT_USERNAME"
           -p "$$MONGO_INITDB_ROOT_PASSWORD"
           --authenticationDatabase admin
@@ -144,7 +144,7 @@ services:
       retries: 30
       start_period: 60s
   mongo-rs-init:
-    image: mongo:4
+    image: mongo:8.0
     restart: "no"
     depends_on:
       mongo-keyfile-init:

--- a/test/lp-swap/docker-compose.lps.yml
+++ b/test/lp-swap/docker-compose.lps.yml
@@ -92,7 +92,7 @@ services:
       - lp-swap-network
     command: ["liquidity-provider-server"]
   mongodb:
-    image: mongo:4
+    image: mongo:8.0
     restart: on-failure
     environment:
       - MONGO_INITDB_ROOT_USERNAME=flyover-user


### PR DESCRIPTION
## What
Upgrade the MongoDB server image to 8.0 in
docker-compose/docker-compose.yml
docker-compose/local/docker-compose.yml
docker-compose/mainnet/docker-compose.yml
test/lp-swap/docker-compose.lps.yml

## Why
The mongo:4 Docker image is pinned across all environments in the LPS repo, but MongoDB 4.x reached end-of-life on Feb 29, 2024 (over 2 years past EOL as of May 2026). It no longer receives security patches except for the recent MongoBleed backport, and any 4.x version below 4.4.30 is exposed to CVE-2025-14847 (MongoBleed).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [x] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [ ] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2290)

## How to test
There is description in JIRA task

## Reviewer Guidelines
Special things to take into consideration during review


## Screenshots (if applicable)
Add screenshots or GIFs to help explain your changes.


## Additional Notes
Add any other context about the pull request here. 