### PR TITLE
perf(mongo): add non-unique indexes for watcher and report hot paths

### DIFF
--- a/internal/adapters/dataproviders/database/mongo/mongo.go
+++ b/internal/adapters/dataproviders/database/mongo/mongo.go
@@ -42,7 +42,7 @@ func Connect(ctx context.Context, connectTimeout time.Duration, username, passwo
 }
 
 func createIndexes(ctx context.Context, db *mongo.Database) error {
-	indexes := []struct {
+	uniqueIndexes := []struct {
 		collection string
 		field      string
 	}{
@@ -50,16 +50,40 @@ func createIndexes(ctx context.Context, db *mongo.Database) error {
 		{collection: TrustedAccountCollection, field: "address"},
 		{collection: BatchPegOutEventsCollection, field: "transaction_hash"},
 	}
-	for _, idx := range indexes {
+	for _, idx := range uniqueIndexes {
 		if err := createUniqueIndex(ctx, db, idx.collection, idx.field); err != nil {
 			return fmt.Errorf("error creating unique index on %s.%s: %w", idx.collection, idx.field, err)
 		}
 		log.Infof("Created unique index on %s.%s", idx.collection, idx.field)
 	}
-	if err := createIndex(ctx, db, RetainedPegoutQuoteCollection, "bridge_rebalances.tx_hash"); err != nil {
-		return fmt.Errorf("error creating index on %s.bridge_rebalances.tx_hash: %w", RetainedPegoutQuoteCollection, err)
+	nonUniqueIndexes := []struct {
+		collection string
+		field      string
+	}{
+		{collection: RetainedPegoutQuoteCollection, field: "bridge_rebalances.tx_hash"},
+		{collection: RetainedPeginQuoteCollection, field: "state"},
+		{collection: RetainedPegoutQuoteCollection, field: "state"},
+		// agreement_timestamp is a Unix-seconds quote-creation time used by reports as a
+		// range filter — two quotes issued in the same second is a legitimate insert.
+		{collection: PeginQuoteCollection, field: "agreement_timestamp"},
+		{collection: PegoutQuoteCollection, field: "agreement_timestamp"},
+		// quote_hash is semantically one-to-one with a quote, but InsertRetainedQuote does
+		// not enforce uniqueness; a unique build would fail and block startup on any pre-
+		// existing duplicate, with no read-perf gain.
+		{collection: RetainedPeginQuoteCollection, field: "quote_hash"},
+		{collection: RetainedPegoutQuoteCollection, field: "quote_hash"},
+		// hash is the quote's content hash and effectively its PK, but InsertQuote performs a
+		// plain insert with no duplicate check; a unique build would block startup on any
+		// pre-existing duplicate (legacy data, replayed insert) with no read-perf gain.
+		{collection: PeginQuoteCollection, field: "hash"},
+		{collection: PegoutQuoteCollection, field: "hash"},
 	}
-	log.Infof("Created index on %s.bridge_rebalances.tx_hash", RetainedPegoutQuoteCollection)
+	for _, idx := range nonUniqueIndexes {
+		if err := createIndex(ctx, db, idx.collection, idx.field); err != nil {
+			return fmt.Errorf("error creating index on %s.%s: %w", idx.collection, idx.field, err)
+		}
+		log.Infof("Created index on %s.%s", idx.collection, idx.field)
+	}
 	return nil
 }
 

--- a/internal/adapters/dataproviders/rootstock/parsing.go
+++ b/internal/adapters/dataproviders/rootstock/parsing.go
@@ -43,7 +43,6 @@ func ParseReceipt(tx *geth.Transaction, receipt *geth.Receipt) (blockchain.Trans
 		to = tx.To().String()
 	}
 
-	
 	if receipt.EffectiveGasPrice == nil {
 		receipt.EffectiveGasPrice = tx.GasPrice()
 	}

--- a/test/mongodb/tests/bootstrap_test.go
+++ b/test/mongodb/tests/bootstrap_test.go
@@ -4,6 +4,7 @@ package mongodb_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -20,31 +21,47 @@ func TestBootstrap_IndexesCreated(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	indexedCollections := map[string]string{
-		mongo.DepositEventsCollection:     "tx_hash",
-		mongo.TrustedAccountCollection:    "address",
-		mongo.BatchPegOutEventsCollection: "transaction_hash",
+	type expectedIndex struct {
+		collection string
+		field      string
+		unique     bool
+	}
+	expectedIndexes := []expectedIndex{
+		{collection: mongo.DepositEventsCollection, field: "tx_hash", unique: true},
+		{collection: mongo.TrustedAccountCollection, field: "address", unique: true},
+		{collection: mongo.BatchPegOutEventsCollection, field: "transaction_hash", unique: true},
+		{collection: mongo.RetainedPegoutQuoteCollection, field: "bridge_rebalances.tx_hash", unique: false},
+		{collection: mongo.RetainedPeginQuoteCollection, field: "state", unique: false},
+		{collection: mongo.RetainedPegoutQuoteCollection, field: "state", unique: false},
+		{collection: mongo.PeginQuoteCollection, field: "agreement_timestamp", unique: false},
+		{collection: mongo.PegoutQuoteCollection, field: "agreement_timestamp", unique: false},
+		{collection: mongo.RetainedPeginQuoteCollection, field: "quote_hash", unique: false},
+		{collection: mongo.RetainedPegoutQuoteCollection, field: "quote_hash", unique: false},
+		{collection: mongo.PeginQuoteCollection, field: "hash", unique: false},
+		{collection: mongo.PegoutQuoteCollection, field: "hash", unique: false},
 	}
 
-	for collName, field := range indexedCollections {
-		t.Run(collName, func(t *testing.T) {
+	for _, expected := range expectedIndexes {
+		t.Run(expected.collection+"."+expected.field, func(t *testing.T) {
 			db := mongoClient.Database(testDbName)
-			cursor, err := db.Collection(collName).Indexes().List(ctx)
-			require.NoError(t, err, "listing indexes for %s", collName)
+			cursor, err := db.Collection(expected.collection).Indexes().List(ctx)
+			require.NoError(t, err, "listing indexes for %s", expected.collection)
 			defer func() { _ = cursor.Close(ctx) }()
 
 			var indexes []map[string]any
 			require.NoError(t, cursor.All(ctx, &indexes))
 
-			found := false
-			for _, idx := range indexes {
-				if utils.IndexKeysContainField(idx["key"], field) {
-					unique, _ := idx["unique"].(bool)
-					assert.True(t, unique, "index on %s.%s should be unique", collName, field)
-					found = true
-				}
-			}
-			require.True(t, found, "unique index on %s.%s not found", collName, field)
+			i := slices.IndexFunc(indexes, func(idx map[string]any) bool {
+				return utils.IndexKeysContainField(idx["key"], expected.field)
+			})
+			require.GreaterOrEqual(t, i, 0, "index on %s.%s not found", expected.collection, expected.field)
+
+			idx := indexes[i]
+			assert.True(t,
+				utils.IndexKeysIsSingleFieldAscending(idx["key"], expected.field),
+				"index on %s.%s must be single-field ascending, got key=%v", expected.collection, expected.field, idx["key"])
+			unique, _ := idx["unique"].(bool)
+			assert.Equal(t, expected.unique, unique, "unique flag on %s.%s", expected.collection, expected.field)
 		})
 	}
 }

--- a/test/mongodb/utils/helpers.go
+++ b/test/mongodb/utils/helpers.go
@@ -36,6 +36,68 @@ func IndexKeysContainField(keys any, field string) bool {
 	}
 }
 
+// IndexKeysIsSingleFieldAscending reports whether keys is exactly {field: 1} —
+// catches accidental compound indexes or descending shapes that IndexKeysContainField
+// would silently accept.
+func IndexKeysIsSingleFieldAscending(keys any, field string) bool {
+	switch typed := keys.(type) {
+	case map[string]any:
+		return mapIsSingleFieldAscending(typed, field)
+	case bson.M:
+		return mapIsSingleFieldAscending(map[string]any(typed), field)
+	case bson.D:
+		return len(typed) == 1 && typed[0].Key == field && isAscending(typed[0].Value)
+	default:
+		return sliceOfKeyedElementsIsSingleFieldAscending(keys, field)
+	}
+}
+
+func mapIsSingleFieldAscending(m map[string]any, field string) bool {
+	if len(m) != 1 {
+		return false
+	}
+	v, ok := m[field]
+	return ok && isAscending(v)
+}
+
+func sliceOfKeyedElementsIsSingleFieldAscending(keys any, field string) bool {
+	val := reflect.ValueOf(keys)
+	if val.Kind() != reflect.Slice || val.Len() != 1 {
+		return false
+	}
+	item := val.Index(0)
+	if item.Kind() == reflect.Pointer {
+		item = item.Elem()
+	}
+	if item.Kind() != reflect.Struct {
+		return false
+	}
+	keyField := item.FieldByName("Key")
+	valueField := item.FieldByName("Value")
+	if !keyField.IsValid() || keyField.Kind() != reflect.String || keyField.String() != field {
+		return false
+	}
+	if !valueField.IsValid() {
+		return false
+	}
+	return isAscending(valueField.Interface())
+}
+
+func isAscending(v any) bool {
+	switch n := v.(type) {
+	case int:
+		return n == 1
+	case int32:
+		return n == 1
+	case int64:
+		return n == 1
+	case float64:
+		return n == 1
+	default:
+		return false
+	}
+}
+
 func mapHasField(m map[string]any, field string) bool {
 	_, ok := m[field]
 	return ok


### PR DESCRIPTION
## What
Add state, quote_hash on retained pegin/pegout collections and hash, agreement_timestamp on the quote collections to replace COLLSCANs in the watcher and report queries (FLY-2320).

## Why
The retainedPeginQuote and retainedPegoutQuote collections currently have no index on the state field. GetRetainedQuoteByState() is invoked by the watchers on every cycle (every 5–60s depending on the watcher), and each call performs a full collection scan. As the LP runs 24/7 and accumulates records, the scan cost grows linearly with collection size and will eventually push watcher cycles past their time budget.

The same access pattern blocks the report endpoints (get_reports_pegin, get_reports_pegout, get_reports_transaction, get_report_summaries), which filter on state and a date range — both today and as record volume scales.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [x] PegIn flow
- [x] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2320)

## How to test
1. The change is index-only — no API or behavior changes. QA validates that the indexes are created on LPS startup, that the planner uses them, and that the non-unique choice doesn't block startup when the database contains pre-existing duplicates.
2. Check that pegout and peging flow works and LPS is stable

## Reviewer Guidelines
Special things to take into consideration during review


## Screenshots (if applicable)
Add screenshots or GIFs to help explain your changes.


## Additional Notes
Add any other context about the pull request here. 