### PR TITLE
docs(FLY-2308): logging library SPIKE — recommend slog

### DIFF
--- a/docs/spikes/logs.md
+++ b/docs/spikes/logs.md
@@ -1,0 +1,633 @@
+# Logging library comparison and recommendation
+
+## Decision
+
+Adopt `log/slog` behind a thin LPS-owned `internal/logging` package.
+
+The wrapper should expose the native slog key/value API plus a small set of helpers for LPS-specific gaps: initialization, error fields, fatal-equivalent logging, lazy values, trace propagation, PII redaction, and test capture.
+
+Replace `gorilla/handlers.LoggingHandler` with structured request-logging middleware during the migration.
+
+## Demo packages
+
+The four runnable prototypes live under [spike/logging/](../../spike/logging/). Each is its own `main` package with the same per-deliverable file layout (see [Prototype deliverables](#prototype-deliverables) below), so the comparison axes below can be checked against working code:
+
+| Library  | Demo                                         | Notable file                                                                              |
+|----------|----------------------------------------------|-------------------------------------------------------------------------------------------|
+| logrus   | [spike/logging/logrus/](../../spike/logging/logrus/)   | [pii.go](../../spike/logging/logrus/pii.go) — hook-based redaction                       |
+| **slog** | [spike/logging/slog/](../../spike/logging/slog/)       | [pii.go](../../spike/logging/slog/pii.go) — `ReplaceAttr` redaction (the cleanest)        |
+| zap      | [spike/logging/zap/](../../spike/logging/zap/)         | [pii.go](../../spike/logging/zap/pii.go) — `zapcore.Core` wrapper                         |
+| zerolog  | [spike/logging/zerolog/](../../spike/logging/zerolog/) | [pii.go](../../spike/logging/zerolog/pii.go) — io.Writer regexp (awkward, deliberately)   |
+
+Run any demo with:
+
+```sh
+LOG_FORMAT=json LOG_LEVEL=info go run ./spike/logging/slog
+go test ./spike/logging/...
+```
+
+See [spike/logging/README.md](../../spike/logging/README.md) for what each demo exercises.
+
+## Why this is the recommendation
+
+The SPIKE did not find a hard blocker against the Rootstock Go guideline that already recommends `log/slog`. All four candidates can be made compliant with the Base Logging Standards, but they do not have the same migration cost or long-term shape.
+
+`slog` is the best fit for LPS because it is standard library, aligns with the org guideline, has a clean handler-level redaction point, supports context-aware logging natively, has an OpenTelemetry bridge in the OpenTelemetry Go contrib project, and avoids introducing a new application-wide logging dependency during a migration that already touches about 325 call sites.
+
+The main slog gaps are real but small and centralized:
+
+- No built-in fatal level.
+- No built-in stack trace field.
+- Lazy evaluation is explicit, not automatic.
+- `logfmt` needs either a small handler or a third-party handler if it is required beyond local text output.
+
+Those gaps fit naturally in `internal/logging`. They do not justify choosing zap or zerolog for this codebase.
+
+## Current LPS baseline
+
+Measured on the current branch:
+
+- Go files importing `github.com/sirupsen/logrus`: 80.
+- Unstructured `log.Info`, `log.Warn`, `log.Error`, `log.Debug`, `log.Fatal`, `log.Trace`, `log.Panic`, `log.Print` calls: about 260.
+- Formatted `log.<Level>f(...)` calls: about 65.
+- Structured `log.WithField` or `log.WithFields` calls: 0.
+- Test calls to `log.SetOutput(...)`: 5 calls across 4 test files.
+- Production call to `log.SetOutput(file)`: 1, in `cmd/application/main.go`.
+- Test calls to `log.SetLevel(log.DebugLevel)`: 32 calls across 7 test files.
+- Logger initialization points: `cmd/application/main.go` and `internal/adapters/entrypoints/rest/server/server.go`.
+- Go version in `go.mod`: `go 1.25.9`.
+
+The conclusion: LPS does not meaningfully use logrus structured logging today. Almost every call site is either string concatenation or `Printf`-style formatting.
+
+This matters for the decision. We cannot keep most call sites unchanged and become compliant. Every option requires rewriting the logging surface; the real comparison is which rewrite is most mechanical and leaves the smallest long-term API.
+
+## Hard requirements from the task
+
+The Base Logging Standards require every candidate demo to show:
+
+- `LOG_FORMAT` supporting `json`, `logfmt`, and `otel` where supported.
+- `LOG_LEVEL` configurable at startup.
+- No plain unstructured output outside local development.
+- Required fields on every log line: `timestamp`, `level`, `service`, `environment`, `version`, `traceId`, `message`.
+- Inbound W3C `traceparent` extraction, with a generated trace if the header is absent.
+- `traceId` carried through `context.Context` and emitted on every request-scoped log line.
+- Outbound HTTP/RPC `traceparent` injection with a fresh span-id.
+- Error logs containing `errorCode`, `errorMessage`, `errorStack`, and `errorContext`.
+- PII drop or redaction by key for `privateKey`, `seed`, `mnemonic`, `apiKey`, `password`, and `authorization`.
+- Either compatibility with `gorilla/handlers.LoggingHandler` through `io.Writer`, or a structured replacement.
+- A test-output capture story for asserting on log content.
+
+None of the four libraries fails these requirements outright. The difference is how much LPS code must be built around each one.
+
+## Candidate assessment
+
+### logrus
+
+Best argument for it:
+
+- It is already installed and wired into the app.
+- `log.SetOutput` and `log.SetLevel` match the current test patterns.
+- Hooks can mutate `Entry.Data`, which is a usable PII redaction point.
+- `WriterLevel` already provides the `io.Writer` adapter used by `gorilla/handlers.LoggingHandler`.
+
+Problems:
+
+- It is in maintenance mode. The README explicitly says there will be no new features.
+- The current LPS codebase uses none of its structured APIs.
+- Context propagation is not first-class. `WithContext` stores context, but it does not extract trace data or attach fields by itself.
+- Stack traces, error shape, W3C Trace Context, and format switching still require custom code.
+- Keeping it contradicts the Go guideline unless the SPIKE finds a blocker in slog, zap, or zerolog. It did not.
+
+Decision: do not choose logrus. It remains useful only as the baseline.
+
+### log/slog
+
+Best argument for it:
+
+- It is standard library since Go 1.21 and requires no new dependency.
+- It matches the Rootstock Go guideline direction.
+- `InfoContext`, `WarnContext`, `ErrorContext`, and `LogAttrs` make context-aware logging part of the native API.
+- `HandlerOptions.ReplaceAttr` is the cleanest PII interception point in the comparison.
+- Handler wrapping is a natural place to add request `traceId` from `context.Context`.
+- `otelslog` exists in `go.opentelemetry.io/contrib/bridges/otelslog`; paper check shows v0.18.0 in the OpenTelemetry Go contrib project.
+- Test capture can be centralized with a buffer-backed JSON handler and a shared `slog.LevelVar`.
+
+Problems:
+
+- No native fatal method.
+- No native stack trace field.
+- Lazy evaluation requires explicit use of `slog.LogValuer`, `LogAttrs`, or an LPS helper.
+- `logfmt` is not in the standard library.
+
+Decision: choose slog with a thin wrapper. Its gaps are small, centralized, and mostly the same cross-cutting code LPS needs regardless of library.
+
+### zap
+
+Best argument for it:
+
+- Strong production reputation and active maintenance.
+- Excellent performance.
+- Best native stack-trace story: `zap.Stack(...)`.
+- Best test capture story: `zaptest/observer`.
+- OTel bridge exists in `go.opentelemetry.io/contrib/bridges/otelzap`.
+- Lazy evaluation is strong when using typed fields and `Check()`.
+
+Problems:
+
+- The typed `zap.Field` API makes the migration less mechanical. Each call site needs decisions such as `zap.String`, `zap.Stringer`, `zap.Int`, `zap.Any`, or a custom marshaler.
+- `SugaredLogger` reduces migration friction but gives up part of the reason to choose zap.
+- It introduces a new application-wide logging dependency.
+- The org guideline rejects zap as the direct API.
+- PII redaction is possible with `zapcore.WrapCore` and a custom encoder, but it is more code than slog's `ReplaceAttr`.
+
+Decision: do not choose zap. It is technically strong, but its advantages do not offset the migration cost for LPS.
+
+### zerolog
+
+Best argument for it:
+
+- Very fast and low-allocation.
+- Fluent API gives good lazy-evaluation behavior.
+- Small dependency footprint.
+- Maintained; paper check shows recent v1.35.x versions.
+
+Problems:
+
+- Fluent chaining is the most different shape from logrus and slog. It makes the migration the least mechanical.
+- PII redaction by arbitrary key is awkward because fields are built through a fluent event API, not a record map.
+- OTel bridge maturity is weaker than slog and zap; it is community-driven rather than an OTel contrib bridge.
+- The org guideline rejects zerolog as the direct API.
+
+Decision: do not choose zerolog. Its runtime performance is not the limiting factor for LPS, and its migration/API shape is the weakest fit.
+
+## Executive comparison matrix
+
+This is a table in plain-text form to keep Cursor/VSCode markdown preview stable.
+
+```text
+Axis                                logrus             slog                zap                 zerolog
+Format switch                       Medium             Good                Good                Medium
+Migration from logrus               Poor if compliant  Best                Expensive           Expensive
+Test capture                        Good               Good                Best                Medium
+io.Writer adapter                   Best               Small wrapper       zapio.Writer        Small wrapper
+Fatal semantics                     Built in           Wrapper             Built in            Built in
+context.Context propagation         Weak               Best                Medium              Medium
+W3C Trace Context                   DIY                DIY + clean handler DIY                 DIY
+Base-field attachment               Medium             Best                Good                Good
+Stack for errorStack                Weak               Wrapper             Best                Hook needed
+Lazy field evaluation               Weak               Explicit helper     Good                Best
+PII deny-list hook                  Good               Best                Medium              Weak
+OTel bridge maturity                Weak               Good                Good                Weak
+Dependency footprint                Existing external  Best                Medium              Good
+Maintenance signal                  Weak               Best                Good                Medium
+Org guideline alignment             Rejected           Recommended         Rejected            Rejected
+Overall fit for LPS                 Do not choose      Choose              Do not choose       Do not choose
+```
+
+## Comparison across required axes
+
+### Format switch ergonomics
+
+Winner: `slog`, with a small caveat for `logfmt`.
+
+- logrus: JSON and text are built in; `logfmt` needs a custom Formatter; OTel requires a third-party path.
+- slog: JSON and text are built in; OTel has `otelslog`; `logfmt` needs a small handler or a third-party handler.
+- zap: JSON and console are built in; `logfmt` needs a custom Encoder; OTel has `otelzap`.
+- zerolog: JSON and console are built in; `logfmt` needs custom work; OTel bridge is community-only.
+
+Recommendation for LPS: implement `json` now, support `otel` through `otelslog` in the demo, and keep `logfmt` as a small handler only if the standards review insists on it. For local development, slog text output is acceptable unless the standards owners require exact logfmt.
+
+### Migration cost from logrus
+
+Winner: `slog`.
+
+- logrus has zero migration cost only if LPS accepts the current standards gaps, which the task explicitly does not.
+- slog is the most mechanical rewrite: string logs become `slog.InfoContext(ctx, "message", "key", value)` or `slog.Info("message", ...)`.
+- zap requires per-field type choices across hundreds of call sites.
+- zerolog requires rewriting each call into fluent chains.
+
+### Test capture ergonomics
+
+Winner in isolation: zap. Winner for LPS migration: slog.
+
+- zap's `zaptest/observer` is the strongest test API.
+- slog can use a buffer-backed JSON handler and assertion helpers in `internal/logging/logtest`.
+- logrus already works with `SetOutput`, but that keeps the current library.
+- zerolog can write JSON to a buffer, but tests then parse JSON manually or through helpers.
+
+LPS has 5 `SetOutput` calls and 32 level toggles. A slog test helper is enough; zap's nicer test API does not justify the heavier migration.
+
+See: [zap `observer.New`](../../spike/logging/zap/capture_test.go) (typed records, no JSON parsing) vs. buffer-based capture in [slog](../../spike/logging/slog/capture_test.go), [logrus](../../spike/logging/logrus/capture_test.go), and [zerolog](../../spike/logging/zerolog/capture_test.go). The buffer approach is repetitive across libraries, but the assertion site stays similar — JSON-parse, then check fields.
+
+### `io.Writer` adapter complexity
+
+Winner if keeping `gorilla/handlers.LoggingHandler`: logrus.
+
+- logrus already uses `WriterLevel`.
+- slog needs a small `io.Writer` wrapper.
+- zap has `zapio.Writer`.
+- zerolog needs a small custom wrapper.
+
+However, this axis should not decide the library. The existing `LoggingHandler` emits plain text and violates the standard. The correct LPS decision is to replace it with structured request middleware.
+
+### Fatal semantics
+
+Winner: logrus, zap, zerolog.
+
+- logrus, zap, and zerolog have fatal APIs.
+- slog intentionally does not.
+
+For LPS this is not a blocker. Fatal usage is startup-oriented and can be centralized as `logging.Fatal(ctx, msg, attrs...)`, which logs and calls `os.Exit(1)`.
+
+### `context.Context` propagation
+
+Winner: `slog`.
+
+- slog has native context-aware methods.
+- logrus can store context but does not interpret it.
+- zap and zerolog need helper packages or manual context/logger plumbing.
+
+LPS needs request-scoped trace fields. Slog's handler model is the cleanest match.
+
+See: [`slog`'s `contextHandler`](../../spike/logging/slog/utils.go) vs. the per-call-site [`baseEntry(ctx)`](../../spike/logging/logrus/utils.go) (logrus), [`loggerWithTrace(ctx)`](../../spike/logging/zap/utils.go) (zap), and [`loggerWithTrace(ctx)`](../../spike/logging/zerolog/utils.go) (zerolog) — only slog adds trace fields without the call site having to ask.
+
+### W3C Trace Context support
+
+No library wins outright.
+
+Every candidate needs LPS middleware to parse inbound `traceparent`, generate a trace if absent, store trace state in `context.Context`, and inject outbound `traceparent` with a fresh span-id.
+
+Slog still has the best fit after that middleware exists, because the handler can read `ctx` and add `traceId` to every record.
+
+### Base-field auto-attachment
+
+Winner: `slog`.
+
+- slog supports base fields through `logger.With(...)` and can set the configured logger as default.
+- logrus supports `WithFields`, but LPS would need to ensure the derived logger is used everywhere.
+- zap supports base fields through `zap.Fields(...)`.
+- zerolog supports base fields through `log.With().Str(...).Logger()`.
+
+Slog's default logger plus handler attrs keeps call sites small and consistent with the Go guideline.
+
+### Stack trace capture for `errorStack`
+
+Winner: zap.
+
+- zap has the best native stack support.
+- slog needs an LPS helper around `runtime.Callers`.
+- logrus needs custom code.
+- zerolog needs a stack-marshaling hook.
+
+For LPS, slog's gap is acceptable because error shape should be centralized anyway. `logging.Error` should be the only place that decides how `errorCode`, `errorMessage`, `errorContext`, and `errorStack` are emitted.
+
+See: [`zap.Stack("errorStack")`](../../spike/logging/zap/errors.go) (one-liner native) vs. the hand-rolled `captureStack` in [slog](../../spike/logging/slog/errors.go), [logrus](../../spike/logging/logrus/errors.go), and [zerolog](../../spike/logging/zerolog/errors.go) — three near-identical 20-line helpers that fit naturally inside `internal/logging` for slog.
+
+### Lazy evaluation of field values
+
+Winner: zerolog and zap.
+
+- zerolog's event chain avoids most work when the level is disabled.
+- zap supports lazy behavior through typed fields, object marshalers, and `Check()`.
+- slog supports lazy values through `slog.LogValuer`, but callers must use it.
+- logrus does not help; arguments are evaluated before the call.
+
+For LPS, the recommendation is to add `logging.Lazy(func() any) slog.LogValuer` and document it for expensive values such as transaction serialization. Most current log calls are cheap string/error values, so this does not justify choosing another library.
+
+### PII deny-list interception
+
+Winner: `slog`.
+
+- slog has `HandlerOptions.ReplaceAttr`, which sees attributes before serialization and can recurse into groups.
+- logrus hooks can mutate `Entry.Data`, which is also good.
+- zap can wrap the core or encoder, but the implementation is more involved.
+- zerolog hooks are less natural for arbitrary key-based redaction.
+
+This is one of the strongest slog arguments for the Base Logging Standards.
+
+See: [slog `piiRedactor`](../../spike/logging/slog/pii.go) (one function, recurses into groups) vs. [logrus `piiRedactHook`](../../spike/logging/logrus/pii.go) (hook mutating `Entry.Data`), [zap `piiCore`](../../spike/logging/zap/pii.go) (full `zapcore.Core` wrapper), and [zerolog `piiWriter`](../../spike/logging/zerolog/pii.go) (regex over the serialized JSON — workable but the weakest of the four).
+
+### OTel bridge maturity
+
+Winner: slog and zap.
+
+- slog: `go.opentelemetry.io/contrib/bridges/otelslog`, maintained in the OTel Go contrib project.
+- zap: `go.opentelemetry.io/contrib/bridges/otelzap`, also maintained in OTel Go contrib.
+- logrus: community paths only.
+- zerolog: community paths only.
+
+The task only asks for Level-1 paper evaluation. Full OTel SDK adoption remains out of scope.
+
+### Dependency footprint
+
+Winner: `slog`.
+
+- slog adds no logging dependency.
+- logrus is already present but remains an external dependency in maintenance mode.
+- zap adds `go.uber.org/zap` and transitive support packages such as `multierr`.
+- zerolog adds `github.com/rs/zerolog`.
+
+Binary-size deltas should be measured in the prototype branch if reviewers want exact numbers. For the recommendation, the important point is dependency shape: slog is already in the toolchain.
+
+### Active maintenance signal
+
+Winner: slog for risk profile; zap for third-party library maturity.
+
+- slog is maintained as part of Go.
+- zap is actively maintained by Uber and has a large production user base.
+- zerolog is maintained and has recent v1.35.x versions, but the maintainer base is smaller.
+- logrus is maintained for compatibility and fixes, but explicitly not for new features.
+
+## Recommended LPS design
+
+Create `internal/logging` with this limited surface:
+
+- `Init(config Config)`: reads `LOG_FORMAT`, `LOG_LEVEL`, service name, environment, version, and output target; builds the handler stack; calls `slog.SetDefault`.
+- `Error(ctx context.Context, msg string, err error, attrs ...slog.Attr)`: emits `errorCode`, `errorMessage`, `errorStack`, and `errorContext`.
+- `Fatal(ctx context.Context, msg string, attrs ...slog.Attr)`: logs once, flushes if needed, then calls `os.Exit(1)`.
+- `Lazy(func() any) slog.LogValuer`: canonical helper for expensive fields.
+- `WithTrace(ctx context.Context, trace TraceContext) context.Context`: stores parsed trace state in context.
+- `TraceMiddleware(next http.Handler) http.Handler`: extracts inbound `traceparent` or creates a trace.
+- `TraceTransport(next http.RoundTripper) http.RoundTripper`: injects outbound `traceparent`.
+- `logtest.NewBuffer(t)` and `logtest.SetLevel(t, level)`: replace direct `SetOutput` and `SetLevel` usage in tests.
+
+The rest of the code should use slog's native API:
+
+```go
+slog.InfoContext(ctx, "quote accepted",
+    "quoteHash", quoteHash,
+    "operation", "acceptQuote",
+)
+```
+
+Avoid building another fluent layer on top. The wrapper should enforce shared behavior at initialization and handler boundaries, not by creating a new logging language at every call site.
+
+## Base Logging Standards compliance for the recommended option
+
+### Format and output
+
+`LOG_FORMAT`:
+
+- `json`: production default, backed by `slog.NewJSONHandler`.
+- `otel`: prototype through `otelslog.NewHandler`.
+- `logfmt`: supported through a small handler only if the standards review requires exact logfmt output. Otherwise, use slog text for local development.
+
+`LOG_LEVEL`:
+
+- Parsed at startup into a `slog.LevelVar`.
+- Test helper can temporarily set it for assertions.
+
+No plain unstructured output:
+
+- Replace `gorilla/handlers.LoggingHandler`.
+- Remove string-only access logs.
+- Migrate call sites to key/value fields.
+
+### Required base fields
+
+Attached at initialization:
+
+- `service`
+- `environment`
+- `version`
+
+Emitted by the handler:
+
+- `timestamp`
+- `level`
+- `message`
+
+Attached per request through context:
+
+- `traceId`
+
+### Distributed tracing
+
+Inbound:
+
+- Middleware reads `traceparent`.
+- If missing or invalid, middleware generates a new trace.
+- Trace state is stored in `context.Context`.
+- Slog handler wrapper adds `traceId` to each record.
+
+Outbound:
+
+- HTTP/RPC transport wrapper reads trace state from `context.Context`.
+- It injects `traceparent` with the same trace-id and a fresh span-id.
+- Integration logs include `integrationName`, `integrationMethod`, `integrationDurationMs`, and `integrationStatusCode`.
+
+### Error logs
+
+`logging.Error` is responsible for the standard shape:
+
+- `errorCode`: use case id or sentinel/domain code.
+- `errorMessage`: root error message.
+- `errorStack`: captured at the logging boundary.
+- `errorContext`: wrapping chain and relevant attrs.
+
+Fatal-equivalent logging reuses the same error field rules where an error exists.
+
+### Sensitive data
+
+Install PII redaction in `HandlerOptions.ReplaceAttr`.
+
+The deny list is:
+
+- `privateKey`
+- `seed`
+- `mnemonic`
+- `apiKey`
+- `password`
+- `authorization`
+
+Policy: redact by default rather than silently dropping, unless the standards owner requires dropping. Redaction keeps the operational signal that a field was attempted without leaking the value.
+
+### LPS-specific access logs
+
+Replace `gorilla/handlers.LoggingHandler` with middleware that emits one structured record per request:
+
+- `httpMethod`
+- `httpPath`
+- `httpStatusCode`
+- `durationMs`
+- `userAgent`
+- `requestId`
+
+Because the trace middleware runs earlier, `traceId` is already available to the handler wrapper and does not need to be passed manually.
+
+### Test capture
+
+Replace direct logrus mutation in tests with `internal/logging/logtest`:
+
+- Buffered JSON handler for assertions.
+- Level override helper backed by `slog.LevelVar`.
+- Helpers to assert message, level, and fields.
+
+This is enough for the current test usage and avoids exposing logger internals across tests.
+
+## Open tensions - resolved
+
+### Tension 1: FluentLogger vs direct library API
+
+Position: use direct slog-style key/value calls through a thin wrapper. Do not build a fluent builder.
+
+Reasons:
+
+- The Go guideline already points toward `slog.Default` from a shared logging package.
+- Required base fields are better attached at initialization than repeated through a builder.
+- PII rejection belongs in `ReplaceAttr`, not in call-site builders.
+- Trace enrichment belongs in a handler that reads `context.Context`.
+- Lazy evaluation is handled by `slog.LogValuer` plus `logging.Lazy`.
+- A fluent builder would create a second logging API and make future migration to a shared org package harder.
+
+Scope for other Go services:
+
+- The principle should propagate: prefer native slog API plus a small shared wrapper.
+- LPS should not define an org-wide builder pattern from this SPIKE.
+- If Rootstock later ships `org/log`, LPS should be able to swap imports with minimal code churn.
+
+### Tension 2: keep or replace `gorilla/handlers.LoggingHandler`
+
+Position: replace it.
+
+Reasons:
+
+- The handler emits plain-text Apache-style access logs.
+- The Base Logging Standards explicitly reject unstructured output outside local development.
+- An `io.Writer` adapter would make the library compatible but would not make the output compliant.
+- A structured middleware is small and directly produces the six required HTTP fields.
+- `gorilla/handlers` is only used for this logging handler in the repo; removing that dependency does not affect `gorilla/mux`, `csrf`, `securecookie`, or `sessions`.
+
+## Prototype deliverables
+
+The four throwaway packages on this SPIKE branch live at:
+
+```text
+spike/logging/
+  logrus/    -> spike/logging/logrus/
+  slog/      -> spike/logging/slog/
+  zap/       -> spike/logging/zap/
+  zerolog/   -> spike/logging/zerolog/
+```
+
+Each package splits the standard into one file per deliverable so the
+implementations diff cleanly. Within each file, **demo functions come
+first** (what `main.go` calls), then the helpers they exercise — so a
+reviewer sees the requirement before the machinery.
+
+| File              | Purpose                                                                                                                                 | slog (recommended)                                                              |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| `main.go`         | End-to-end orchestration — numbered checklist of the ten Base Logging Standards                                                       | [spike/logging/slog/main.go](../../spike/logging/slog/main.go)                  |
+| `config.go`       | `demoLogFormatSupport`, `demoLogLevelConfiguredAtStartup`, `demoStructuredOutputOnly`, `demoRequiredFields`                             | [spike/logging/slog/config.go](../../spike/logging/slog/config.go)              |
+| `utils.go`        | `Config`, env parsing, `initLogger`, package state, library-specific base-field / trace helper                                          | [spike/logging/slog/utils.go](../../spike/logging/slog/utils.go)                |
+| `real_project_examples.go` | `demoRealLPSUseCaseLogging` (info path) and `demoRealLPSUseCaseError` (sentinel + `WrapUseCaseError` migrated to the structured error shape, with `errors.Is` still matching) | [spike/logging/slog/real_project_examples.go](../../spike/logging/slog/real_project_examples.go) |
+| `tracing.go`      | Trace demos, `hit`, W3C plumbing, `traceMiddleware`, `traceTransport`, `sampleHandler`                                                  | [spike/logging/slog/tracing.go](../../spike/logging/slog/tracing.go)            |
+| `errors.go`       | `demoErrorFields`, `demoFatal`, then `logError` / `logFatal` and stack capture                                                          | [spike/logging/slog/errors.go](../../spike/logging/slog/errors.go)              |
+| `pii.go`          | `demoPIIRedaction`, then deny-list redaction (`privateKey`, `seed`, `mnemonic`, …)                                                      | [spike/logging/slog/pii.go](../../spike/logging/slog/pii.go)                    |
+| `capture_test.go` | Test-output capture helper + assertions                                                                                                 | [spike/logging/slog/capture_test.go](../../spike/logging/slog/capture_test.go)  |
+
+Each file inside a demo uses its corresponding library at every log site. In particular **`traceMiddleware` in `tracing.go`** is the structured request-logging middleware the SPIKE recommends as the gorilla `LoggingHandler` replacement — implemented four times so the trace-decision log and the six standard HTTP fields read in the library's native idiom. The only shared code is the W3C trace-context plumbing (parse / mint / context get-set / `statusRecorder`), which is data, not logging — its near-identical duplication across all four demos is deliberate, so side-by-side diffs of *logging* code are clean.
+
+Each demo must produce comparable output for:
+
+- Startup setup with `LOG_FORMAT` and `LOG_LEVEL`.
+- Base fields auto-attached at initialization.
+- Real LPS pegout-rebalance domain fields imported from `internal/entities` and `internal/usecases`, including the sentinel + `WrapUseCaseError` pattern as a structured error log with `errors.Is` still matching the sentinel after wrapping.
+- Request info log with `httpMethod`, `httpPath`, `httpStatusCode`, `durationMs`, `userAgent`, and `requestId`.
+- Outbound integration log with `integrationName`, `integrationMethod`, `integrationDurationMs`, and `integrationStatusCode`.
+- Error log with `errorCode`, `errorMessage`, `errorStack`, and `errorContext`.
+- PII attempt using `privateKey`.
+- Fatal-equivalent logging.
+- Test capture.
+
+If a candidate cannot produce one item cleanly, the demo should state the reason in its package README.
+
+## Migration effort and risk
+
+### Recommended path: slog + wrapper
+
+Estimated effort: one sprint, 1 PR.
+
+Risk: low to medium.
+
+Why:
+
+- The migration is broad but mostly mechanical.
+- The wrapper centralizes the non-stdlib behavior.
+- No new logging dependency is introduced.
+- The biggest behavior change is replacing access logging and converting unstructured strings to key/value fields.
+
+### zap
+
+Estimated effort: one sprint, 1 PR.
+
+Risk: medium.
+
+Why:
+
+- Better stack and test tools.
+- More per-call-site thought because of typed fields.
+- New dependency and direct API not aligned with the guideline.
+
+### zerolog
+
+Estimated effort: one sprint, 1 PR.
+
+Risk: medium-high.
+
+Why:
+
+- Fast runtime behavior.
+- Largest API-shape change from current logrus calls.
+- Awkward PII interception story.
+- Weaker OTel bridge maturity.
+
+### logrus
+
+Estimated effort: 0 days if doing nothing; more if made compliant.
+
+Risk: medium-high and increasing.
+
+Why:
+
+- Does not satisfy the standards in the current codebase.
+- Library is in maintenance mode.
+- Keeping it would require most of the same wrapper/middleware work while staying on a deprecated direction.
+
+## Acceptance status
+
+Covered by this document:
+
+- Candidate comparison against all requested axes.
+- Section-by-section compliance check for the recommended library.
+- Recommendation with reasoning.
+- Migration effort and risk per option.
+- Explicit positions on FluentLogger vs direct slog API.
+- Explicit position on replacing `gorilla/handlers.LoggingHandler`.
+- Suggested follow-up PR split.
+
+Delivered on this SPIKE branch:
+
+- Four demo packages under [`spike/logging/`](../../spike/logging/) (logrus, slog, zap, zerolog).
+- Each demo includes a project-aware example that imports LPS packages and logs representative pegout-rebalance fields, plus the sentinel + `WrapUseCaseError` pattern flowing into the structured error shape (`real_project_examples.go`).
+- Each demo includes inbound trace extraction and outbound injection (`tracing.go`).
+- Each demo includes error logging with all four required error fields and a stack (`errors.go`).
+- Each demo includes the PII deny-list attempt (`pii.go`).
+- Each demo includes a test-capture helper with three asserting tests (`capture_test.go`); all pass under `go test ./spike/logging/...`.
+
+Still required before closing FLY-2308:
+
+- Notion publication of this document.
+- Review by at least one team member.
+
+## References
+
+- FLY-2308 task description.
+- Rootstock Observability Standards draft: Base Logging Standards, Golang sub-page, FluentLogger Appendix.
+- logrus README and releases: maintenance-mode notice, latest observed v1.9.4.
+- Go `log/slog` package documentation.
+- `go.opentelemetry.io/contrib/bridges/otelslog` package documentation.
+- `go.opentelemetry.io/contrib/bridges/otelzap` package documentation.
+- zap package documentation, including `zaptest/observer` and `zapio`.
+- zerolog package documentation and releases.
+- LPS code anchors: `cmd/application/main.go`, `internal/adapters/entrypoints/rest/server/server.go`, and `test/utils.go`.

--- a/go.mod
+++ b/go.mod
@@ -72,10 +72,13 @@ require (
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/rs/zerolog v1.35.1 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/supranational/blst v0.3.16 // indirect
@@ -90,6 +93,8 @@ require (
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
+	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
@@ -290,6 +292,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=
+github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
@@ -344,6 +348,10 @@ go.opentelemetry.io/otel/trace v1.40.0 h1:WA4etStDttCSYuhwvEa8OP8I5EWu24lkOzp+ZY
 go.opentelemetry.io/otel/trace v1.40.0/go.mod h1:zeAhriXecNGP/s2SEG3+Y8X9ujcJOTqQ5RgdEJcawiA=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.28.0 h1:IZzaP1Fv73/T/pBMLk4VutPl36uNC+OSUh3JLG3FIjo=
+go.uber.org/zap v1.28.0/go.mod h1:rDLpOi171uODNm/mxFcuYWxDsqWSAVkFdX4XojSKg/Q=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
 go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -386,6 +394,7 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=

--- a/spike/logging/README.md
+++ b/spike/logging/README.md
@@ -1,0 +1,114 @@
+# `spike/logging/` — FLY-2308 logging library demos
+
+Throwaway code that supports the comparison in
+[`docs/spikes/logs.md`](../../docs/spikes/logs.md). Each subdirectory is a
+self-contained `main` package that exercises the same scenario against a
+different logger, so the comparison axes in the SPIKE doc are backed by
+runnable evidence.
+
+> Status: SPIKE-only. Not wired into the application. Not for production
+> use. Will be deleted after the migration tickets land per
+> [`docs/spikes/logs.md`](../../docs/spikes/logs.md#suggested-migration-pr-split).
+
+## Layout
+
+```text
+spike/logging/
+  logrus/    baseline — what LPS uses today
+  slog/      stdlib — the recommended target (see logs.md)
+  zap/       Uber's library — strongest stack + test story
+  zerolog/   rs/zerolog — fluent, low-allocation
+```
+
+Each demo is split into per-deliverable files so the comparison axes in
+[`docs/spikes/logs.md`](../../docs/spikes/logs.md#prototype-deliverables)
+can be diffed across libraries one axis at a time. Within each file,
+**demo functions are at the top** (what `main.go` calls), then the helpers
+they exercise:
+
+| File              | What it shows                                                                                                      |
+|-------------------|--------------------------------------------------------------------------------------------------------------------|
+| `main.go`         | End-to-end orchestration: numbered checklist of the ten Base Logging Standards deliverables                        |
+| `config.go`       | `demoLogFormatSupport`, `demoLogLevelConfiguredAtStartup`, `demoStructuredOutputOnly`, `demoRequiredFields`          |
+| `utils.go`        | `Config`, `readConfig`, `initLogger`, env defaults, package state, library-specific base-field / trace helper      |
+| `real_project_examples.go` | `demoRealLPSUseCaseLogging` (info path) and `demoRealLPSUseCaseError` (sentinel + `WrapUseCaseError` migrated to the structured error shape, with `errors.Is` still matching) |
+| `tracing.go`      | Trace demos, `hit`, W3C plumbing, `traceMiddleware`, `traceTransport`, `sampleHandler`                             |
+| `errors.go`       | `demoErrorFields`, `demoFatal`, then error shape (`errorCode`, …), `logError` / `logFatal`, stack capture          |
+| `pii.go`          | `demoPIIRedaction`, then deny-list redaction (`privateKey`, `seed`, `mnemonic`, `apiKey`, `password`, `authorization`) |
+| `capture_test.go` | Test-output capture helper + assertions over required fields                                                       |
+
+The library-specific call style is what varies between demos, so each file
+is a one-screen side-by-side comparison point. Every `.go` file starts with
+a package comment (immediately before `package main`) describing what that
+file demonstrates.
+
+Each package also has a `README.md` with the same checklist, so reviewers can
+check candidate-specific caveats without reading the whole implementation.
+
+## Scenario contract
+
+All four demos run the same scenario. This keeps the code useful for
+side-by-side comparison rather than just proving that each library can print
+one log line.
+
+| Evidence file     | Requirement proved                                                                 |
+|-------------------|-------------------------------------------------------------------------------------|
+| `main.go`         | orchestration of all deliverables                                                   |
+| `config.go`       | `LOG_FORMAT`, `LOG_LEVEL`, structured-only output, required base fields             |
+| `utils.go`        | logger init and base-field attachment                                               |
+| `real_project_examples.go` | project imports, real LPS-domain structured fields, and sentinel + `WrapUseCaseError` mapped to the structured error shape |
+| `tracing.go`      | inbound `traceparent` extraction, structured access log, outbound injection         |
+| `errors.go`       | `errorCode`, `errorMessage`, `errorStack`, `errorContext`, fatal-equivalent         |
+| `pii.go`          | deny-list redaction for `privateKey`, `seed`, `mnemonic`, `apiKey`, `password`, `authorization` |
+| `capture_test.go` | test-output capture strategy and assertions over required fields                    |
+
+## Run a demo
+
+```sh
+LOG_FORMAT=json LOG_LEVEL=debug go run ./spike/logging/slog
+LOG_FORMAT=text LOG_LEVEL=info  go run ./spike/logging/logrus
+LOG_FORMAT=json LOG_LEVEL=info  go run ./spike/logging/zap
+LOG_FORMAT=json LOG_LEVEL=info  go run ./spike/logging/zerolog
+```
+
+Each demo:
+
+1. Initialises a logger with the requested format/level and the six required
+   base fields (`service`, `environment`, `version`; `timestamp`, `level`,
+   `message` come from the handler; `traceId` is attached per-request).
+2. Logs representative LPS pegout-rebalance fields using real project
+   packages (`internal/entities` and `internal/usecases`), then re-logs
+   the same scenario as an error to show sentinel + `WrapUseCaseError`
+   flowing into the structured error shape — `errors.Is` against the
+   sentinel still matches after wrapping.
+3. Spins up an inbound `httptest` server wrapped by the trace middleware,
+   then sends one request with an existing `traceparent` and one without.
+4. Calls an outbound `httptest` server through a `RoundTripper` that
+   injects `traceparent` with a fresh span-id and logs the four
+   integration fields.
+5. Emits one error log with all four error fields including a stack.
+6. Attempts to log a `privateKey` value and shows what the deny-list does.
+7. Logs the "fatal" line (guarded — does not call `os.Exit` so the demo
+   stays inspectable; the wrapper that *does* exit is shown in the file).
+
+Run `go test ./spike/logging/...` to exercise the test-capture helpers.
+
+## Demo limitations
+
+- `LOG_FORMAT=otel` is paper-evaluated in this spike and falls back to JSON in
+  runnable demos. Full OpenTelemetry SDK wiring is out of scope for FLY-2308.
+- `LOG_FORMAT=logfmt` is approximate for some candidates. The comparison
+  calls out where an exact handler or encoder would be needed.
+- PII handling intentionally uses each library's natural interception point,
+  even when that makes the candidate look worse. For example, zerolog uses a
+  writer-level redactor to demonstrate why arbitrary key redaction is awkward.
+- Fatal-equivalent logs are guarded by default so demos and tests remain
+  inspectable. Set `DEMO_FATAL_EXIT=1` to exercise the actual exit path where
+  a library or wrapper supports it.
+
+## How the demos map to the comparison axes
+
+The Comparison-axes section of
+[`docs/spikes/logs.md`](../../docs/spikes/logs.md#comparison-across-required-axes)
+links into the file in each demo that owns that axis, so a reviewer can
+diff the four implementations of the same thing side-by-side.

--- a/spike/logging/logrus/README.md
+++ b/spike/logging/logrus/README.md
@@ -1,0 +1,35 @@
+# logrus demo checklist
+
+This package is the current LPS baseline for the FLY-2308 comparison in
+[docs/spikes/logs.md](../../../docs/spikes/logs.md).
+
+Run it with:
+
+```sh
+LOG_FORMAT=json LOG_LEVEL=debug go run ./spike/logging/logrus
+go test ./spike/logging/logrus
+```
+
+## Requirement checklist
+
+| Requirement | Evidence | Notes |
+|-------------|----------|-------|
+| `LOG_FORMAT` / `LOG_LEVEL` | `config.go`, `main.go` | JSON and text are built in. `logfmt` uses text output. `otel` falls back to JSON because there is no first-party maintained logrus bridge. |
+| Base fields | `baseEntry(ctx)` in `utils.go` | Works, but every call site must use the derived entry. Weaker than slog handler-level enrichment. |
+| Real LPS examples | `real_project_examples.go` | Imports `internal/entities` and `internal/usecases` to show pegout-rebalance logs with real domain values. Also covers the sentinel + `WrapUseCaseError` migration: useCase id → `errorCode`, wrapping chain → `errorMessage`, `errors.Is` against the sentinel still matches. |
+| Inbound trace extraction | `tracing.go` (`demoInboundTraceExtraction`, `traceMiddleware`) | Parses W3C `traceparent`, mints a trace when absent, stores trace state in `context.Context`. |
+| Structured access log | `tracing.go` (`traceMiddleware`) | Replaces `gorilla/handlers.LoggingHandler` with one structured record containing the six required HTTP fields. |
+| Outbound trace injection | `tracing.go` (`demoOutboundTraceInjection`, `traceTransport`) | Injects the same trace-id and a fresh span-id into `traceparent`. |
+| Error shape | `errors.go` | `demoErrorFields` / `demoFatal` at top; `logError` emits all four error fields; stack capture is custom. |
+| PII redaction | `pii.go` | `demoPIIRedaction` at top; `piiRedactHook` mutates `Entry.Data`. Usable and better than writer-level redaction. |
+| Fatal-equivalent | `errors.go`, `main.go` | `logFatal` logs with the standard error shape and exits; demo path is guarded by `DEMO_FATAL_EXIT`. |
+| Test capture | `capture_test.go` | Matches current LPS-style `SetOutput` capture, then parses JSON lines for assertions. |
+
+## Candidate caveats
+
+- logrus is in maintenance mode, so keeping it would need most of the same LPS
+  wrapper work while staying on the rejected direction from the Go guideline.
+- Context propagation is not first-class. `WithContext` stores context, but it
+  does not add trace fields; the demo must call `baseEntry(ctx)` everywhere.
+- The current LPS codebase barely uses logrus structured fields, so the
+  migration is still broad even if the library is kept.

--- a/spike/logging/logrus/capture_test.go
+++ b/spike/logging/logrus/capture_test.go
@@ -1,0 +1,137 @@
+// Test-output capture via logrus.SetOutput to a buffer, then JSON-line parsing
+// and field assertions. Matches current LPS test patterns.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// newCaptureLogger swaps the package-level logger for one that writes to
+// a buffer, matching the SetOutput pattern that the current LPS tests
+// already use (logs.md "Test capture ergonomics").
+func newCaptureLogger(buf *bytes.Buffer) *logrus.Logger {
+	cfg = Config{
+		Format:      "json",
+		Level:       logrus.DebugLevel,
+		Service:     "liquidity-provider-server",
+		Environment: "test",
+		Version:     "test",
+	}
+	l := logrus.New()
+	l.SetOutput(buf)
+	l.SetLevel(cfg.Level)
+	l.SetFormatter(&logrus.JSONFormatter{
+		TimestampFormat: time.RFC3339Nano,
+		FieldMap: logrus.FieldMap{
+			logrus.FieldKeyTime: "timestamp",
+			logrus.FieldKeyMsg:  "message",
+		},
+	})
+	l.AddHook(&piiRedactHook{})
+	logger = l
+	return l
+}
+
+func records(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	out := []map[string]any{}
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+func TestCapture_BaseFieldsAndTraceId(t *testing.T) {
+	buf := &bytes.Buffer{}
+	newCaptureLogger(buf)
+
+	tc := TraceContext{TraceID: "4bf92f3577b34da6a3ce929d0e0e4736", SpanID: "00f067aa0ba902b7"}
+	ctx := contextWithTrace(context.Background(), tc)
+	baseEntry(ctx).WithField("requestId", "req-001").Info("ping")
+
+	recs := records(t, buf)
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+	r := recs[0]
+	for k, want := range map[string]string{
+		"service":     "liquidity-provider-server",
+		"environment": "test",
+		"version":     "test",
+		"traceId":     tc.TraceID,
+		"spanId":      tc.SpanID,
+		"message":     "ping",
+		"requestId":   "req-001",
+	} {
+		if got, _ := r[k].(string); got != want {
+			t.Errorf("field %q: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestCapture_PIIRedaction(t *testing.T) {
+	buf := &bytes.Buffer{}
+	newCaptureLogger(buf)
+
+	baseEntry(context.Background()).WithFields(logrus.Fields{
+		"privateKey": "0xdeadbeef",
+		"apiKey":     "sk-live-XYZ",
+		"safe":       "ok",
+	}).Warn("attempt")
+
+	recs := records(t, buf)
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+	r := recs[0]
+	for _, key := range []string{"privateKey", "apiKey"} {
+		if got, _ := r[key].(string); got != "[REDACTED]" {
+			t.Errorf("expected %q redacted, got %q", key, got)
+		}
+	}
+	if got, _ := r["safe"].(string); got != "ok" {
+		t.Errorf("non-PII field clobbered: got %q", got)
+	}
+}
+
+func TestCapture_ErrorShape(t *testing.T) {
+	buf := &bytes.Buffer{}
+	newCaptureLogger(buf)
+
+	logError(context.Background(), "demo", "DEMO_CODE", errors.New("boom"), logrus.Fields{
+		"integrationName": "rsk-lbc",
+	})
+
+	recs := records(t, buf)
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+	r := recs[0]
+	if got, _ := r["errorCode"].(string); got != "DEMO_CODE" {
+		t.Errorf("errorCode: got %q", got)
+	}
+	if got, _ := r["errorMessage"].(string); got != "boom" {
+		t.Errorf("errorMessage: got %q", got)
+	}
+	if got, _ := r["errorStack"].(string); got == "" {
+		t.Errorf("errorStack: empty")
+	}
+	if _, ok := r["errorContext"].(map[string]any); !ok {
+		t.Errorf("errorContext: not a map, got %T", r["errorContext"])
+	}
+}

--- a/spike/logging/logrus/config.go
+++ b/spike/logging/logrus/config.go
@@ -1,0 +1,46 @@
+// Demos LOG_FORMAT, LOG_LEVEL, structured-only output, and the seven required
+// base fields from the Base Logging Standards checklist (deliverables 1-4).
+package main
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+func demoLogFormatSupport() {
+	baseEntry(contextless()).WithFields(logrus.Fields{
+		"configuredLogFormat": cfg.Format,
+		"jsonSupported":       true,
+		"logfmtSupported":     cfg.Format == "logfmt",
+		"otelSupported":       false,
+		"otelFallback":        cfg.Format == "otel",
+	}).Info("LOG_FORMAT support")
+}
+
+func demoLogLevelConfiguredAtStartup() {
+	baseEntry(contextless()).WithFields(logrus.Fields{
+		"configuredLogLevel": cfg.Level.String(),
+	}).Info("LOG_LEVEL configured at startup")
+}
+
+func demoStructuredOutputOnly(ctx context.Context) {
+	baseEntry(ctx).WithFields(logrus.Fields{
+		"plainOutputAllowed": false,
+		"localDevException":  cfg.Environment == "local",
+	}).Info("structured output only")
+}
+
+func demoRequiredFields(ctx context.Context) {
+	baseEntry(ctx).WithFields(logrus.Fields{
+		"requiredFields": []string{
+			"timestamp",
+			"level",
+			"service",
+			"environment",
+			"version",
+			"traceId",
+			"message",
+		},
+	}).Info("required fields present")
+}

--- a/spike/logging/logrus/errors.go
+++ b/spike/logging/logrus/errors.go
@@ -1,0 +1,89 @@
+// Error log shape and logFatal wrapper; stack capture is hand-rolled because
+// logrus has no native errorStack field.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func demoErrorFields(ctx context.Context) {
+	root := errors.New("ECONNREFUSED 127.0.0.1:4444")
+	wrapped := fmt.Errorf("lbc.getQuote: %w", root)
+	logError(ctx, "outbound rpc failed", "RPC_DIAL_FAILED", wrapped, logrus.Fields{
+		"integrationName":   "rsk-lbc",
+		"integrationMethod": "getQuote",
+	})
+}
+
+// demoFatal shows the fatal-equivalent log line. The real helper calls
+// os.Exit(1); we set DEMO_FATAL_EXIT=1 to opt into that — by default we
+// just log so the SPIKE output remains inspectable.
+func demoFatal(ctx context.Context) {
+	exitNow := os.Getenv("DEMO_FATAL_EXIT") == "1"
+	if exitNow {
+		logFatal(ctx, "would exit now", "DEMO_FATAL", errors.New("forced"))
+		return
+	}
+	baseEntry(ctx).WithFields(logrus.Fields{
+		"errorCode":    "DEMO_FATAL",
+		"errorMessage": "forced",
+	}).Error("fatal-equivalent (DEMO_FATAL_EXIT=1 to actually exit)")
+}
+
+// captureStack mirrors the slog demo so the error log shape is
+// comparable across libraries. logrus has no native stack capture.
+func captureStack(skip int) string {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(skip, pcs[:])
+	if n == 0 {
+		return ""
+	}
+	frames := runtime.CallersFrames(pcs[:n])
+	var b strings.Builder
+	for {
+		f, more := frames.Next()
+		b.WriteString(f.Function)
+		b.WriteByte('\n')
+		b.WriteByte('\t')
+		b.WriteString(f.File)
+		b.WriteByte(':')
+		b.WriteString(strconv.Itoa(f.Line))
+		b.WriteByte('\n')
+		if !more {
+			break
+		}
+	}
+	return b.String()
+}
+
+// logError emits the four standard error fields. logrus's WithError
+// stashes the error under "error"; the standard wants errorMessage so
+// we duplicate it explicitly.
+func logError(ctx context.Context, msg, code string, err error, extra logrus.Fields) {
+	if extra == nil {
+		extra = logrus.Fields{}
+	}
+	fields := logrus.Fields{
+		"errorCode":    code,
+		"errorMessage": err.Error(),
+		"errorStack":   captureStack(3),
+		"errorContext": extra,
+	}
+	baseEntry(ctx).WithFields(fields).Error(msg)
+}
+
+// logFatal exits 1 after logging. logrus has logrus.Fatal but it would
+// not run hooks the same way for our wrapper, so we own the exit.
+func logFatal(ctx context.Context, msg, code string, err error) {
+	logError(ctx, msg, code, err, nil)
+	os.Exit(1)
+}

--- a/spike/logging/logrus/main.go
+++ b/spike/logging/logrus/main.go
@@ -1,0 +1,73 @@
+// Package main is the FLY-2308 spike demo for logrus. logrus is the
+// current LPS baseline (see docs/spikes/logs.md "Current LPS baseline").
+// It demonstrates how much LPS-specific code is needed to make logrus
+// meet the Base Logging Standards.
+//
+// Run: LOG_FORMAT=json LOG_LEVEL=debug go run ./spike/logging/logrus
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+)
+
+func main() {
+	cfg = readConfig()
+	logger = initLogger(os.Stdout, cfg)
+	ctx := contextWithTrace(context.Background(), newTraceContext())
+
+	// 1. LOG_FORMAT supporting json, logfmt, and otel where supported.
+	demoLogFormatSupport()
+
+	// 2. LOG_LEVEL configurable at startup.
+	demoLogLevelConfiguredAtStartup()
+
+	// 3. No plain unstructured output outside local development.
+	demoStructuredOutputOnly(ctx)
+
+	// 4. Required fields on every log line:
+	//    timestamp, level, service, environment, version, traceId, message.
+	demoRequiredFields(ctx)
+
+	// Extra LPS example: imports project packages and logs real domain fields.
+	demoRealLPSUseCaseLogging(ctx)
+
+	// 5-6 and 10 use the structured request middleware below.
+	inbound := httptest.NewServer(traceMiddleware(http.HandlerFunc(sampleHandler)))
+	defer inbound.Close()
+
+	// 5. Inbound W3C traceparent extraction, with a generated trace if absent.
+	demoInboundTraceExtraction(inbound.URL + "/quote")
+
+	// 6. traceId carried through context.Context and emitted on request logs.
+	demoRequestScopedTrace(inbound.URL + "/quote")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Received-Traceparent", r.Header.Get("traceparent"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	// 7. Outbound HTTP/RPC traceparent injection with a fresh span-id.
+	demoOutboundTraceInjection(upstream.URL + "/lbc/getQuote")
+
+	// 8. Error logs containing errorCode, errorMessage, errorStack,
+	//    and errorContext.
+	demoErrorFields(ctx)
+
+	// Extra LPS example: sentinel + WrapUseCaseError migrated to the
+	// structured error shape, with errors.Is still matching.
+	demoRealLPSUseCaseError(ctx)
+
+	// 9. PII drop or redaction by key for the required deny-list.
+	demoPIIRedaction(ctx)
+
+	// 10. Structured replacement for gorilla/handlers.LoggingHandler.
+	demoStructuredRequestLoggingReplacement(inbound.URL + "/quote")
+
+	// Extra task deliverable: fatal-equivalent behavior.
+	demoFatal(ctx)
+}

--- a/spike/logging/logrus/pii.go
+++ b/spike/logging/logrus/pii.go
@@ -1,0 +1,58 @@
+// PII deny-list redaction through a logrus Hook that mutates Entry.Data, with
+// recursion into nested Fields for errorContext-shaped data.
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func demoPIIRedaction(ctx context.Context) {
+	baseEntry(ctx).WithFields(logrus.Fields{
+		"privateKey":    "0xdeadbeefcafebabe",
+		"apiKey":        "sk-live-XYZ",
+		"authorization": "Bearer eyJhbGciOi...",
+		"safe":          "ok",
+	}).Warn("attempted to log PII (expect redaction)")
+}
+
+// piiDenyList — matches the slog demo so the policy is identical.
+var piiDenyList = map[string]struct{}{
+	"privatekey":    {},
+	"seed":          {},
+	"mnemonic":      {},
+	"apikey":        {},
+	"password":      {},
+	"authorization": {},
+}
+
+// piiRedactHook implements logrus.Hook. logrus's redaction story is
+// hooks that mutate Entry.Data in place. This is the "PII deny-list
+// interception" row for logrus in the comparison table — usable, but
+// only sees fields after they have been built into the Entry, and does
+// not recurse into nested logrus.Fields the way slog's ReplaceAttr does.
+type piiRedactHook struct{}
+
+func (h *piiRedactHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *piiRedactHook) Fire(e *logrus.Entry) error {
+	for k := range e.Data {
+		if _, deny := piiDenyList[strings.ToLower(k)]; deny {
+			e.Data[k] = "[REDACTED]"
+			continue
+		}
+		// Recurse into nested logrus.Fields (used by errorContext).
+		if nested, ok := e.Data[k].(logrus.Fields); ok {
+			for nk := range nested {
+				if _, deny := piiDenyList[strings.ToLower(nk)]; deny {
+					nested[nk] = "[REDACTED]"
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/spike/logging/logrus/real_project_examples.go
+++ b/spike/logging/logrus/real_project_examples.go
@@ -1,0 +1,46 @@
+// Real LPS examples: imports project packages and rewrites representative
+// pegout-rebalance logs into structured logrus fields.
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rsksmart/liquidity-provider-server/internal/entities"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
+	"github.com/sirupsen/logrus"
+)
+
+func demoRealLPSUseCaseLogging(ctx context.Context) {
+	adjustedTotal := entities.SatoshiToWei(75_000_000)
+	bridgeMin := entities.EtherToWei(1)
+
+	baseEntry(ctx).WithFields(logrus.Fields{
+		"useCase":           string(usecases.BridgePegoutId),
+		"adjustedTotalWei":  adjustedTotal.String(),
+		"adjustedTotalRbtc": adjustedTotal.ToRbtc().Text('f', 18),
+		"bridgeMinWei":      bridgeMin.String(),
+		"bridgeMinRbtc":     bridgeMin.ToRbtc().Text('f', 18),
+	}).Info("bridge pegout threshold not met")
+
+	baseEntry(ctx).WithFields(logrus.Fields{
+		"useCase":         string(usecases.BridgePegoutId),
+		"chunkIndex":      1,
+		"totalChunks":     3,
+		"transactionHash": "0xfeedbeef",
+	}).Info("bridge pegout split transaction persisted")
+}
+
+// demoRealLPSUseCaseError shows the LPS sentinel + WrapUseCaseError pattern
+func demoRealLPSUseCaseError(ctx context.Context) {
+	adjustedTotal := entities.SatoshiToWei(50_000_000)
+	bridgeMin := entities.EtherToWei(1)
+
+	wrapped := usecases.WrapUseCaseError(usecases.BridgePegoutId, usecases.TxBelowMinimumError)
+
+	logError(ctx, "bridge pegout threshold not met", string(usecases.BridgePegoutId), wrapped, logrus.Fields{
+		"adjustedTotalRbtc": adjustedTotal.ToRbtc().Text('f', 18),
+		"bridgeMinRbtc":     bridgeMin.ToRbtc().Text('f', 18),
+		"matchesSentinel":   errors.Is(wrapped, usecases.TxBelowMinimumError),
+	})
+}

--- a/spike/logging/logrus/tracing.go
+++ b/spike/logging/logrus/tracing.go
@@ -1,0 +1,203 @@
+// W3C Trace Context and structured HTTP logging via baseEntry(ctx) at each log
+// site: traceMiddleware, traceTransport, and integration-call logging.
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func demoInboundTraceExtraction(url string) {
+	hit(url, "")
+}
+
+func demoRequestScopedTrace(url string) {
+	hit(url, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+}
+
+func demoStructuredRequestLoggingReplacement(url string) {
+	hit(url, "00-11111111111111111111111111111111-2222222222222222-01")
+}
+
+func demoOutboundTraceInjection(url string) {
+	ctx := contextWithTrace(context.Background(), newTraceContext())
+	client := &http.Client{Transport: traceTransport{Base: http.DefaultTransport}}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	start := time.Now()
+	resp, err := client.Do(req)
+	dur := time.Since(start).Milliseconds()
+	if err != nil {
+		logError(ctx, "integration call failed", "OUTBOUND_FAILED", err, logrus.Fields{
+			"integrationName":       "rsk-lbc",
+			"integrationMethod":     "getQuote",
+			"integrationDurationMs": dur,
+		})
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	baseEntry(ctx).WithFields(logrus.Fields{
+		"integrationName":       "rsk-lbc",
+		"integrationMethod":     "getQuote",
+		"integrationDurationMs": dur,
+		"integrationStatusCode": resp.StatusCode,
+	}).Info("integration call")
+}
+
+func hit(url, traceparent string) {
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("X-Request-Id", "req-001")
+	if traceparent != "" {
+		req.Header.Set("traceparent", traceparent)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		baseEntry(context.Background()).WithError(err).Error("inbound demo request failed")
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+type TraceContext struct {
+	TraceID string
+	SpanID  string
+}
+
+type traceCtxKey struct{}
+
+var traceparentPattern = regexp.MustCompile(`^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$`)
+
+func parseTraceparent(v string) (TraceContext, bool) {
+	m := traceparentPattern.FindStringSubmatch(v)
+	if m == nil {
+		return TraceContext{}, false
+	}
+	return TraceContext{TraceID: m[2], SpanID: m[3]}, true
+}
+
+func newTraceContext() TraceContext {
+	var t [16]byte
+	var s [8]byte
+	_, _ = rand.Read(t[:])
+	_, _ = rand.Read(s[:])
+	return TraceContext{TraceID: hex.EncodeToString(t[:]), SpanID: hex.EncodeToString(s[:])}
+}
+
+func contextWithTrace(ctx context.Context, tc TraceContext) context.Context {
+	return context.WithValue(ctx, traceCtxKey{}, tc)
+}
+
+func traceFromContext(ctx context.Context) (TraceContext, bool) {
+	if ctx == nil {
+		return TraceContext{}, false
+	}
+	tc, ok := ctx.Value(traceCtxKey{}).(TraceContext)
+	return tc, ok
+}
+
+func traceSource(adopted bool) string {
+	if adopted {
+		return "inbound-header"
+	}
+	return "minted"
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}
+
+// traceMiddleware is the logrus-flavoured structured request middleware.
+// Every log call goes through baseEntry(ctx).WithFields(...).<Level>(msg)
+// — there is no auto-attachment, so the function reads as a sequence of
+// explicit logrus.Entry mutations. That verbosity *is* the logrus
+// ergonomics story this demo is showing.
+func traceMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw := r.Header.Get("traceparent")
+		tc, adopted := parseTraceparent(raw)
+		if !adopted {
+			tc = newTraceContext()
+		}
+		ctx := contextWithTrace(r.Context(), tc)
+
+		baseEntry(ctx).WithFields(logrus.Fields{
+			"traceAdopted":        adopted,
+			"traceSource":         traceSource(adopted),
+			"incomingTraceparent": raw,
+		}).Debug("trace context resolved")
+
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r.WithContext(ctx))
+
+		baseEntry(ctx).WithFields(logrus.Fields{
+			"httpMethod":     r.Method,
+			"httpPath":       r.URL.Path,
+			"httpStatusCode": rec.status,
+			"durationMs":     time.Since(start).Milliseconds(),
+			"userAgent":      r.UserAgent(),
+			"requestId":      r.Header.Get("X-Request-Id"),
+		}).Info("http request")
+	})
+}
+
+// traceTransport is the logrus-flavoured outbound RoundTripper. Note
+// the per-call cost: every branch has to call baseEntry(ctx) to attach
+// the trace fields, then .WithFields(...), then .<Level>(msg). That is
+// the same verbosity slog avoids structurally via its contextHandler.
+type traceTransport struct{ Base http.RoundTripper }
+
+func (t traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	ctx := req.Context()
+
+	tc, ok := traceFromContext(ctx)
+	if !ok {
+		baseEntry(ctx).WithField("integrationUrl", req.URL.String()).
+			Warn("outbound call with no trace in context")
+		return base.RoundTrip(req)
+	}
+
+	fresh := newTraceContext()
+	header := "00-" + tc.TraceID + "-" + fresh.SpanID + "-01"
+	req = req.Clone(ctx)
+	req.Header.Set("traceparent", header)
+
+	baseEntry(ctx).WithFields(logrus.Fields{
+		"parentSpanId":   tc.SpanID,
+		"childSpanId":    fresh.SpanID,
+		"integrationUrl": req.URL.String(),
+	}).Debug("outbound traceparent injected")
+
+	return base.RoundTrip(req)
+}
+
+// sampleHandler is the business handler. traceMiddleware now owns the
+// six standard HTTP fields, so this handler only emits the business log
+// via baseEntry(ctx), because logrus has no native context-to-fields bridge.
+func sampleHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"quoteHash":"0xabc"}`))
+
+	baseEntry(r.Context()).WithField("quoteHash", "0xabc").Info("quote returned")
+}

--- a/spike/logging/logrus/utils.go
+++ b/spike/logging/logrus/utils.go
@@ -1,0 +1,113 @@
+// Shared logger setup: env-driven Config, global logrus logger, and baseEntry for
+// init-time base fields plus per-request trace fields on every call site.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Config struct {
+	Format      string
+	Level       logrus.Level
+	Service     string
+	Environment string
+	Version     string
+}
+
+func readConfig() Config {
+	cfg := Config{
+		Format:      strings.ToLower(envDefault("LOG_FORMAT", "json")),
+		Service:     envDefault("LOG_SERVICE", "liquidity-provider-server"),
+		Environment: envDefault("LOG_ENVIRONMENT", "spike"),
+		Version:     envDefault("LOG_VERSION", "spike-fly-2308"),
+	}
+	lvl, err := logrus.ParseLevel(envDefault("LOG_LEVEL", "info"))
+	if err != nil {
+		lvl = logrus.InfoLevel
+	}
+	cfg.Level = lvl
+	return cfg
+}
+
+// initLogger builds the global logger. Because logrus has no native
+// context handler, base fields must live on a *logrus.Entry that every
+// call site has to thread through (see baseEntry below). That is the
+// "Base-field auto-attachment" weakness called out in logs.md.
+func initLogger(out io.Writer, cfg Config) *logrus.Logger {
+	l := logrus.New()
+	l.SetOutput(out)
+	l.SetLevel(cfg.Level)
+	switch cfg.Format {
+	case "json", "otel":
+		// "otel" has no first-party logrus bridge — log a notice and
+		// fall back to JSON for the spike.
+		if cfg.Format == "otel" {
+			fmt.Fprintln(os.Stderr, "LOG_FORMAT=otel has no maintained logrus bridge; falling back to JSON")
+		}
+		l.SetFormatter(&logrus.JSONFormatter{
+			TimestampFormat: time.RFC3339Nano,
+			FieldMap: logrus.FieldMap{
+				logrus.FieldKeyTime: "timestamp",
+				logrus.FieldKeyMsg:  "message",
+			},
+		})
+	case "text", "logfmt":
+		l.SetFormatter(&logrus.TextFormatter{
+			TimestampFormat: time.RFC3339Nano,
+			DisableColors:   true,
+			FullTimestamp:   true,
+		})
+	default:
+		l.SetFormatter(&logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano})
+	}
+	l.AddHook(&piiRedactHook{})
+	return l
+}
+
+// baseEntry returns a *logrus.Entry pre-populated with the three init
+// fields and (if present) the trace fields from ctx. Every call site
+// in a "real" logrus migration would call this — there is no slog-style
+// handler that adds them automatically.
+func baseEntry(ctx context.Context) *logrus.Entry {
+	e := logger.WithFields(logrus.Fields{
+		"service":     cfg.Service,
+		"environment": cfg.Environment,
+		"version":     cfg.Version,
+	})
+	if tc, ok := traceFromContext(ctx); ok {
+		e = e.WithFields(logrus.Fields{
+			"traceId": tc.TraceID,
+			"spanId":  tc.SpanID,
+		})
+	}
+	return e
+}
+
+func envDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// contextless returns context.Background for the non-request demos. The
+// logrus call sites still have to take a context to thread base fields
+// through baseEntry, so this saves repeating context.Background() at
+// every non-request demo site.
+func contextless() context.Context {
+	return context.Background()
+}
+
+// Package-level state. logrus's ergonomic API is package-global; storing
+// cfg and logger here matches how a real migration would use it.
+var (
+	cfg    Config
+	logger *logrus.Logger
+)

--- a/spike/logging/slog/README.md
+++ b/spike/logging/slog/README.md
@@ -1,0 +1,37 @@
+# slog demo checklist
+
+This package is the recommended target for the FLY-2308 comparison in
+[docs/spikes/logs.md](../../../docs/spikes/logs.md).
+
+Run it with:
+
+```sh
+LOG_FORMAT=json LOG_LEVEL=debug go run ./spike/logging/slog
+go test ./spike/logging/slog
+```
+
+## Requirement checklist
+
+| Requirement | Evidence | Notes |
+|-------------|----------|-------|
+| `LOG_FORMAT` / `LOG_LEVEL` | `config.go`, `main.go` | JSON and text are stdlib. `logfmt` uses slog text as a close local-dev format. `otel` falls back to JSON in the runnable demo; the document points to `otelslog` for real wiring. |
+| Base fields | `initLogger` in `utils.go` | `service`, `environment`, and `version` are attached once with `logger.With(...)`. |
+| Real LPS examples | `real_project_examples.go` | Imports `internal/entities` and `internal/usecases` to show pegout-rebalance logs with real domain values. Also covers the sentinel + `WrapUseCaseError` migration: useCase id → `errorCode`, wrapping chain → `errorMessage`, and `errors.Is` against the sentinel still matches. |
+| Request trace fields | `contextHandler` in `utils.go` | Handler reads `context.Context` and adds `traceId` / `spanId` without per-call-site fields. |
+| Inbound trace extraction | `tracing.go` (`demoInboundTraceExtraction`, `traceMiddleware`) | Parses W3C `traceparent`, mints a trace when absent, stores trace state in `context.Context`. |
+| Structured access log | `tracing.go` (`traceMiddleware`) | Replaces `gorilla/handlers.LoggingHandler` with one structured record containing the six required HTTP fields. |
+| Outbound trace injection | `tracing.go` (`demoOutboundTraceInjection`, `traceTransport`) | Injects the same trace-id and a fresh span-id into `traceparent`. |
+| Error shape | `errors.go` | `demoErrorFields` / `demoFatal` at top; `logError` emits `errorCode`, `errorMessage`, `errorStack`, and `errorContext`; stack capture is centralized. |
+| Standard key names and PII redaction | `pii.go` | `demoPIIRedaction` at top; `HandlerOptions.ReplaceAttr` renames `time`/`msg` to `timestamp`/`message` and redacts denied PII keys. Cleanest interception point in the comparison. |
+| Fatal-equivalent | `errors.go`, `main.go` | `logFatal` logs once and exits; demo path is guarded by `DEMO_FATAL_EXIT`. |
+| Test capture | `capture_test.go` | Buffer-backed JSON handler with the same redaction and context handler stack. |
+
+## Candidate caveats
+
+- slog has no built-in fatal level. LPS should own `logging.Fatal`.
+- slog has no built-in stack field. LPS should own `logging.Error` and capture
+  `errorStack` centrally.
+- Lazy evaluation is explicit through `slog.LogValuer` or an LPS
+  `logging.Lazy` helper.
+- Exact `logfmt` requires a small handler or third-party handler if the
+  standards review requires more than slog text output.

--- a/spike/logging/slog/capture_test.go
+++ b/spike/logging/slog/capture_test.go
@@ -1,0 +1,128 @@
+// Test-output capture: buffer-backed JSON handler mirroring initLogger's stack,
+// with field assertions. Replaces logrus SetOutput/SetLevel patterns in tests.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// newCaptureLogger returns a logger that writes JSON records to buf,
+// wired with the same handler stack (PII redactor + context handler)
+// that initLogger installs. This is the slog "test capture story" —
+// see logs.md "Test capture ergonomics".
+func newCaptureLogger(buf *bytes.Buffer) *slog.Logger {
+	base := slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		Level:       slog.LevelDebug,
+		ReplaceAttr: replaceAttr,
+	})
+	return slog.New(contextHandler{Handler: base}).With(
+		slog.String("service", "liquidity-provider-server"),
+		slog.String("environment", "test"),
+		slog.String("version", "test"),
+	)
+}
+
+// records parses each non-empty line of the buffer as one slog record.
+func records(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	out := []map[string]any{}
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+func TestCapture_BaseFieldsAndTraceId(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := newCaptureLogger(buf)
+
+	tc := TraceContext{TraceID: "4bf92f3577b34da6a3ce929d0e0e4736", SpanID: "00f067aa0ba902b7"}
+	ctx := contextWithTrace(context.Background(), tc)
+	logger.InfoContext(ctx, "ping", slog.String("requestId", "req-001"))
+
+	recs := records(t, buf)
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+	r := recs[0]
+
+	for k, want := range map[string]string{
+		"service":     "liquidity-provider-server",
+		"environment": "test",
+		"version":     "test",
+		"traceId":     tc.TraceID,
+		"spanId":      tc.SpanID,
+		"message":     "ping",
+		"requestId":   "req-001",
+	} {
+		if got, _ := r[k].(string); got != want {
+			t.Errorf("field %q: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestCapture_PIIRedaction(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := newCaptureLogger(buf)
+
+	logger.Warn("attempt",
+		slog.String("privateKey", "0xdeadbeef"),
+		slog.String("apiKey", "sk-live-XYZ"),
+		slog.String("safe", "ok"),
+	)
+
+	recs := records(t, buf)
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+	r := recs[0]
+
+	for _, key := range []string{"privateKey", "apiKey"} {
+		if got, _ := r[key].(string); got != "[REDACTED]" {
+			t.Errorf("expected %q to be redacted, got %q", key, got)
+		}
+	}
+	if got, _ := r["safe"].(string); got != "ok" {
+		t.Errorf("non-PII field clobbered: got %q", got)
+	}
+}
+
+func TestCapture_ErrorShape(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := newCaptureLogger(buf)
+	slog.SetDefault(logger) // logError uses slog.LogAttrs on the default logger.
+
+	logError(context.Background(), "demo", "DEMO_CODE", errPlaceholder("boom"),
+		slog.String("integrationName", "rsk-lbc"))
+
+	recs := records(t, buf)
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+	r := recs[0]
+
+	if got, _ := r["errorCode"].(string); got != "DEMO_CODE" {
+		t.Errorf("errorCode: got %q", got)
+	}
+	if got, _ := r["errorMessage"].(string); got != "boom" {
+		t.Errorf("errorMessage: got %q", got)
+	}
+	if got, _ := r["errorStack"].(string); got == "" {
+		t.Errorf("errorStack: empty")
+	}
+	if _, ok := r["errorContext"].(map[string]any); !ok {
+		t.Errorf("errorContext: not a group, got %T", r["errorContext"])
+	}
+}

--- a/spike/logging/slog/config.go
+++ b/spike/logging/slog/config.go
@@ -1,0 +1,45 @@
+// Demos LOG_FORMAT, LOG_LEVEL, structured-only output, and the seven required
+// base fields from the Base Logging Standards checklist (deliverables 1-4).
+package main
+
+import (
+	"context"
+	"log/slog"
+)
+
+func demoLogFormatSupport() {
+	slog.Info("LOG_FORMAT support",
+		slog.String("configuredLogFormat", cfg.Format),
+		slog.Bool("jsonSupported", true),
+		slog.Bool("logfmtSupported", cfg.Format == "logfmt"),
+		slog.Bool("otelSupported", true),
+		slog.Bool("otelFallbackInDemo", cfg.Format == "otel"),
+	)
+}
+
+func demoLogLevelConfiguredAtStartup(cfg Config) {
+	slog.Info("LOG_LEVEL configured at startup",
+		slog.String("configuredLogLevel", cfg.Level.String()),
+	)
+}
+
+func demoStructuredOutputOnly(ctx context.Context, cfg Config) {
+	slog.InfoContext(ctx, "structured output only",
+		slog.Bool("plainOutputAllowed", false),
+		slog.Bool("localDevException", cfg.Environment == "local"),
+	)
+}
+
+func demoRequiredFields(ctx context.Context) {
+	slog.InfoContext(ctx, "required fields present",
+		slog.Any("requiredFields", []string{
+			"timestamp",
+			"level",
+			"service",
+			"environment",
+			"version",
+			"traceId",
+			"message",
+		}),
+	)
+}

--- a/spike/logging/slog/errors.go
+++ b/spike/logging/slog/errors.go
@@ -1,0 +1,105 @@
+// Error log shape (errorCode, errorMessage, errorStack, errorContext) and
+// fatal-equivalent logging. Demonstrates centralized wrappers because slog has
+// no native fatal level or stack field.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func demoErrorFields(ctx context.Context) {
+	root := errors.New("ECONNREFUSED 127.0.0.1:4444")
+	wrapped := fmt.Errorf("lbc.getQuote: %w", root)
+	logError(ctx, "outbound rpc failed", "RPC_DIAL_FAILED", wrapped,
+		slog.String("integrationName", "rsk-lbc"),
+		slog.String("integrationMethod", "getQuote"),
+	)
+}
+
+// demoFatal shows the fatal-equivalent log line. The real helper calls
+// os.Exit(1); we set DEMO_FATAL_EXIT=1 to opt into that — by default we
+// just log so the SPIKE output remains inspectable.
+func demoFatal(ctx context.Context) {
+	exitNow := os.Getenv("DEMO_FATAL_EXIT") == "1"
+	if exitNow {
+		logFatal(ctx, "would exit now", "DEMO_FATAL", errors.New("forced"))
+		return
+	}
+	slog.LogAttrs(ctx, slog.LevelError, "fatal-equivalent (DEMO_FATAL_EXIT=1 to actually exit)",
+		slog.String("errorCode", "DEMO_FATAL"),
+		slog.String("errorMessage", "forced"),
+	)
+}
+
+// captureStack returns a textual stack trace suitable for the
+// errorStack field. slog has no native stack support; centralising
+// capture here means call sites stay short.
+//
+// skip = 2 drops captureStack and its immediate caller (logError /
+// logFatal), so the first frame is the application call site.
+func captureStack(skip int) string {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(skip, pcs[:])
+	if n == 0 {
+		return ""
+	}
+	frames := runtime.CallersFrames(pcs[:n])
+	var b strings.Builder
+	for {
+		f, more := frames.Next()
+		b.WriteString(f.Function)
+		b.WriteByte('\n')
+		b.WriteByte('\t')
+		b.WriteString(f.File)
+		b.WriteByte(':')
+		b.WriteString(strconv.Itoa(f.Line))
+		b.WriteByte('\n')
+		if !more {
+			break
+		}
+	}
+	return b.String()
+}
+
+// logError emits the four-field error log shape required by the Base
+// Logging Standards: errorCode, errorMessage, errorStack, errorContext.
+//
+// extra carries call-site context (e.g. integrationName) and ends up in
+// errorContext as a slog.Group.
+func logError(ctx context.Context, msg, code string, err error, extra ...slog.Attr) {
+	if err == nil {
+		err = errPlaceholder("nil error")
+	}
+	all := append([]slog.Attr{
+		slog.String("errorCode", code),
+		slog.String("errorMessage", err.Error()),
+		slog.String("errorStack", captureStack(3)),
+		slog.Any("errorContext", attrsAsGroup(extra)),
+	}, extra...)
+	slog.LogAttrs(ctx, slog.LevelError, msg, all...)
+}
+
+// logFatal logs once and exits 1. Centralising fatal here is the
+// "Fatal semantics" entry in logs.md — slog has no native fatal level.
+func logFatal(ctx context.Context, msg, code string, err error, extra ...slog.Attr) {
+	logError(ctx, msg, code, err, extra...)
+	os.Exit(1)
+}
+
+func attrsAsGroup(attrs []slog.Attr) slog.Value {
+	out := make([]slog.Attr, len(attrs))
+	copy(out, attrs)
+	return slog.GroupValue(out...)
+}
+
+type errPlaceholder string
+
+func (e errPlaceholder) Error() string { return string(e) }

--- a/spike/logging/slog/main.go
+++ b/spike/logging/slog/main.go
@@ -1,0 +1,71 @@
+// Package main is the FLY-2308 spike demo for log/slog. See
+// ../README.md and docs/spikes/logs.md for context.
+//
+// Run: LOG_FORMAT=json LOG_LEVEL=debug go run ./spike/logging/slog
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+)
+
+func main() {
+	cfg = readConfig()
+	initLogger(os.Stdout, cfg)
+	ctx := contextWithTrace(context.Background(), newTraceContext())
+
+	// 1. LOG_FORMAT supporting json, logfmt, and otel where supported.
+	demoLogFormatSupport()
+
+	// 2. LOG_LEVEL configurable at startup.
+	demoLogLevelConfiguredAtStartup(cfg)
+
+	// 3. No plain unstructured output outside local development.
+	demoStructuredOutputOnly(ctx, cfg)
+
+	// 4. Required fields on every log line:
+	//    timestamp, level, service, environment, version, traceId, message.
+	demoRequiredFields(ctx)
+
+	// Extra LPS example: imports project packages and logs real domain fields.
+	demoRealLPSUseCaseLogging(ctx)
+
+	// 5-6 and 10 use the structured request middleware below.
+	inbound := httptest.NewServer(traceMiddleware(http.HandlerFunc(sampleHandler)))
+	defer inbound.Close()
+
+	// 5. Inbound W3C traceparent extraction, with a generated trace if absent.
+	demoInboundTraceExtraction(inbound.URL + "/quote")
+
+	// 6. traceId carried through context.Context and emitted on request logs.
+	demoRequestScopedTrace(inbound.URL + "/quote")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Received-Traceparent", r.Header.Get("traceparent"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	// 7. Outbound HTTP/RPC traceparent injection with a fresh span-id.
+	demoOutboundTraceInjection(upstream.URL + "/lbc/getQuote")
+
+	// 8. Error logs containing errorCode, errorMessage, errorStack,
+	//    and errorContext.
+	demoErrorFields(ctx)
+
+	// Extra LPS example: sentinel + WrapUseCaseError migrated to the
+	// structured error shape, with errors.Is still matching.
+	demoRealLPSUseCaseError(ctx)
+
+	// 9. PII drop or redaction by key for the required deny-list.
+	demoPIIRedaction(ctx)
+
+	// 10. Structured replacement for gorilla/handlers.LoggingHandler.
+	demoStructuredRequestLoggingReplacement(inbound.URL + "/quote")
+
+	// Extra task deliverable: fatal-equivalent behavior.
+	demoFatal(ctx)
+}

--- a/spike/logging/slog/pii.go
+++ b/spike/logging/slog/pii.go
@@ -1,0 +1,89 @@
+// PII deny-list redaction through HandlerOptions.ReplaceAttr, including nested
+// groups. Uses a redact-not-drop policy per the Base Logging Standards.
+package main
+
+import (
+	"context"
+	"log/slog"
+)
+
+func demoPIIRedaction(ctx context.Context) {
+	slog.WarnContext(ctx, "attempted to log PII (expect redaction)",
+		slog.String("privateKey", "0xdeadbeefcafebabe"),
+		slog.String("apiKey", "sk-live-XYZ"),
+		slog.String("authorization", "Bearer eyJhbGciOi..."),
+		slog.String("safe", "ok"),
+	)
+}
+
+// piiDenyList is the deny-list from the Base Logging Standards. Keys
+// are matched case-insensitively against attribute names.
+var piiDenyList = map[string]struct{}{
+	"privatekey":    {},
+	"seed":          {},
+	"mnemonic":      {},
+	"apikey":        {},
+	"password":      {},
+	"authorization": {},
+}
+
+// replaceAttr is the single handler interception point for the slog demo.
+// It first normalizes stdlib field names to the Base Logging Standards, then
+// applies the PII deny-list policy.
+func replaceAttr(groups []string, a slog.Attr) slog.Attr {
+	a = normalizeStandardKey(groups, a)
+	return piiRedactor(groups, a)
+}
+
+func normalizeStandardKey(groups []string, a slog.Attr) slog.Attr {
+	if len(groups) != 0 {
+		return a
+	}
+	switch a.Key {
+	case slog.TimeKey:
+		a.Key = "timestamp"
+	case slog.MessageKey:
+		a.Key = "message"
+	}
+	return a
+}
+
+// piiRedactor is the ReplaceAttr function plugged into every handler in
+// initLogger. This is slog's "deny-list interception point" — the one
+// place where the redaction policy lives.
+//
+// Decision (see logs.md "Sensitive data"): redact rather than drop, so
+// the operational signal "someone tried to log a key" survives even
+// when the value does not.
+func piiRedactor(groups []string, a slog.Attr) slog.Attr {
+	if _, deny := piiDenyList[lowerASCII(a.Key)]; deny {
+		return slog.String(a.Key, "[REDACTED]")
+	}
+	// Recurse into groups (e.g. errorContext) so PII keys nested inside
+	// structured attrs are also caught.
+	if a.Value.Kind() == slog.KindGroup {
+		attrs := a.Value.Group()
+		out := make([]slog.Attr, 0, len(attrs))
+		for _, child := range attrs {
+			out = append(out, piiRedactor(append(groups, a.Key), child))
+		}
+		return slog.Attr{Key: a.Key, Value: slog.GroupValue(out...)}
+	}
+	return a
+}
+
+// lowerASCII avoids strings.ToLower so we don't allocate for every key.
+func lowerASCII(s string) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 'A' && s[i] <= 'Z' {
+			b := []byte(s)
+			for j := i; j < len(b); j++ {
+				if b[j] >= 'A' && b[j] <= 'Z' {
+					b[j] += 'a' - 'A'
+				}
+			}
+			return string(b)
+		}
+	}
+	return s
+}

--- a/spike/logging/slog/real_project_examples.go
+++ b/spike/logging/slog/real_project_examples.go
@@ -1,0 +1,46 @@
+// Real LPS examples: imports project packages and rewrites representative
+// pegout-rebalance logs into structured slog fields.
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/rsksmart/liquidity-provider-server/internal/entities"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
+)
+
+func demoRealLPSUseCaseLogging(ctx context.Context) {
+	adjustedTotal := entities.SatoshiToWei(75_000_000)
+	bridgeMin := entities.EtherToWei(1)
+
+	slog.InfoContext(ctx, "bridge pegout threshold not met",
+		slog.String("useCase", string(usecases.BridgePegoutId)),
+		slog.String("adjustedTotalWei", adjustedTotal.String()),
+		slog.String("adjustedTotalRbtc", adjustedTotal.ToRbtc().Text('f', 18)),
+		slog.String("bridgeMinWei", bridgeMin.String()),
+		slog.String("bridgeMinRbtc", bridgeMin.ToRbtc().Text('f', 18)),
+	)
+
+	slog.InfoContext(ctx, "bridge pegout split transaction persisted",
+		slog.String("useCase", string(usecases.BridgePegoutId)),
+		slog.Int("chunkIndex", 1),
+		slog.Int("totalChunks", 3),
+		slog.String("transactionHash", "0xfeedbeef"),
+	)
+}
+
+// demoRealLPSUseCaseError shows the LPS sentinel + WrapUseCaseError pattern
+func demoRealLPSUseCaseError(ctx context.Context) {
+	adjustedTotal := entities.SatoshiToWei(50_000_000)
+	bridgeMin := entities.EtherToWei(1)
+
+	wrapped := usecases.WrapUseCaseError(usecases.BridgePegoutId, usecases.TxBelowMinimumError)
+
+	logError(ctx, "bridge pegout threshold not met", string(usecases.BridgePegoutId), wrapped,
+		slog.String("adjustedTotalRbtc", adjustedTotal.ToRbtc().Text('f', 18)),
+		slog.String("bridgeMinRbtc", bridgeMin.ToRbtc().Text('f', 18)),
+		slog.Bool("matchesSentinel", errors.Is(wrapped, usecases.TxBelowMinimumError)),
+	)
+}

--- a/spike/logging/slog/tracing.go
+++ b/spike/logging/slog/tracing.go
@@ -1,0 +1,223 @@
+// W3C Trace Context and structured HTTP logging: inbound traceparent extraction,
+// middleware replacing gorilla/handlers.LoggingHandler, outbound traceparent
+// injection, and integration-call logging. All log sites use slog directly.
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"time"
+)
+
+func demoInboundTraceExtraction(url string) {
+	hit(url, "")
+}
+
+func demoRequestScopedTrace(url string) {
+	hit(url, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+}
+
+func demoStructuredRequestLoggingReplacement(url string) {
+	hit(url, "00-11111111111111111111111111111111-2222222222222222-01")
+}
+
+// demoOutbound exercises traceTransport end-to-end and logs the four
+// integration fields required by the standard via slog.
+func demoOutboundTraceInjection(url string) {
+	ctx := contextWithTrace(context.Background(), newTraceContext())
+	client := &http.Client{Transport: traceTransport{Base: http.DefaultTransport}}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	start := time.Now()
+	resp, err := client.Do(req)
+	dur := time.Since(start).Milliseconds()
+	if err != nil {
+		logError(ctx, "integration call failed", "OUTBOUND_FAILED", err,
+			slog.String("integrationName", "rsk-lbc"),
+			slog.String("integrationMethod", "getQuote"),
+			slog.Int64("integrationDurationMs", dur),
+		)
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	slog.LogAttrs(ctx, slog.LevelInfo, "integration call",
+		slog.String("integrationName", "rsk-lbc"),
+		slog.String("integrationMethod", "getQuote"),
+		slog.Int64("integrationDurationMs", dur),
+		slog.Int("integrationStatusCode", resp.StatusCode),
+	)
+}
+
+func hit(url, traceparent string) {
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("X-Request-Id", "req-001")
+	if traceparent != "" {
+		req.Header.Set("traceparent", traceparent)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Error("inbound demo request failed", slog.String("error", err.Error()))
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+// TraceContext is the minimal W3C Trace Context state we carry through
+// context. A real implementation would also keep traceFlags + tracestate.
+type TraceContext struct {
+	TraceID string // 32 hex chars
+	SpanID  string // 16 hex chars
+}
+
+type traceCtxKey struct{}
+
+// W3C traceparent: version "-" trace-id "-" parent-id "-" flags
+//
+//	00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+var traceparentPattern = regexp.MustCompile(`^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$`)
+
+func parseTraceparent(v string) (TraceContext, bool) {
+	m := traceparentPattern.FindStringSubmatch(v)
+	if m == nil {
+		return TraceContext{}, false
+	}
+	return TraceContext{TraceID: m[2], SpanID: m[3]}, true
+}
+
+func newTraceContext() TraceContext {
+	var t [16]byte
+	var s [8]byte
+	_, _ = rand.Read(t[:])
+	_, _ = rand.Read(s[:])
+	return TraceContext{TraceID: hex.EncodeToString(t[:]), SpanID: hex.EncodeToString(s[:])}
+}
+
+func contextWithTrace(ctx context.Context, tc TraceContext) context.Context {
+	return context.WithValue(ctx, traceCtxKey{}, tc)
+}
+
+func traceFromContext(ctx context.Context) (TraceContext, bool) {
+	if ctx == nil {
+		return TraceContext{}, false
+	}
+	tc, ok := ctx.Value(traceCtxKey{}).(TraceContext)
+	return tc, ok
+}
+
+func traceSource(adopted bool) string {
+	if adopted {
+		return "inbound-header"
+	}
+	return "minted"
+}
+
+// statusRecorder lets the middleware see the response status the
+// downstream handler wrote.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}
+
+// traceMiddleware is the slog-flavoured implementation of the
+// structured request-logging middleware that the SPIKE recommends as
+// the replacement for gorilla/handlers.LoggingHandler. It:
+//
+//  1. Extracts or mints a W3C trace context.
+//  2. Logs the trace decision at DEBUG via slog (contextHandler picks
+//     up the ctx).
+//  3. After serving, logs the six standard HTTP fields at INFO via
+//     slog.InfoContext.
+//
+// Every log call uses slog directly so the middleware reads as a slog
+// demo end-to-end.
+func traceMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw := r.Header.Get("traceparent")
+		tc, adopted := parseTraceparent(raw)
+		if !adopted {
+			tc = newTraceContext()
+		}
+		ctx := contextWithTrace(r.Context(), tc)
+
+		slog.LogAttrs(ctx, slog.LevelDebug, "trace context resolved",
+			slog.Bool("traceAdopted", adopted),
+			slog.String("traceSource", traceSource(adopted)),
+			slog.String("incomingTraceparent", raw),
+		)
+
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r.WithContext(ctx))
+
+		slog.LogAttrs(ctx, slog.LevelInfo, "http request",
+			slog.String("httpMethod", r.Method),
+			slog.String("httpPath", r.URL.Path),
+			slog.Int("httpStatusCode", rec.status),
+			slog.Int64("durationMs", time.Since(start).Milliseconds()),
+			slog.String("userAgent", r.UserAgent()),
+			slog.String("requestId", r.Header.Get("X-Request-Id")),
+		)
+	})
+}
+
+// traceTransport is the slog-flavoured outbound RoundTripper. Every
+// branch logs through slog so this file reads as a slog demo end-to-end:
+//
+//   - injection success: DEBUG with the parent + child span ids;
+//   - no trace in ctx: WARN through slog so the operator notices the
+//     missing context propagation instead of silently shipping a header.
+type traceTransport struct{ Base http.RoundTripper }
+
+func (t traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	ctx := req.Context()
+
+	tc, ok := traceFromContext(ctx)
+	if !ok {
+		slog.WarnContext(ctx, "outbound call with no trace in context",
+			slog.String("integrationUrl", req.URL.String()),
+		)
+		return base.RoundTrip(req)
+	}
+
+	fresh := newTraceContext()
+	header := "00-" + tc.TraceID + "-" + fresh.SpanID + "-01"
+	req = req.Clone(ctx)
+	req.Header.Set("traceparent", header)
+
+	slog.LogAttrs(ctx, slog.LevelDebug, "outbound traceparent injected",
+		slog.String("parentSpanId", tc.SpanID),
+		slog.String("childSpanId", fresh.SpanID),
+		slog.String("integrationUrl", req.URL.String()),
+	)
+	return base.RoundTrip(req)
+}
+
+// sampleHandler is the inbound business handler. The six standard HTTP
+// fields are emitted by traceMiddleware, so this handler only logs the
+// business event. contextHandler adds traceId without explicit attrs here.
+func sampleHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"quoteHash":"0xabc"}`))
+
+	slog.InfoContext(r.Context(), "quote returned",
+		slog.String("quoteHash", "0xabc"),
+	)
+}

--- a/spike/logging/slog/utils.go
+++ b/spike/logging/slog/utils.go
@@ -1,0 +1,119 @@
+// Shared logger setup: env-driven Config, handler stack (JSON/text/otel fallback),
+// init-time base fields, and contextHandler for per-request traceId.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Config holds the env-driven settings shared across all four demos.
+type Config struct {
+	Format      string // json | text | logfmt | otel
+	Level       slog.Level
+	Service     string
+	Environment string
+	Version     string
+}
+
+// readConfig parses the env vars listed in the Base Logging Standards.
+func readConfig() Config {
+	cfg := Config{
+		Format:      strings.ToLower(envDefault("LOG_FORMAT", "json")),
+		Service:     envDefault("LOG_SERVICE", "liquidity-provider-server"),
+		Environment: envDefault("LOG_ENVIRONMENT", "spike"),
+		Version:     envDefault("LOG_VERSION", "spike-fly-2308"),
+	}
+	switch strings.ToLower(envDefault("LOG_LEVEL", "info")) {
+	case "debug":
+		cfg.Level = slog.LevelDebug
+	case "warn", "warning":
+		cfg.Level = slog.LevelWarn
+	case "error":
+		cfg.Level = slog.LevelError
+	default:
+		cfg.Level = slog.LevelInfo
+	}
+	return cfg
+}
+
+// initLogger builds the handler stack and installs it as slog.Default.
+//
+// The stack is, outermost to innermost:
+//
+//	contextHandler (adds traceId from ctx)
+//	  -> base handler (JSON or text) with:
+//	       HandlerOptions.ReplaceAttr = piiRedactor (drops PII keys)
+//
+// Base fields (service, environment, version) are attached once via
+// logger.With and ride along on every record without being repeated at
+// call sites — see docs/spikes/logs.md "Base-field auto-attachment".
+func initLogger(out io.Writer, cfg Config) *slog.Logger {
+	opts := &slog.HandlerOptions{
+		Level:       cfg.Level,
+		ReplaceAttr: replaceAttr,
+		AddSource:   false,
+	}
+
+	var base slog.Handler
+	switch cfg.Format {
+	case "text", "logfmt":
+		// slog.NewTextHandler is logfmt-ish (key=value, space-separated).
+		// Exact RFC-5424-style logfmt would need a third-party handler;
+		// see logs.md "Format switch ergonomics".
+		base = slog.NewTextHandler(out, opts)
+	case "otel":
+		// Paper-only in the SPIKE: a real wiring uses
+		// go.opentelemetry.io/contrib/bridges/otelslog. We log a notice
+		// and fall back to JSON so the demo stays self-contained.
+		fmt.Fprintln(os.Stderr, "LOG_FORMAT=otel: would use otelslog.NewHandler; falling back to JSON for the spike")
+		base = slog.NewJSONHandler(out, opts)
+	default:
+		base = slog.NewJSONHandler(out, opts)
+	}
+
+	logger := slog.New(contextHandler{Handler: base}).With(
+		slog.String("service", cfg.Service),
+		slog.String("environment", cfg.Environment),
+		slog.String("version", cfg.Version),
+	)
+	slog.SetDefault(logger)
+	return logger
+}
+
+// contextHandler enriches every record with the request-scoped traceId
+// (and spanId, when present) so call sites don't pass it explicitly.
+// This is the cleanest demonstration of slog's "context.Context
+// propagation" win in the comparison.
+type contextHandler struct{ slog.Handler }
+
+func (h contextHandler) Handle(ctx context.Context, r slog.Record) error {
+	if tc, ok := traceFromContext(ctx); ok {
+		r.AddAttrs(
+			slog.String("traceId", tc.TraceID),
+			slog.String("spanId", tc.SpanID),
+		)
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+func (h contextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return contextHandler{Handler: h.Handler.WithAttrs(attrs)}
+}
+
+func (h contextHandler) WithGroup(name string) slog.Handler {
+	return contextHandler{Handler: h.Handler.WithGroup(name)}
+}
+
+func envDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+var cfg Config

--- a/spike/logging/zap/README.md
+++ b/spike/logging/zap/README.md
@@ -1,0 +1,35 @@
+# zap demo checklist
+
+This package evaluates `go.uber.org/zap` for the FLY-2308 comparison in
+[docs/spikes/logs.md](../../../docs/spikes/logs.md).
+
+Run it with:
+
+```sh
+LOG_FORMAT=json LOG_LEVEL=debug go run ./spike/logging/zap
+go test ./spike/logging/zap
+```
+
+## Requirement checklist
+
+| Requirement | Evidence | Notes |
+|-------------|----------|-------|
+| `LOG_FORMAT` / `LOG_LEVEL` | `config.go`, `main.go` | JSON and console are built in. `logfmt` would need a custom encoder. `otel` falls back to JSON in the runnable demo; the document points to `otelzap` for real wiring. |
+| Base fields | `initLogger` in `utils.go` | Uses `logger.With(...)` and typed `zap.Field` values. |
+| Real LPS examples | `real_project_examples.go` | Imports `internal/entities` and `internal/usecases` to show pegout-rebalance logs with real domain values. Also covers the sentinel + `WrapUseCaseError` migration: useCase id → `errorCode`, wrapping chain → `errorMessage`, `errors.Is` against the sentinel still matches. |
+| Request trace fields | `loggerWithTrace(ctx)` in `utils.go` | Works, but call sites must opt into the context-derived logger. |
+| Inbound trace extraction | `tracing.go` (`demoInboundTraceExtraction`, `traceMiddleware`) | Parses W3C `traceparent`, mints a trace when absent, stores trace state in `context.Context`. |
+| Structured access log | `tracing.go` (`traceMiddleware`) | Replaces `gorilla/handlers.LoggingHandler` with one structured record containing the six required HTTP fields. |
+| Outbound trace injection | `tracing.go` (`demoOutboundTraceInjection`, `traceTransport`) | Injects the same trace-id and a fresh span-id into `traceparent`. |
+| Error shape | `errors.go` | `demoErrorFields` / `demoFatal` at top; `zap.Stack` in `logError` is the strongest native stack story. |
+| PII redaction | `pii.go` | `demoPIIRedaction` at top; `piiCore` wraps `zapcore.Core`. More involved than slog `ReplaceAttr`. |
+| Fatal-equivalent | `errors.go`, `main.go` | Native `Fatal` exists and exits; demo path is guarded by `DEMO_FATAL_EXIT`. |
+| Test capture | `capture_test.go` | Uses `zaptest/observer`, the strongest test capture API among the candidates. |
+
+## Candidate caveats
+
+- The typed field API makes migration from logrus less mechanical than slog.
+- `SugaredLogger` would reduce migration friction, but also gives up part of
+  the reason to choose zap.
+- Direct zap usage does not align with the existing Go guideline preference for
+  slog.

--- a/spike/logging/zap/capture_test.go
+++ b/spike/logging/zap/capture_test.go
@@ -1,0 +1,106 @@
+// Test-output capture using zaptest/observer, the strongest API in the comparison.
+// Asserts on typed observed logs without JSON parsing.
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// newCaptureLogger uses zaptest/observer — the cleanest test API of the
+// four candidates (see logs.md "Test capture ergonomics"). It also wraps
+// the observer core in piiCore so redaction is part of the assertion.
+func newCaptureLogger(t *testing.T) (*zap.Logger, *observer.ObservedLogs) {
+	t.Helper()
+	obsCore, recorded := observer.New(zapcore.DebugLevel)
+	core := piiCore{Core: obsCore}
+	l := zap.New(core).With(
+		zap.String("service", "liquidity-provider-server"),
+		zap.String("environment", "test"),
+		zap.String("version", "test"),
+	)
+	logger = l
+	return l, recorded
+}
+
+func TestCapture_BaseFieldsAndTraceId(t *testing.T) {
+	_, recorded := newCaptureLogger(t)
+
+	tc := TraceContext{TraceID: "4bf92f3577b34da6a3ce929d0e0e4736", SpanID: "00f067aa0ba902b7"}
+	ctx := contextWithTrace(context.Background(), tc)
+	loggerWithTrace(ctx).Info("ping", zap.String("requestId", "req-001"))
+
+	all := recorded.All()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(all))
+	}
+	m := all[0].ContextMap()
+	for k, want := range map[string]string{
+		"service":     "liquidity-provider-server",
+		"environment": "test",
+		"version":     "test",
+		"traceId":     tc.TraceID,
+		"spanId":      tc.SpanID,
+		"requestId":   "req-001",
+	} {
+		if got, _ := m[k].(string); got != want {
+			t.Errorf("field %q: got %q, want %q", k, got, want)
+		}
+	}
+	if all[0].Message != "ping" {
+		t.Errorf("message: got %q", all[0].Message)
+	}
+}
+
+func TestCapture_PIIRedaction(t *testing.T) {
+	_, recorded := newCaptureLogger(t)
+	loggerWithTrace(context.Background()).Warn("attempt",
+		zap.String("privateKey", "0xdeadbeef"),
+		zap.String("apiKey", "sk-live-XYZ"),
+		zap.String("safe", "ok"),
+	)
+	m := recorded.All()[0].ContextMap()
+	for _, key := range []string{"privateKey", "apiKey"} {
+		if got, _ := m[key].(string); got != "[REDACTED]" {
+			t.Errorf("expected %q redacted, got %q", key, got)
+		}
+	}
+	if got, _ := m["safe"].(string); got != "ok" {
+		t.Errorf("non-PII field clobbered: got %q", got)
+	}
+}
+
+func TestCapture_ErrorShape(t *testing.T) {
+	_, recorded := newCaptureLogger(t)
+	logError(context.Background(), "demo", "DEMO_CODE", errors.New("boom"),
+		zap.String("integrationName", "rsk-lbc"))
+
+	all := recorded.All()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(all))
+	}
+	m := all[0].ContextMap()
+	if got, _ := m["errorCode"].(string); got != "DEMO_CODE" {
+		t.Errorf("errorCode: got %q", got)
+	}
+	if got, _ := m["errorMessage"].(string); got != "boom" {
+		t.Errorf("errorMessage: got %q", got)
+	}
+	if got, _ := m["errorStack"].(string); got == "" {
+		t.Errorf("errorStack: empty")
+	}
+	// zap.Namespace nests subsequent fields under "errorContext"; the
+	// observer represents that as a map[string]any.
+	ctxMap, ok := m["errorContext"].(map[string]any)
+	if !ok {
+		t.Fatalf("errorContext: not a map, got %T", m["errorContext"])
+	}
+	if got, _ := ctxMap["integrationName"].(string); got != "rsk-lbc" {
+		t.Errorf("errorContext.integrationName: got %q", got)
+	}
+}

--- a/spike/logging/zap/config.go
+++ b/spike/logging/zap/config.go
@@ -1,0 +1,46 @@
+// Demos LOG_FORMAT, LOG_LEVEL, structured-only output, and the seven required
+// base fields from the Base Logging Standards checklist (deliverables 1-4).
+package main
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+func demoLogFormatSupport() {
+	logger.Info("LOG_FORMAT support",
+		zap.String("configuredLogFormat", cfg.Format),
+		zap.Bool("jsonSupported", true),
+		zap.Bool("logfmtSupported", cfg.Format == "logfmt"),
+		zap.Bool("otelSupported", true),
+		zap.Bool("otelFallbackInDemo", cfg.Format == "otel"),
+	)
+}
+
+func demoLogLevelConfiguredAtStartup() {
+	logger.Info("LOG_LEVEL configured at startup",
+		zap.String("configuredLogLevel", cfg.Level.String()),
+	)
+}
+
+func demoStructuredOutputOnly(ctx context.Context) {
+	loggerWithTrace(ctx).Info("structured output only",
+		zap.Bool("plainOutputAllowed", false),
+		zap.Bool("localDevException", cfg.Environment == "local"),
+	)
+}
+
+func demoRequiredFields(ctx context.Context) {
+	loggerWithTrace(ctx).Info("required fields present",
+		zap.Strings("requiredFields", []string{
+			"timestamp",
+			"level",
+			"service",
+			"environment",
+			"version",
+			"traceId",
+			"message",
+		}),
+	)
+}

--- a/spike/logging/zap/errors.go
+++ b/spike/logging/zap/errors.go
@@ -1,0 +1,56 @@
+// Error log shape with zap.Stack for errorStack and native Fatal support.
+// demoFatal is guarded by DEMO_FATAL_EXIT so spike output stays inspectable.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+)
+
+func demoErrorFields(ctx context.Context) {
+	root := errors.New("ECONNREFUSED 127.0.0.1:4444")
+	wrapped := fmt.Errorf("lbc.getQuote: %w", root)
+	logError(ctx, "outbound rpc failed", "RPC_DIAL_FAILED", wrapped,
+		zap.String("integrationName", "rsk-lbc"),
+		zap.String("integrationMethod", "getQuote"),
+	)
+}
+
+// demoFatal shows the fatal-equivalent log line. zap has a real Fatal
+// that calls os.Exit(1) after sync — DEMO_FATAL_EXIT=1 opts in. By
+// default we log at Error so the SPIKE output stays inspectable.
+func demoFatal(ctx context.Context) {
+	exitNow := os.Getenv("DEMO_FATAL_EXIT") == "1"
+	if exitNow {
+		logger.Fatal("fatal-equivalent",
+			zap.String("errorCode", "DEMO_FATAL"),
+			zap.String("errorMessage", "forced"),
+		)
+		return
+	}
+	loggerWithTrace(ctx).Error("fatal-equivalent (DEMO_FATAL_EXIT=1 to actually exit)",
+		zap.String("errorCode", "DEMO_FATAL"),
+		zap.String("errorMessage", "forced"),
+	)
+}
+
+// logError emits the four-field error log shape. zap's killer feature
+// here is zap.Stack — native, well-tested stack capture — which is the
+// reason zap wins the "Stack trace capture" axis in logs.md.
+//
+// We attach extra fields as a "errorContext" namespace so the structure
+// is comparable to the slog demo.
+func logError(ctx context.Context, msg, code string, err error, extra ...zap.Field) {
+	fields := []zap.Field{
+		zap.String("errorCode", code),
+		zap.String("errorMessage", err.Error()),
+		zap.Stack("errorStack"),
+		zap.Namespace("errorContext"),
+	}
+	fields = append(fields, extra...)
+	loggerWithTrace(ctx).Error(msg, fields...)
+}

--- a/spike/logging/zap/main.go
+++ b/spike/logging/zap/main.go
@@ -1,0 +1,72 @@
+// Package main is the FLY-2308 spike demo for go.uber.org/zap. See
+// ../README.md and docs/spikes/logs.md for context.
+//
+// Run: LOG_FORMAT=json LOG_LEVEL=debug go run ./spike/logging/zap
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+)
+
+func main() {
+	cfg = readConfig()
+	logger = initLogger(os.Stdout, cfg)
+	defer func() { _ = logger.Sync() }()
+	ctx := contextWithTrace(context.Background(), newTraceContext())
+
+	// 1. LOG_FORMAT supporting json, logfmt, and otel where supported.
+	demoLogFormatSupport()
+
+	// 2. LOG_LEVEL configurable at startup.
+	demoLogLevelConfiguredAtStartup()
+
+	// 3. No plain unstructured output outside local development.
+	demoStructuredOutputOnly(ctx)
+
+	// 4. Required fields on every log line:
+	//    timestamp, level, service, environment, version, traceId, message.
+	demoRequiredFields(ctx)
+
+	// Extra LPS example: imports project packages and logs real domain fields.
+	demoRealLPSUseCaseLogging(ctx)
+
+	// 5-6 and 10 use the structured request middleware below.
+	inbound := httptest.NewServer(traceMiddleware(http.HandlerFunc(sampleHandler)))
+	defer inbound.Close()
+
+	// 5. Inbound W3C traceparent extraction, with a generated trace if absent.
+	demoInboundTraceExtraction(inbound.URL + "/quote")
+
+	// 6. traceId carried through context.Context and emitted on request logs.
+	demoRequestScopedTrace(inbound.URL + "/quote")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Received-Traceparent", r.Header.Get("traceparent"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	// 7. Outbound HTTP/RPC traceparent injection with a fresh span-id.
+	demoOutboundTraceInjection(upstream.URL + "/lbc/getQuote")
+
+	// 8. Error logs containing errorCode, errorMessage, errorStack,
+	//    and errorContext.
+	demoErrorFields(ctx)
+
+	// Extra LPS example: sentinel + WrapUseCaseError migrated to the
+	// structured error shape, with errors.Is still matching.
+	demoRealLPSUseCaseError(ctx)
+
+	// 9. PII drop or redaction by key for the required deny-list.
+	demoPIIRedaction(ctx)
+
+	// 10. Structured replacement for gorilla/handlers.LoggingHandler.
+	demoStructuredRequestLoggingReplacement(inbound.URL + "/quote")
+
+	// Extra task deliverable: fatal-equivalent behavior.
+	demoFatal(ctx)
+}

--- a/spike/logging/zap/pii.go
+++ b/spike/logging/zap/pii.go
@@ -1,0 +1,64 @@
+// PII deny-list redaction through a zapcore.Core wrapper (piiCore). Heavier than
+// slog ReplaceAttr but workable for arbitrary key denial.
+package main
+
+import (
+	"context"
+	"strings"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func demoPIIRedaction(ctx context.Context) {
+	loggerWithTrace(ctx).Warn("attempted to log PII (expect redaction)",
+		zap.String("privateKey", "0xdeadbeefcafebabe"),
+		zap.String("apiKey", "sk-live-XYZ"),
+		zap.String("authorization", "Bearer eyJhbGciOi..."),
+		zap.String("safe", "ok"),
+	)
+}
+
+var piiDenyList = map[string]struct{}{
+	"privatekey":    {},
+	"seed":          {},
+	"mnemonic":      {},
+	"apikey":        {},
+	"password":      {},
+	"authorization": {},
+}
+
+// piiCore wraps a zapcore.Core. We intercept Write so we can mutate
+// fields before they reach the encoder. This is the "PII deny-list
+// interception" row for zap — workable, but heavier than slog's
+// ReplaceAttr: zap's fields are typed, and we must reset each denied
+// field through zapcore.Field assignment rather than a simple value
+// swap.
+type piiCore struct{ zapcore.Core }
+
+func (c piiCore) With(fields []zapcore.Field) zapcore.Core {
+	return piiCore{Core: c.Core.With(redactFields(fields))}
+}
+
+func (c piiCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(ent.Level) {
+		return ce.AddCore(ent, c)
+	}
+	return ce
+}
+
+func (c piiCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	return c.Core.Write(ent, redactFields(fields))
+}
+
+func redactFields(fields []zapcore.Field) []zapcore.Field {
+	out := make([]zapcore.Field, len(fields))
+	for i, f := range fields {
+		if _, deny := piiDenyList[strings.ToLower(f.Key)]; deny {
+			out[i] = zapcore.Field{Key: f.Key, Type: zapcore.StringType, String: "[REDACTED]"}
+			continue
+		}
+		out[i] = f
+	}
+	return out
+}

--- a/spike/logging/zap/real_project_examples.go
+++ b/spike/logging/zap/real_project_examples.go
@@ -1,0 +1,46 @@
+// Real LPS examples: imports project packages and rewrites representative
+// pegout-rebalance logs into structured zap fields.
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rsksmart/liquidity-provider-server/internal/entities"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
+	"go.uber.org/zap"
+)
+
+func demoRealLPSUseCaseLogging(ctx context.Context) {
+	adjustedTotal := entities.SatoshiToWei(75_000_000)
+	bridgeMin := entities.EtherToWei(1)
+
+	loggerWithTrace(ctx).Info("bridge pegout threshold not met",
+		zap.String("useCase", string(usecases.BridgePegoutId)),
+		zap.String("adjustedTotalWei", adjustedTotal.String()),
+		zap.String("adjustedTotalRbtc", adjustedTotal.ToRbtc().Text('f', 18)),
+		zap.String("bridgeMinWei", bridgeMin.String()),
+		zap.String("bridgeMinRbtc", bridgeMin.ToRbtc().Text('f', 18)),
+	)
+
+	loggerWithTrace(ctx).Info("bridge pegout split transaction persisted",
+		zap.String("useCase", string(usecases.BridgePegoutId)),
+		zap.Int("chunkIndex", 1),
+		zap.Int("totalChunks", 3),
+		zap.String("transactionHash", "0xfeedbeef"),
+	)
+}
+
+// demoRealLPSUseCaseError shows the LPS sentinel + WrapUseCaseError pattern
+func demoRealLPSUseCaseError(ctx context.Context) {
+	adjustedTotal := entities.SatoshiToWei(50_000_000)
+	bridgeMin := entities.EtherToWei(1)
+
+	wrapped := usecases.WrapUseCaseError(usecases.BridgePegoutId, usecases.TxBelowMinimumError)
+
+	logError(ctx, "bridge pegout threshold not met", string(usecases.BridgePegoutId), wrapped,
+		zap.String("adjustedTotalRbtc", adjustedTotal.ToRbtc().Text('f', 18)),
+		zap.String("bridgeMinRbtc", bridgeMin.ToRbtc().Text('f', 18)),
+		zap.Bool("matchesSentinel", errors.Is(wrapped, usecases.TxBelowMinimumError)),
+	)
+}

--- a/spike/logging/zap/tracing.go
+++ b/spike/logging/zap/tracing.go
@@ -1,0 +1,204 @@
+// W3C Trace Context and structured HTTP logging with zap typed fields at every
+// log site: traceMiddleware, traceTransport, and integration-call logging.
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"regexp"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func demoInboundTraceExtraction(url string) {
+	hit(url, "")
+}
+
+func demoRequestScopedTrace(url string) {
+	hit(url, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+}
+
+func demoStructuredRequestLoggingReplacement(url string) {
+	hit(url, "00-11111111111111111111111111111111-2222222222222222-01")
+}
+
+func demoOutboundTraceInjection(url string) {
+	ctx := contextWithTrace(context.Background(), newTraceContext())
+	client := &http.Client{Transport: traceTransport{Base: http.DefaultTransport}}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	start := time.Now()
+	resp, err := client.Do(req)
+	dur := time.Since(start).Milliseconds()
+	if err != nil {
+		logError(ctx, "integration call failed", "OUTBOUND_FAILED", err,
+			zap.String("integrationName", "rsk-lbc"),
+			zap.String("integrationMethod", "getQuote"),
+			zap.Int64("integrationDurationMs", dur),
+		)
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	loggerWithTrace(ctx).Info("integration call",
+		zap.String("integrationName", "rsk-lbc"),
+		zap.String("integrationMethod", "getQuote"),
+		zap.Int64("integrationDurationMs", dur),
+		zap.Int("integrationStatusCode", resp.StatusCode),
+	)
+}
+
+func hit(url, traceparent string) {
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("X-Request-Id", "req-001")
+	if traceparent != "" {
+		req.Header.Set("traceparent", traceparent)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logger.Error("inbound demo request failed", zap.Error(err))
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+type TraceContext struct {
+	TraceID string
+	SpanID  string
+}
+
+type traceCtxKey struct{}
+
+var traceparentPattern = regexp.MustCompile(`^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$`)
+
+func parseTraceparent(v string) (TraceContext, bool) {
+	m := traceparentPattern.FindStringSubmatch(v)
+	if m == nil {
+		return TraceContext{}, false
+	}
+	return TraceContext{TraceID: m[2], SpanID: m[3]}, true
+}
+
+func newTraceContext() TraceContext {
+	var t [16]byte
+	var s [8]byte
+	_, _ = rand.Read(t[:])
+	_, _ = rand.Read(s[:])
+	return TraceContext{TraceID: hex.EncodeToString(t[:]), SpanID: hex.EncodeToString(s[:])}
+}
+
+func contextWithTrace(ctx context.Context, tc TraceContext) context.Context {
+	return context.WithValue(ctx, traceCtxKey{}, tc)
+}
+
+func traceFromContext(ctx context.Context) (TraceContext, bool) {
+	if ctx == nil {
+		return TraceContext{}, false
+	}
+	tc, ok := ctx.Value(traceCtxKey{}).(TraceContext)
+	return tc, ok
+}
+
+func traceSource(adopted bool) string {
+	if adopted {
+		return "inbound-header"
+	}
+	return "minted"
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}
+
+// traceMiddleware is the zap-flavoured structured request middleware.
+// Every log call uses zap's typed-field API — note the explicit
+// zap.String / zap.Int / zap.Int64 / zap.Bool wrappers at every call
+// site. That typing buys lazy evaluation and zero-alloc encoding, at
+// the cost of being chattier than slog's slog.String/etc helpers
+// (which are also typed but feel less heavy because of slog.Attr).
+func traceMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw := r.Header.Get("traceparent")
+		tc, adopted := parseTraceparent(raw)
+		if !adopted {
+			tc = newTraceContext()
+		}
+		ctx := contextWithTrace(r.Context(), tc)
+
+		loggerWithTrace(ctx).Debug("trace context resolved",
+			zap.Bool("traceAdopted", adopted),
+			zap.String("traceSource", traceSource(adopted)),
+			zap.String("incomingTraceparent", raw),
+		)
+
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r.WithContext(ctx))
+
+		loggerWithTrace(ctx).Info("http request",
+			zap.String("httpMethod", r.Method),
+			zap.String("httpPath", r.URL.Path),
+			zap.Int("httpStatusCode", rec.status),
+			zap.Int64("durationMs", time.Since(start).Milliseconds()),
+			zap.String("userAgent", r.UserAgent()),
+			zap.String("requestId", r.Header.Get("X-Request-Id")),
+		)
+	})
+}
+
+// traceTransport is the zap-flavoured outbound RoundTripper. Each
+// branch is a zap call with typed fields.
+type traceTransport struct{ Base http.RoundTripper }
+
+func (t traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	ctx := req.Context()
+
+	tc, ok := traceFromContext(ctx)
+	if !ok {
+		loggerWithTrace(ctx).Warn("outbound call with no trace in context",
+			zap.String("integrationUrl", req.URL.String()),
+		)
+		return base.RoundTrip(req)
+	}
+
+	fresh := newTraceContext()
+	header := "00-" + tc.TraceID + "-" + fresh.SpanID + "-01"
+	req = req.Clone(ctx)
+	req.Header.Set("traceparent", header)
+
+	loggerWithTrace(ctx).Debug("outbound traceparent injected",
+		zap.String("parentSpanId", tc.SpanID),
+		zap.String("childSpanId", fresh.SpanID),
+		zap.String("integrationUrl", req.URL.String()),
+	)
+	return base.RoundTrip(req)
+}
+
+// sampleHandler is the business handler. traceMiddleware emits the six
+// standard HTTP fields; here we only emit the business log via zap with
+// traceId attached by loggerWithTrace.
+func sampleHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"quoteHash":"0xabc"}`))
+
+	loggerWithTrace(r.Context()).Info("quote returned",
+		zap.String("quoteHash", "0xabc"),
+	)
+}

--- a/spike/logging/zap/utils.go
+++ b/spike/logging/zap/utils.go
@@ -1,0 +1,104 @@
+// Shared logger setup: env-driven Config, zap core stack with piiCore, init-time
+// base fields, and loggerWithTrace for per-request trace fields.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type Config struct {
+	Format      string
+	Level       zapcore.Level
+	Service     string
+	Environment string
+	Version     string
+}
+
+func readConfig() Config {
+	cfg := Config{
+		Format:      strings.ToLower(envDefault("LOG_FORMAT", "json")),
+		Service:     envDefault("LOG_SERVICE", "liquidity-provider-server"),
+		Environment: envDefault("LOG_ENVIRONMENT", "spike"),
+		Version:     envDefault("LOG_VERSION", "spike-fly-2308"),
+	}
+	switch strings.ToLower(envDefault("LOG_LEVEL", "info")) {
+	case "debug":
+		cfg.Level = zapcore.DebugLevel
+	case "warn", "warning":
+		cfg.Level = zapcore.WarnLevel
+	case "error":
+		cfg.Level = zapcore.ErrorLevel
+	default:
+		cfg.Level = zapcore.InfoLevel
+	}
+	return cfg
+}
+
+// initLogger builds the zap core stack:
+//
+//	piiCore (drops PII fields)
+//	  -> base core (JSON or console encoder)
+//
+// Base fields are attached with zap.Fields and then frozen onto the
+// returned logger. Trace fields ride along by way of loggerWithTrace.
+func initLogger(out io.Writer, cfg Config) *zap.Logger {
+	enc := buildEncoder(cfg.Format)
+	core := zapcore.NewCore(enc, zapcore.AddSync(out), cfg.Level)
+	core = piiCore{Core: core}
+
+	logger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(0)).With(
+		zap.String("service", cfg.Service),
+		zap.String("environment", cfg.Environment),
+		zap.String("version", cfg.Version),
+	)
+	return logger
+}
+
+func buildEncoder(format string) zapcore.Encoder {
+	encCfg := zap.NewProductionEncoderConfig()
+	encCfg.TimeKey = "timestamp"
+	encCfg.MessageKey = "message"
+	encCfg.LevelKey = "level"
+	encCfg.EncodeTime = zapcore.RFC3339NanoTimeEncoder
+	encCfg.EncodeLevel = zapcore.LowercaseLevelEncoder
+	switch format {
+	case "text", "logfmt":
+		// Console is human-readable, not strict logfmt; a real
+		// logfmt would need a custom encoder.
+		return zapcore.NewConsoleEncoder(encCfg)
+	case "otel":
+		fmt.Fprintln(os.Stderr, "LOG_FORMAT=otel: would use otelzap; falling back to JSON for the spike")
+		return zapcore.NewJSONEncoder(encCfg)
+	default:
+		return zapcore.NewJSONEncoder(encCfg)
+	}
+}
+
+// loggerWithTrace returns the package logger with traceId/spanId
+// attached if ctx carries a TraceContext. zap has no native handler hook
+// that reads ctx — call sites must opt in.
+func loggerWithTrace(ctx context.Context) *zap.Logger {
+	if tc, ok := traceFromContext(ctx); ok {
+		return logger.With(zap.String("traceId", tc.TraceID), zap.String("spanId", tc.SpanID))
+	}
+	return logger
+}
+
+func envDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+var (
+	cfg    Config
+	logger *zap.Logger
+)

--- a/spike/logging/zerolog/README.md
+++ b/spike/logging/zerolog/README.md
@@ -1,0 +1,35 @@
+# zerolog demo checklist
+
+This package evaluates `github.com/rs/zerolog` for the FLY-2308 comparison in
+[docs/spikes/logs.md](../../../docs/spikes/logs.md).
+
+Run it with:
+
+```sh
+LOG_FORMAT=json LOG_LEVEL=debug go run ./spike/logging/zerolog
+go test ./spike/logging/zerolog
+```
+
+## Requirement checklist
+
+| Requirement | Evidence | Notes |
+|-------------|----------|-------|
+| `LOG_FORMAT` / `LOG_LEVEL` | `config.go`, `main.go` | JSON and console output are built in. `logfmt` is approximated by console output. `otel` falls back to JSON because there is no first-party zerolog bridge. |
+| Base fields | `initLogger` in `utils.go` | Uses `logger.With().Str(...).Logger()`. |
+| Real LPS examples | `real_project_examples.go` | Imports `internal/entities` and `internal/usecases` to show pegout-rebalance logs with real domain values. Also covers the sentinel + `WrapUseCaseError` migration: useCase id → `errorCode`, wrapping chain → `errorMessage`, `errors.Is` against the sentinel still matches. |
+| Request trace fields | `loggerWithTrace(ctx)` in `utils.go` | Works, but call sites must opt into the context-derived logger. |
+| Inbound trace extraction | `tracing.go` (`demoInboundTraceExtraction`, `traceMiddleware`) | Parses W3C `traceparent`, mints a trace when absent, stores trace state in `context.Context`. |
+| Structured access log | `tracing.go` (`traceMiddleware`) | Replaces `gorilla/handlers.LoggingHandler` with one structured record containing the six required HTTP fields. |
+| Outbound trace injection | `tracing.go` (`demoOutboundTraceInjection`, `traceTransport`) | Injects the same trace-id and a fresh span-id into `traceparent`. |
+| Error shape | `errors.go` | `demoErrorFields` / `demoFatal` at top; custom stack capture in `logError`. |
+| PII redaction | `pii.go` | `demoPIIRedaction` at top; `piiWriter` does writer-level JSON rewriting — intentionally awkward. |
+| Fatal-equivalent | `errors.go`, `main.go` | Native `Fatal` exists and exits; demo path is guarded by `DEMO_FATAL_EXIT`. |
+| Test capture | `capture_test.go` | Buffer capture plus JSON-line parsing. |
+
+## Candidate caveats
+
+- Fluent chaining is the largest API-shape change from current logrus calls.
+- Arbitrary PII key redaction is weaker than slog or logrus because zerolog
+  does not expose a natural record-level map/hook.
+- OTel bridge maturity is weaker than slog and zap for this task's paper
+  evaluation.

--- a/spike/logging/zerolog/capture_test.go
+++ b/spike/logging/zerolog/capture_test.go
@@ -1,0 +1,129 @@
+// Test-output capture via a buffer-backed logger and JSON-line parsing, mirroring
+// the slog demo's buffer approach.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// newCaptureLogger wires a logger that writes JSON through piiWriter
+// into a buffer. zerolog's "test capture story" is essentially this —
+// SetOutput a buffer, then JSON-parse lines. Workable, but less
+// expressive than zap's observer.
+func newCaptureLogger(buf *bytes.Buffer) zerolog.Logger {
+	zerolog.TimeFieldFormat = time.RFC3339Nano
+	zerolog.MessageFieldName = "message"
+	zerolog.TimestampFieldName = "timestamp"
+	zerolog.LevelFieldName = "level"
+
+	l := zerolog.New(piiWriter{Out: buf}).Level(zerolog.DebugLevel).With().
+		Timestamp().
+		Str("service", "liquidity-provider-server").
+		Str("environment", "test").
+		Str("version", "test").
+		Logger()
+	logger = l
+	return l
+}
+
+func records(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	out := []map[string]any{}
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+func TestCapture_BaseFieldsAndTraceId(t *testing.T) {
+	buf := &bytes.Buffer{}
+	newCaptureLogger(buf)
+
+	tc := TraceContext{TraceID: "4bf92f3577b34da6a3ce929d0e0e4736", SpanID: "00f067aa0ba902b7"}
+	ctx := contextWithTrace(context.Background(), tc)
+	loggerWithTrace(ctx).Info().Str("requestId", "req-001").Msg("ping")
+
+	recs := records(t, buf)
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+	r := recs[0]
+	for k, want := range map[string]string{
+		"service":     "liquidity-provider-server",
+		"environment": "test",
+		"version":     "test",
+		"traceId":     tc.TraceID,
+		"spanId":      tc.SpanID,
+		"message":     "ping",
+		"requestId":   "req-001",
+	} {
+		if got, _ := r[k].(string); got != want {
+			t.Errorf("field %q: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestCapture_PIIRedaction(t *testing.T) {
+	buf := &bytes.Buffer{}
+	newCaptureLogger(buf)
+	loggerWithTrace(context.Background()).Warn().
+		Str("privateKey", "0xdeadbeef").
+		Str("apiKey", "sk-live-XYZ").
+		Str("safe", "ok").
+		Msg("attempt")
+
+	recs := records(t, buf)
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+	r := recs[0]
+	for _, key := range []string{"privateKey", "apiKey"} {
+		if got, _ := r[key].(string); got != "[REDACTED]" {
+			t.Errorf("expected %q redacted, got %q", key, got)
+		}
+	}
+	if got, _ := r["safe"].(string); got != "ok" {
+		t.Errorf("non-PII field clobbered: got %q", got)
+	}
+}
+
+func TestCapture_ErrorShape(t *testing.T) {
+	buf := &bytes.Buffer{}
+	newCaptureLogger(buf)
+	logError(context.Background(), "demo", "DEMO_CODE", errors.New("boom"), map[string]string{
+		"integrationName": "rsk-lbc",
+	})
+
+	recs := records(t, buf)
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+	r := recs[0]
+	if got, _ := r["errorCode"].(string); got != "DEMO_CODE" {
+		t.Errorf("errorCode: got %q", got)
+	}
+	if got, _ := r["errorMessage"].(string); got != "boom" {
+		t.Errorf("errorMessage: got %q", got)
+	}
+	if got, _ := r["errorStack"].(string); got == "" {
+		t.Errorf("errorStack: empty")
+	}
+	if _, ok := r["errorContext"].(map[string]any); !ok {
+		t.Errorf("errorContext: not a map, got %T", r["errorContext"])
+	}
+}

--- a/spike/logging/zerolog/config.go
+++ b/spike/logging/zerolog/config.go
@@ -1,0 +1,42 @@
+// Demos LOG_FORMAT, LOG_LEVEL, structured-only output, and the seven required
+// base fields from the Base Logging Standards checklist (deliverables 1-4).
+package main
+
+import "context"
+
+func demoLogFormatSupport() {
+	logger.Info().
+		Str("configuredLogFormat", cfg.Format).
+		Bool("jsonSupported", true).
+		Bool("logfmtSupported", cfg.Format == "logfmt").
+		Bool("otelSupported", false).
+		Bool("otelFallback", cfg.Format == "otel").
+		Msg("LOG_FORMAT support")
+}
+
+func demoLogLevelConfiguredAtStartup() {
+	logger.Info().
+		Str("configuredLogLevel", cfg.Level.String()).
+		Msg("LOG_LEVEL configured at startup")
+}
+
+func demoStructuredOutputOnly(ctx context.Context) {
+	loggerWithTrace(ctx).Info().
+		Bool("plainOutputAllowed", false).
+		Bool("localDevException", cfg.Environment == "local").
+		Msg("structured output only")
+}
+
+func demoRequiredFields(ctx context.Context) {
+	loggerWithTrace(ctx).Info().
+		Strs("requiredFields", []string{
+			"timestamp",
+			"level",
+			"service",
+			"environment",
+			"version",
+			"traceId",
+			"message",
+		}).
+		Msg("required fields present")
+}

--- a/spike/logging/zerolog/errors.go
+++ b/spike/logging/zerolog/errors.go
@@ -1,0 +1,82 @@
+// Error log shape and fatal-equivalent logging; stack capture is hand-rolled.
+// zerolog.Fatal is available; demoFatal is guarded by DEMO_FATAL_EXIT.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func demoErrorFields(ctx context.Context) {
+	root := errors.New("ECONNREFUSED 127.0.0.1:4444")
+	wrapped := fmt.Errorf("lbc.getQuote: %w", root)
+	logError(ctx, "outbound rpc failed", "RPC_DIAL_FAILED", wrapped, map[string]string{
+		"integrationName":   "rsk-lbc",
+		"integrationMethod": "getQuote",
+	})
+}
+
+// demoFatal shows the fatal-equivalent log line. zerolog has Fatal() — it
+// logs at Fatal level and calls os.Exit(1) — DEMO_FATAL_EXIT=1 opts in.
+// By default we log at Error so the SPIKE output stays inspectable.
+func demoFatal(ctx context.Context) {
+	exitNow := os.Getenv("DEMO_FATAL_EXIT") == "1"
+	if exitNow {
+		logger.Fatal().
+			Str("errorCode", "DEMO_FATAL").
+			Str("errorMessage", "forced").
+			Msg("fatal-equivalent")
+		return
+	}
+	loggerWithTrace(ctx).Error().
+		Str("errorCode", "DEMO_FATAL").
+		Str("errorMessage", "forced").
+		Msg("fatal-equivalent (DEMO_FATAL_EXIT=1 to actually exit)")
+}
+
+// captureStack — zerolog has zerolog.ErrorStackMarshaler but it depends
+// on a third-party errors package (pkg/errors style). We capture the
+// stack ourselves for symmetry with the other demos and to avoid pulling
+// another dep into this spike. This is why zerolog ranks "hook needed"
+// on the stack-trace axis.
+func captureStack(skip int) string {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(skip, pcs[:])
+	if n == 0 {
+		return ""
+	}
+	frames := runtime.CallersFrames(pcs[:n])
+	var b strings.Builder
+	for {
+		f, more := frames.Next()
+		b.WriteString(f.Function)
+		b.WriteByte('\n')
+		b.WriteByte('\t')
+		b.WriteString(f.File)
+		b.WriteByte(':')
+		b.WriteString(strconv.Itoa(f.Line))
+		b.WriteByte('\n')
+		if !more {
+			break
+		}
+	}
+	return b.String()
+}
+
+// logError emits the four standard error fields. extra is folded into
+// errorContext as a sub-object via .Interface so the JSON shape matches
+// the slog and zap demos.
+func logError(ctx context.Context, msg, code string, err error, extra map[string]string) {
+	loggerWithTrace(ctx).Error().
+		Str("errorCode", code).
+		Str("errorMessage", err.Error()).
+		Str("errorStack", captureStack(3)).
+		Interface("errorContext", extra).
+		Msg(msg)
+}

--- a/spike/logging/zerolog/main.go
+++ b/spike/logging/zerolog/main.go
@@ -1,0 +1,71 @@
+// Package main is the FLY-2308 spike demo for github.com/rs/zerolog.
+// See ../README.md and docs/spikes/logs.md for context.
+//
+// Run: LOG_FORMAT=json LOG_LEVEL=debug go run ./spike/logging/zerolog
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+)
+
+func main() {
+	cfg = readConfig()
+	logger = initLogger(os.Stdout, cfg)
+	ctx := contextWithTrace(context.Background(), newTraceContext())
+
+	// 1. LOG_FORMAT supporting json, logfmt, and otel where supported.
+	demoLogFormatSupport()
+
+	// 2. LOG_LEVEL configurable at startup.
+	demoLogLevelConfiguredAtStartup()
+
+	// 3. No plain unstructured output outside local development.
+	demoStructuredOutputOnly(ctx)
+
+	// 4. Required fields on every log line:
+	//    timestamp, level, service, environment, version, traceId, message.
+	demoRequiredFields(ctx)
+
+	// Extra LPS example: imports project packages and logs real domain fields.
+	demoRealLPSUseCaseLogging(ctx)
+
+	// 5-6 and 10 use the structured request middleware below.
+	inbound := httptest.NewServer(traceMiddleware(http.HandlerFunc(sampleHandler)))
+	defer inbound.Close()
+
+	// 5. Inbound W3C traceparent extraction, with a generated trace if absent.
+	demoInboundTraceExtraction(inbound.URL + "/quote")
+
+	// 6. traceId carried through context.Context and emitted on request logs.
+	demoRequestScopedTrace(inbound.URL + "/quote")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Received-Traceparent", r.Header.Get("traceparent"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	// 7. Outbound HTTP/RPC traceparent injection with a fresh span-id.
+	demoOutboundTraceInjection(upstream.URL + "/lbc/getQuote")
+
+	// 8. Error logs containing errorCode, errorMessage, errorStack,
+	//    and errorContext.
+	demoErrorFields(ctx)
+
+	// Extra LPS example: sentinel + WrapUseCaseError migrated to the
+	// structured error shape, with errors.Is still matching.
+	demoRealLPSUseCaseError(ctx)
+
+	// 9. PII drop or redaction by key for the required deny-list.
+	demoPIIRedaction(ctx)
+
+	// 10. Structured replacement for gorilla/handlers.LoggingHandler.
+	demoStructuredRequestLoggingReplacement(inbound.URL + "/quote")
+
+	// Extra task deliverable: fatal-equivalent behavior.
+	demoFatal(ctx)
+}

--- a/spike/logging/zerolog/pii.go
+++ b/spike/logging/zerolog/pii.go
@@ -1,0 +1,58 @@
+// PII deny-list redaction through piiWriter, a JSON regex rewrite on the
+// io.Writer. Demonstrates the weak arbitrary-key story called out in logs.md.
+package main
+
+import (
+	"context"
+	"io"
+	"regexp"
+)
+
+func demoPIIRedaction(ctx context.Context) {
+	loggerWithTrace(ctx).Warn().
+		Str("privateKey", "0xdeadbeefcafebabe").
+		Str("apiKey", "sk-live-XYZ").
+		Str("authorization", "Bearer eyJhbGciOi...").
+		Str("safe", "ok").
+		Msg("attempted to log PII (expect redaction)")
+}
+
+var piiDenyList = []string{
+	"privateKey",
+	"seed",
+	"mnemonic",
+	"apiKey",
+	"password",
+	"authorization",
+}
+
+// piiPattern matches one denied key in zerolog's JSON output:
+//
+//	"privateKey":"0xdeadbeef"
+//
+// We replace the value with "[REDACTED]". This is the structural
+// downside of zerolog called out in logs.md "PII deny-list interception":
+// zerolog has no per-field hook, so redaction either has to live inside
+// the writer (here) or every call site must remember to use a wrapper.
+// Both are weaker than slog's ReplaceAttr.
+var piiPattern = func() *regexp.Regexp {
+	alt := piiDenyList[0]
+	for _, k := range piiDenyList[1:] {
+		alt += "|" + k
+	}
+	return regexp.MustCompile(`"(` + alt + `)":"[^"]*"`)
+}()
+
+// piiWriter wraps zerolog's destination io.Writer and rewrites denied
+// keys on the way out. JSON-aware enough for flat values; nested objects
+// would need a real JSON walker.
+type piiWriter struct{ Out io.Writer }
+
+func (w piiWriter) Write(p []byte) (int, error) {
+	redacted := piiPattern.ReplaceAll(p, []byte(`"$1":"[REDACTED]"`))
+	if _, err := w.Out.Write(redacted); err != nil {
+		return 0, err
+	}
+	// Report the original length so zerolog does not think it wrote less.
+	return len(p), nil
+}

--- a/spike/logging/zerolog/real_project_examples.go
+++ b/spike/logging/zerolog/real_project_examples.go
@@ -1,0 +1,46 @@
+// Real LPS examples: imports project packages and rewrites representative
+// pegout-rebalance logs into structured zerolog fields.
+package main
+
+import (
+	"context"
+	"errors"
+	"strconv"
+
+	"github.com/rsksmart/liquidity-provider-server/internal/entities"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
+)
+
+func demoRealLPSUseCaseLogging(ctx context.Context) {
+	adjustedTotal := entities.SatoshiToWei(75_000_000)
+	bridgeMin := entities.EtherToWei(1)
+
+	loggerWithTrace(ctx).Info().
+		Str("useCase", string(usecases.BridgePegoutId)).
+		Str("adjustedTotalWei", adjustedTotal.String()).
+		Str("adjustedTotalRbtc", adjustedTotal.ToRbtc().Text('f', 18)).
+		Str("bridgeMinWei", bridgeMin.String()).
+		Str("bridgeMinRbtc", bridgeMin.ToRbtc().Text('f', 18)).
+		Msg("bridge pegout threshold not met")
+
+	loggerWithTrace(ctx).Info().
+		Str("useCase", string(usecases.BridgePegoutId)).
+		Int("chunkIndex", 1).
+		Int("totalChunks", 3).
+		Str("transactionHash", "0xfeedbeef").
+		Msg("bridge pegout split transaction persisted")
+}
+
+// demoRealLPSUseCaseError shows the LPS sentinel + WrapUseCaseError pattern
+func demoRealLPSUseCaseError(ctx context.Context) {
+	adjustedTotal := entities.SatoshiToWei(50_000_000)
+	bridgeMin := entities.EtherToWei(1)
+
+	wrapped := usecases.WrapUseCaseError(usecases.BridgePegoutId, usecases.TxBelowMinimumError)
+
+	logError(ctx, "bridge pegout threshold not met", string(usecases.BridgePegoutId), wrapped, map[string]string{
+		"adjustedTotalRbtc": adjustedTotal.ToRbtc().Text('f', 18),
+		"bridgeMinRbtc":     bridgeMin.ToRbtc().Text('f', 18),
+		"matchesSentinel":   strconv.FormatBool(errors.Is(wrapped, usecases.TxBelowMinimumError)),
+	})
+}

--- a/spike/logging/zerolog/tracing.go
+++ b/spike/logging/zerolog/tracing.go
@@ -1,0 +1,203 @@
+// W3C Trace Context and structured HTTP logging via zerolog's fluent event API:
+// traceMiddleware, traceTransport, and integration-call logging.
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"regexp"
+	"time"
+)
+
+func demoInboundTraceExtraction(url string) {
+	hit(url, "")
+}
+
+func demoRequestScopedTrace(url string) {
+	hit(url, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+}
+
+func demoStructuredRequestLoggingReplacement(url string) {
+	hit(url, "00-11111111111111111111111111111111-2222222222222222-01")
+}
+
+func demoOutboundTraceInjection(url string) {
+	ctx := contextWithTrace(context.Background(), newTraceContext())
+	client := &http.Client{Transport: traceTransport{Base: http.DefaultTransport}}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	start := time.Now()
+	resp, err := client.Do(req)
+	dur := time.Since(start).Milliseconds()
+	if err != nil {
+		logError(ctx, "integration call failed", "OUTBOUND_FAILED", err, map[string]string{
+			"integrationName":   "rsk-lbc",
+			"integrationMethod": "getQuote",
+		})
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	loggerWithTrace(ctx).Info().
+		Str("integrationName", "rsk-lbc").
+		Str("integrationMethod", "getQuote").
+		Int64("integrationDurationMs", dur).
+		Int("integrationStatusCode", resp.StatusCode).
+		Msg("integration call")
+}
+
+func hit(url, traceparent string) {
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("X-Request-Id", "req-001")
+	if traceparent != "" {
+		req.Header.Set("traceparent", traceparent)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logger.Error().Err(err).Msg("inbound demo request failed")
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+type TraceContext struct {
+	TraceID string
+	SpanID  string
+}
+
+type traceCtxKey struct{}
+
+var traceparentPattern = regexp.MustCompile(`^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$`)
+
+func parseTraceparent(v string) (TraceContext, bool) {
+	m := traceparentPattern.FindStringSubmatch(v)
+	if m == nil {
+		return TraceContext{}, false
+	}
+	return TraceContext{TraceID: m[2], SpanID: m[3]}, true
+}
+
+func newTraceContext() TraceContext {
+	var t [16]byte
+	var s [8]byte
+	_, _ = rand.Read(t[:])
+	_, _ = rand.Read(s[:])
+	return TraceContext{TraceID: hex.EncodeToString(t[:]), SpanID: hex.EncodeToString(s[:])}
+}
+
+func contextWithTrace(ctx context.Context, tc TraceContext) context.Context {
+	return context.WithValue(ctx, traceCtxKey{}, tc)
+}
+
+func traceFromContext(ctx context.Context) (TraceContext, bool) {
+	if ctx == nil {
+		return TraceContext{}, false
+	}
+	tc, ok := ctx.Value(traceCtxKey{}).(TraceContext)
+	return tc, ok
+}
+
+func traceSource(adopted bool) string {
+	if adopted {
+		return "inbound-header"
+	}
+	return "minted"
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}
+
+// traceMiddleware is the zerolog-flavoured structured request
+// middleware. Every log call is a fluent chain — Event builders for
+// Debug() / Info() / Warn() followed by typed .Str / .Int / .Bool
+// methods and a terminal .Msg(). That chain is the heart of the zerolog
+// API surface and what makes the migration from logrus the most
+// invasive of the four candidates: every existing call site has to be
+// rewritten into this shape.
+func traceMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw := r.Header.Get("traceparent")
+		tc, adopted := parseTraceparent(raw)
+		if !adopted {
+			tc = newTraceContext()
+		}
+		ctx := contextWithTrace(r.Context(), tc)
+
+		loggerWithTrace(ctx).Debug().
+			Bool("traceAdopted", adopted).
+			Str("traceSource", traceSource(adopted)).
+			Str("incomingTraceparent", raw).
+			Msg("trace context resolved")
+
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r.WithContext(ctx))
+
+		loggerWithTrace(ctx).Info().
+			Str("httpMethod", r.Method).
+			Str("httpPath", r.URL.Path).
+			Int("httpStatusCode", rec.status).
+			Int64("durationMs", time.Since(start).Milliseconds()).
+			Str("userAgent", r.UserAgent()).
+			Str("requestId", r.Header.Get("X-Request-Id")).
+			Msg("http request")
+	})
+}
+
+// traceTransport is the zerolog-flavoured outbound RoundTripper. Each
+// branch uses zerolog's fluent event API directly.
+type traceTransport struct{ Base http.RoundTripper }
+
+func (t traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	ctx := req.Context()
+
+	tc, ok := traceFromContext(ctx)
+	if !ok {
+		loggerWithTrace(ctx).Warn().
+			Str("integrationUrl", req.URL.String()).
+			Msg("outbound call with no trace in context")
+		return base.RoundTrip(req)
+	}
+
+	fresh := newTraceContext()
+	header := "00-" + tc.TraceID + "-" + fresh.SpanID + "-01"
+	req = req.Clone(ctx)
+	req.Header.Set("traceparent", header)
+
+	loggerWithTrace(ctx).Debug().
+		Str("parentSpanId", tc.SpanID).
+		Str("childSpanId", fresh.SpanID).
+		Str("integrationUrl", req.URL.String()).
+		Msg("outbound traceparent injected")
+
+	return base.RoundTrip(req)
+}
+
+// sampleHandler is the business handler. traceMiddleware emits the six
+// standard HTTP fields; here we only emit the business log via the
+// zerolog fluent chain with trace fields added by loggerWithTrace.
+func sampleHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"quoteHash":"0xabc"}`))
+
+	loggerWithTrace(r.Context()).Info().
+		Str("quoteHash", "0xabc").
+		Msg("quote returned")
+}

--- a/spike/logging/zerolog/utils.go
+++ b/spike/logging/zerolog/utils.go
@@ -1,0 +1,100 @@
+// Shared logger setup: env-driven Config, zerolog logger with piiWriter, and
+// loggerWithTrace for init-time base fields plus per-request trace fields.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+type Config struct {
+	Format      string
+	Level       zerolog.Level
+	Service     string
+	Environment string
+	Version     string
+}
+
+func readConfig() Config {
+	cfg := Config{
+		Format:      strings.ToLower(envDefault("LOG_FORMAT", "json")),
+		Service:     envDefault("LOG_SERVICE", "liquidity-provider-server"),
+		Environment: envDefault("LOG_ENVIRONMENT", "spike"),
+		Version:     envDefault("LOG_VERSION", "spike-fly-2308"),
+	}
+	switch strings.ToLower(envDefault("LOG_LEVEL", "info")) {
+	case "debug":
+		cfg.Level = zerolog.DebugLevel
+	case "warn", "warning":
+		cfg.Level = zerolog.WarnLevel
+	case "error":
+		cfg.Level = zerolog.ErrorLevel
+	default:
+		cfg.Level = zerolog.InfoLevel
+	}
+	return cfg
+}
+
+// initLogger builds the zerolog logger. zerolog's fluent API does not
+// expose a record-level redaction hook the way slog's ReplaceAttr does;
+// instead we wrap the io.Writer (see piiWriter in pii.go) so denied
+// keys are stripped on the way out. This is why zerolog ranks weakest
+// on the "PII deny-list interception" axis.
+//
+// Note: zerolog.MessageFieldName / TimestampFieldName / LevelFieldName
+// are process-global; setting them here flows to any zerolog usage in
+// the same binary, which is fine for the spike but worth knowing.
+func initLogger(out io.Writer, cfg Config) zerolog.Logger {
+	zerolog.TimeFieldFormat = time.RFC3339Nano
+	zerolog.MessageFieldName = "message"
+	zerolog.TimestampFieldName = "timestamp"
+	zerolog.LevelFieldName = "level"
+
+	var w io.Writer = out
+	switch cfg.Format {
+	case "text", "logfmt":
+		w = zerolog.ConsoleWriter{Out: out, TimeFormat: time.RFC3339Nano}
+	case "otel":
+		fmt.Fprintln(os.Stderr, "LOG_FORMAT=otel has no first-party zerolog bridge; falling back to JSON")
+	}
+	w = piiWriter{Out: w}
+
+	return zerolog.New(w).Level(cfg.Level).With().
+		Timestamp().
+		Str("service", cfg.Service).
+		Str("environment", cfg.Environment).
+		Str("version", cfg.Version).
+		Logger()
+}
+
+// loggerWithTrace returns a child logger carrying traceId/spanId. Note
+// that the result is returned by pointer because zerolog's event
+// builders (Info/Warn/Error/...) are defined on *zerolog.Logger — a
+// small ergonomics tax that the other libraries don't have.
+//
+// zerolog has no native ctx-handler — call sites opt in.
+func loggerWithTrace(ctx context.Context) *zerolog.Logger {
+	if tc, ok := traceFromContext(ctx); ok {
+		l := logger.With().Str("traceId", tc.TraceID).Str("spanId", tc.SpanID).Logger()
+		return &l
+	}
+	return &logger
+}
+
+func envDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+var (
+	cfg    Config
+	logger zerolog.Logger
+)


### PR DESCRIPTION
## What
Add SPIKE doc and four runnable demo packages comparing logrus, slog, zap, and zerolog against the Base Logging Standards. Recommendation: adopt log/slog behind a thin LPS wrapper.

## Why
The reason behind this change.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [x] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [ ] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2308)

## How to test
That is just spike task 

## Reviewer Guidelines
Special things to take into consideration during review


## Screenshots (if applicable)
Add screenshots or GIFs to help explain your changes.


## Additional Notes
Add any other context about the pull request here. 