### PR TITLE
feat: unlock utxos in case of error inside derivative wallet

### DIFF
--- a/internal/adapters/dataproviders/bitcoin/btcclient/binding.go
+++ b/internal/adapters/dataproviders/bitcoin/btcclient/binding.go
@@ -34,6 +34,7 @@ type RpcWallet interface {
 	GetAddressInfo(address string) (*btcjson.GetAddressInfoResult, error)
 	ImportPubKeyRescan(pubKey string, rescan bool) error
 	ImportPubKey(pubKey string) error
+	LockUnspent(unlock bool, ops []*wire.OutPoint) error
 }
 
 type RpcClient interface {

--- a/internal/adapters/dataproviders/bitcoin/btcclient/methods.go
+++ b/internal/adapters/dataproviders/bitcoin/btcclient/methods.go
@@ -1,0 +1,7 @@
+package btcclient
+
+type BitcoindRPCMethod string
+
+const (
+	MethodLockUnspent BitcoindRPCMethod = "lockunspent"
+)

--- a/internal/adapters/dataproviders/bitcoin/btcclient/rpc_errors.go
+++ b/internal/adapters/dataproviders/bitcoin/btcclient/rpc_errors.go
@@ -1,0 +1,57 @@
+package btcclient
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcjson"
+)
+
+// RPCCallError annotates a bitcoind RPC failure with the method used (we can extend it later to include some context of the caller too)
+type RPCCallError struct {
+	Method BitcoindRPCMethod
+	RPC    *btcjson.RPCError
+	Cause  error
+}
+
+func (e *RPCCallError) Error() string {
+	if e.RPC != nil {
+		return fmt.Sprintf("%s: RPC %d: %s", e.Method, e.RPC.Code, e.RPC.Message)
+	}
+	return fmt.Sprintf("%s: %v", e.Method, e.Cause)
+}
+
+func (e *RPCCallError) Unwrap() error { return e.Cause }
+
+func AsRPCError(err error) (*btcjson.RPCError, bool) {
+	var rpcErr *btcjson.RPCError
+	if errors.As(err, &rpcErr) {
+		return rpcErr, true
+	}
+	return nil, false
+}
+
+func IsRPCCode(err error, code btcjson.RPCErrorCode) bool {
+	rpcErr, ok := AsRPCError(err)
+	return ok && rpcErr.Code == code
+}
+
+func WrapRPCError(method BitcoindRPCMethod, err error) error {
+	if err == nil {
+		return nil
+	}
+	wrapped := &RPCCallError{Method: method, Cause: err}
+	if rpcErr, ok := AsRPCError(err); ok {
+		wrapped.RPC = rpcErr
+	}
+	return wrapped
+}
+
+func IsLockUnspentAlreadyUnlocked(err error) bool {
+	if err == nil {
+		return false
+	}
+	return IsRPCCode(err, btcjson.ErrRPCInvalidParameter) &&
+		strings.Contains(strings.ToLower(err.Error()), "expected unspent output")
+}

--- a/internal/adapters/dataproviders/bitcoin/btcclient/rpc_errors_test.go
+++ b/internal/adapters/dataproviders/bitcoin/btcclient/rpc_errors_test.go
@@ -1,0 +1,51 @@
+package btcclient_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/rsksmart/liquidity-provider-server/internal/adapters/dataproviders/bitcoin/btcclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsRPCError(t *testing.T) {
+	rpcErr := btcjson.NewRPCError(btcjson.ErrRPCInvalidParameter, "Invalid parameter, expected unspent output")
+	var extracted *btcjson.RPCError
+	require.ErrorAs(t, rpcErr, &extracted)
+	assert.Equal(t, rpcErr, extracted)
+
+	err, ok := btcclient.AsRPCError(errors.New("plain error"))
+	assert.False(t, ok)
+	require.Nil(t, err)
+}
+
+func TestIsRPCCode(t *testing.T) {
+	err := btcjson.NewRPCError(btcjson.ErrRPCInvalidParameter, "Invalid parameter")
+	assert.True(t, btcclient.IsRPCCode(err, btcjson.ErrRPCInvalidParameter))
+	assert.False(t, btcclient.IsRPCCode(err, btcjson.ErrRPCMethodNotFound.Code))
+}
+
+func TestWrapRPCError(t *testing.T) {
+	cause := btcjson.NewRPCError(btcjson.ErrRPCInvalidParameter, "Invalid parameter, expected unspent output")
+	wrapped := btcclient.WrapRPCError(btcclient.MethodLockUnspent, cause)
+	require.Error(t, wrapped)
+	require.ErrorContains(t, wrapped, string(btcclient.MethodLockUnspent))
+	require.ErrorContains(t, wrapped, "expected unspent output")
+
+	var callErr *btcclient.RPCCallError
+	require.ErrorAs(t, wrapped, &callErr)
+	assert.Equal(t, btcclient.MethodLockUnspent, callErr.Method)
+	assert.Equal(t, cause, callErr.Cause)
+}
+
+func TestIsLockUnspentAlreadyUnlocked(t *testing.T) {
+	assert.False(t, btcclient.IsLockUnspentAlreadyUnlocked(nil))
+
+	rpcErr := btcjson.NewRPCError(btcjson.ErrRPCInvalidParameter, "Invalid parameter, expected unspent output")
+	assert.True(t, btcclient.IsLockUnspentAlreadyUnlocked(rpcErr))
+
+	otherErr := btcjson.NewRPCError(btcjson.ErrRPCMethodNotFound.Code, "Method not found")
+	assert.False(t, btcclient.IsLockUnspentAlreadyUnlocked(otherErr))
+}

--- a/internal/adapters/dataproviders/bitcoin/derivative_wallet.go
+++ b/internal/adapters/dataproviders/bitcoin/derivative_wallet.go
@@ -358,11 +358,14 @@ func (wallet *DerivativeWallet) unlockUtxos(tx *wire.MsgTx) {
 	if tx == nil {
 		return
 	}
-	outpoints := make([]*wire.OutPoint, 0)
+	outpoints := make([]*wire.OutPoint, 0, len(tx.TxIn))
 	for _, input := range tx.TxIn {
 		if input != nil {
 			outpoints = append(outpoints, &input.PreviousOutPoint)
 		}
+	}
+	if len(outpoints) == 0 {
+		return
 	}
 	err := wallet.conn.client.LockUnspent(true, outpoints)
 	if err == nil || btcclient.IsLockUnspentAlreadyUnlocked(err) {

--- a/internal/adapters/dataproviders/bitcoin/derivative_wallet.go
+++ b/internal/adapters/dataproviders/bitcoin/derivative_wallet.go
@@ -209,7 +209,7 @@ func (wallet *DerivativeWallet) SendWithOpReturn(address string, value *entities
 	if err != nil {
 		return blockchain.BitcoinTransactionResult{}, err
 	}
-
+	defer wallet.unlockUtxos(fundedTx.Transaction)
 	signedTx, err := wallet.signFundedTransaction(fundedTx)
 	if err != nil {
 		return blockchain.BitcoinTransactionResult{}, err
@@ -352,4 +352,25 @@ func (wallet *DerivativeWallet) buildRawTransactionWithOpReturn(address string, 
 	rawTx.AddTxOut(wire.NewTxOut(0, opReturnScript))
 
 	return rawTx, nil
+}
+
+func (wallet *DerivativeWallet) unlockUtxos(tx *wire.MsgTx) {
+	if tx == nil {
+		return
+	}
+	outpoints := make([]*wire.OutPoint, 0)
+	for _, input := range tx.TxIn {
+		if input != nil {
+			outpoints = append(outpoints, &input.PreviousOutPoint)
+		}
+	}
+	err := wallet.conn.client.LockUnspent(true, outpoints)
+	if err == nil || btcclient.IsLockUnspentAlreadyUnlocked(err) {
+		return
+	}
+	log.Errorf(
+		"error unlocking utxos for transaction %s: %v",
+		tx.TxHash(),
+		btcclient.WrapRPCError(btcclient.MethodLockUnspent, err),
+	)
 }

--- a/internal/adapters/dataproviders/bitcoin/derivative_wallet_test.go
+++ b/internal/adapters/dataproviders/bitcoin/derivative_wallet_test.go
@@ -501,6 +501,9 @@ func testSendWithOpReturn(t *testing.T, rskAccount *account.RskAccount, addressI
 		},
 		LockTime: 0,
 	}
+	fundedTxValue := *tx
+	fundedTxValue.TxIn = []*wire.TxIn{{PreviousOutPoint: mustCreateOutpoint(test.AnyHash, 0)}}
+	fundedTx := &fundedTxValue
 	client.On("EstimateSmartFee", int64(1), &btcjson.EstimateModeEconomical).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 2}, nil).Once()
 	client.On("FundRawTransaction", tx, btcjson.FundRawTransactionOpts{
 		ChangeAddress:   btcjson.String(btcAddress),
@@ -509,12 +512,12 @@ func testSendWithOpReturn(t *testing.T, rskAccount *account.RskAccount, addressI
 		LockUnspents:    btcjson.Bool(true),
 		FeeRate:         btcjson.Float64(feeRate),
 		Replaceable:     btcjson.Bool(true),
-	}, (*bool)(nil)).Return(&btcjson.FundRawTransactionResult{Transaction: tx, Fee: 50, ChangePosition: 2}, nil).Once()
+	}, (*bool)(nil)).Return(&btcjson.FundRawTransactionResult{Transaction: fundedTx, Fee: 50, ChangePosition: 2}, nil).Once()
 	client.On("LockUnspent", true, mock.Anything).Return(nil).Once()
-	client.On("SendRawTransaction", tx, false).Return(chainhash.NewHashFromStr(testnetTestTxHash)).Once()
-	client.On("SignRawTransactionWithKey", tx, mock.MatchedBy(func(pks []string) bool {
+	client.On("SendRawTransaction", fundedTx, false).Return(chainhash.NewHashFromStr(testnetTestTxHash)).Once()
+	client.On("SignRawTransactionWithKey", fundedTx, mock.MatchedBy(func(pks []string) bool {
 		return len(pks) == 1 && pks[0] != ""
-	})).Return(tx, true, nil).Once()
+	})).Return(fundedTx, true, nil).Once()
 	wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
 	require.NoError(t, err)
 	result, err := wallet.SendWithOpReturn(testnetAddress, value, []byte{0xf1, 0xf2, 0xf3, 0xf4, 0x00})
@@ -532,6 +535,9 @@ func derivativeWalletSendWithOpReturnErrorSetups(rskAccount *account.RskAccount)
 	setup       func(t *testing.T, client *mocks.ClientAdapterMock)
 } {
 	rawTx := &wire.MsgTx{TxOut: []*wire.TxOut{{Value: int64(50000000), PkScript: []byte(paymentScriptMock)}}}
+	fundedTxValue := *rawTx
+	fundedTxValue.TxIn = []*wire.TxIn{{PreviousOutPoint: mustCreateOutpoint(test.AnyHash, 0)}}
+	fundedTx := &fundedTxValue
 	return []struct {
 		description string
 		setup       func(t *testing.T, client *mocks.ClientAdapterMock)
@@ -626,7 +632,7 @@ func derivativeWalletSendWithOpReturnErrorSetups(rskAccount *account.RskAccount)
 			setup: func(t *testing.T, client *mocks.ClientAdapterMock) {
 				client.On("CreateRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(rawTx, nil).Once()
 				client.On("EstimateSmartFee", mock.Anything, mock.Anything).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 1}, nil).Once()
-				client.On("FundRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: rawTx, Fee: 50, ChangePosition: 2}, nil).Once()
+				client.On("FundRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: fundedTx, Fee: 50, ChangePosition: 2}, nil).Once()
 				client.On("LockUnspent", true, mock.Anything).Return(nil).Once()
 				client.On("SignRawTransactionWithKey", mock.Anything, mock.Anything).Return(nil, false, assert.AnError).Once()
 				wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
@@ -643,9 +649,9 @@ func derivativeWalletSendWithOpReturnErrorSetups(rskAccount *account.RskAccount)
 			setup: func(t *testing.T, client *mocks.ClientAdapterMock) {
 				client.On("CreateRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(rawTx, nil).Once()
 				client.On("EstimateSmartFee", mock.Anything, mock.Anything).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 1}, nil).Once()
-				client.On("FundRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: rawTx, Fee: 50, ChangePosition: 2}, nil).Once()
+				client.On("FundRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: fundedTx, Fee: 50, ChangePosition: 2}, nil).Once()
 				client.On("LockUnspent", true, mock.Anything).Return(nil).Once()
-				client.On("SignRawTransactionWithKey", mock.Anything, mock.Anything).Return(rawTx, true, nil).Once()
+				client.On("SignRawTransactionWithKey", mock.Anything, mock.Anything).Return(fundedTx, true, nil).Once()
 				client.On("SendRawTransaction", mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
 				wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
 				require.NoError(t, err)
@@ -661,9 +667,9 @@ func derivativeWalletSendWithOpReturnErrorSetups(rskAccount *account.RskAccount)
 			setup: func(t *testing.T, client *mocks.ClientAdapterMock) {
 				client.On("CreateRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(rawTx, nil).Once()
 				client.On("EstimateSmartFee", mock.Anything, mock.Anything).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 1}, nil).Once()
-				client.On("FundRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: rawTx, Fee: 50, ChangePosition: 2}, nil).Once()
+				client.On("FundRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: fundedTx, Fee: 50, ChangePosition: 2}, nil).Once()
 				client.On("LockUnspent", true, mock.Anything).Return(nil).Once()
-				client.On("SignRawTransactionWithKey", mock.Anything, mock.Anything).Return(rawTx, false, nil).Once()
+				client.On("SignRawTransactionWithKey", mock.Anything, mock.Anything).Return(fundedTx, false, nil).Once()
 				wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
 				require.NoError(t, err)
 				result, err := wallet.SendWithOpReturn(testnetAddress, entities.NewWei(1), []byte{0xf1})
@@ -678,9 +684,9 @@ func derivativeWalletSendWithOpReturnErrorSetups(rskAccount *account.RskAccount)
 			setup: func(t *testing.T, client *mocks.ClientAdapterMock) {
 				client.EXPECT().CreateRawTransaction(mock.Anything, mock.Anything, mock.Anything).Return(rawTx, nil).Once()
 				client.EXPECT().EstimateSmartFee(mock.Anything, mock.Anything).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 1}, nil).Once()
-				client.EXPECT().FundRawTransaction(mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: rawTx, Fee: 50, ChangePosition: 2}, nil).Once()
+				client.EXPECT().FundRawTransaction(mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: fundedTx, Fee: 50, ChangePosition: 2}, nil).Once()
 				client.EXPECT().LockUnspent(true, mock.Anything).Return(assert.AnError).Once()
-				client.EXPECT().SignRawTransactionWithKey(mock.Anything, mock.Anything).Return(rawTx, true, nil).Once()
+				client.EXPECT().SignRawTransactionWithKey(mock.Anything, mock.Anything).Return(fundedTx, true, nil).Once()
 				client.EXPECT().SendRawTransaction(mock.Anything, mock.Anything).Return(chainhash.NewHashFromStr(testnetTestTxHash)).Once()
 
 				wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
@@ -693,6 +699,27 @@ func derivativeWalletSendWithOpReturnErrorSetups(rskAccount *account.RskAccount)
 				assert.NotNil(t, result.Fee)
 
 				client.AssertExpectations(t)
+			},
+		},
+		{
+			description: "fundrawtransaction does not add any input",
+			setup: func(t *testing.T, client *mocks.ClientAdapterMock) {
+				client.EXPECT().CreateRawTransaction(mock.Anything, mock.Anything, mock.Anything).Return(rawTx, nil).Once()
+				client.EXPECT().EstimateSmartFee(mock.Anything, mock.Anything).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 1}, nil).Once()
+				client.EXPECT().FundRawTransaction(mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: rawTx, Fee: 50, ChangePosition: 2}, nil).Once()
+				client.EXPECT().SignRawTransactionWithKey(mock.Anything, mock.Anything).Return(rawTx, true, nil).Once()
+				client.EXPECT().SendRawTransaction(mock.Anything, mock.Anything).Return(chainhash.NewHashFromStr(testnetTestTxHash)).Once()
+
+				wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
+				require.NoError(t, err)
+
+				result, err := wallet.SendWithOpReturn(testnetAddress, entities.NewWei(1), []byte{0xf1})
+				require.NoError(t, err)
+				assert.NotEmpty(t, result.Hash)
+				assert.NotNil(t, result.Fee)
+
+				client.AssertExpectations(t)
+				client.AssertNotCalled(t, "UnlockUnspent")
 			},
 		},
 	}
@@ -883,4 +910,12 @@ func derivativeWalletCreateUnfundedTxErrorSetups(rskAccount *account.RskAccount)
 			},
 		},
 	}
+}
+
+func mustCreateOutpoint(hash string, index uint32) wire.OutPoint {
+	parsedHash, err := chainhash.NewHashFromStr(hash)
+	if err != nil {
+		panic(err)
+	}
+	return *wire.NewOutPoint(parsedHash, index)
 }

--- a/internal/adapters/dataproviders/bitcoin/derivative_wallet_test.go
+++ b/internal/adapters/dataproviders/bitcoin/derivative_wallet_test.go
@@ -510,6 +510,7 @@ func testSendWithOpReturn(t *testing.T, rskAccount *account.RskAccount, addressI
 		FeeRate:         btcjson.Float64(feeRate),
 		Replaceable:     btcjson.Bool(true),
 	}, (*bool)(nil)).Return(&btcjson.FundRawTransactionResult{Transaction: tx, Fee: 50, ChangePosition: 2}, nil).Once()
+	client.On("LockUnspent", true, mock.Anything).Return(nil).Once()
 	client.On("SendRawTransaction", tx, false).Return(chainhash.NewHashFromStr(testnetTestTxHash)).Once()
 	client.On("SignRawTransactionWithKey", tx, mock.MatchedBy(func(pks []string) bool {
 		return len(pks) == 1 && pks[0] != ""
@@ -626,6 +627,7 @@ func derivativeWalletSendWithOpReturnErrorSetups(rskAccount *account.RskAccount)
 				client.On("CreateRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(rawTx, nil).Once()
 				client.On("EstimateSmartFee", mock.Anything, mock.Anything).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 1}, nil).Once()
 				client.On("FundRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: rawTx, Fee: 50, ChangePosition: 2}, nil).Once()
+				client.On("LockUnspent", true, mock.Anything).Return(nil).Once()
 				client.On("SignRawTransactionWithKey", mock.Anything, mock.Anything).Return(nil, false, assert.AnError).Once()
 				wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
 				require.NoError(t, err)
@@ -642,6 +644,7 @@ func derivativeWalletSendWithOpReturnErrorSetups(rskAccount *account.RskAccount)
 				client.On("CreateRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(rawTx, nil).Once()
 				client.On("EstimateSmartFee", mock.Anything, mock.Anything).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 1}, nil).Once()
 				client.On("FundRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: rawTx, Fee: 50, ChangePosition: 2}, nil).Once()
+				client.On("LockUnspent", true, mock.Anything).Return(nil).Once()
 				client.On("SignRawTransactionWithKey", mock.Anything, mock.Anything).Return(rawTx, true, nil).Once()
 				client.On("SendRawTransaction", mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
 				wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
@@ -659,6 +662,7 @@ func derivativeWalletSendWithOpReturnErrorSetups(rskAccount *account.RskAccount)
 				client.On("CreateRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(rawTx, nil).Once()
 				client.On("EstimateSmartFee", mock.Anything, mock.Anything).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 1}, nil).Once()
 				client.On("FundRawTransaction", mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: rawTx, Fee: 50, ChangePosition: 2}, nil).Once()
+				client.On("LockUnspent", true, mock.Anything).Return(nil).Once()
 				client.On("SignRawTransactionWithKey", mock.Anything, mock.Anything).Return(rawTx, false, nil).Once()
 				wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
 				require.NoError(t, err)
@@ -666,6 +670,28 @@ func derivativeWalletSendWithOpReturnErrorSetups(rskAccount *account.RskAccount)
 				require.Error(t, err)
 				assert.Empty(t, result.Hash)
 				assert.Nil(t, result.Fee)
+				client.AssertExpectations(t)
+			},
+		},
+		{
+			description: "unlocking outputs fails and logs error",
+			setup: func(t *testing.T, client *mocks.ClientAdapterMock) {
+				client.EXPECT().CreateRawTransaction(mock.Anything, mock.Anything, mock.Anything).Return(rawTx, nil).Once()
+				client.EXPECT().EstimateSmartFee(mock.Anything, mock.Anything).Return(&btcjson.EstimateSmartFeeResult{FeeRate: btcjson.Float64(feeRate), Blocks: 1}, nil).Once()
+				client.EXPECT().FundRawTransaction(mock.Anything, mock.Anything, mock.Anything).Return(&btcjson.FundRawTransactionResult{Transaction: rawTx, Fee: 50, ChangePosition: 2}, nil).Once()
+				client.EXPECT().LockUnspent(true, mock.Anything).Return(assert.AnError).Once()
+				client.EXPECT().SignRawTransactionWithKey(mock.Anything, mock.Anything).Return(rawTx, true, nil).Once()
+				client.EXPECT().SendRawTransaction(mock.Anything, mock.Anything).Return(chainhash.NewHashFromStr(testnetTestTxHash)).Once()
+
+				wallet, err := bitcoin.NewDerivativeWallet(bitcoin.NewWalletConnection(&chaincfg.TestNet3Params, client, bitcoin.DerivativeWalletId), rskAccount)
+				require.NoError(t, err)
+
+				defer test.AssertLogContains(t, "error unlocking utxos for transaction")
+				result, err := wallet.SendWithOpReturn(testnetAddress, entities.NewWei(1), []byte{0xf1})
+				require.NoError(t, err)
+				assert.NotEmpty(t, result.Hash)
+				assert.NotNil(t, result.Fee)
+
 				client.AssertExpectations(t)
 			},
 		},

--- a/internal/adapters/entrypoints/watcher/btc_release_watcher_test.go
+++ b/internal/adapters/entrypoints/watcher/btc_release_watcher_test.go
@@ -213,7 +213,7 @@ func TestBtcReleaseWatcher_Start_ErrorCases(t *testing.T) {
 			bridge.AssertNotCalled(mt, "GetBatchPegOutCreatedEvent")
 			rskRpc.AssertExpectations(mt)
 		}, time.Second*3, time.Millisecond*100)
-		assert.True(t, assertErrorLog())
+		assert.Eventually(t, assertErrorLog, time.Second*3, time.Millisecond*100)
 	})
 	t.Run("should handle error getting event", func(t *testing.T) {
 		bridge := &mocks.BridgeMock{}
@@ -241,7 +241,7 @@ func TestBtcReleaseWatcher_Start_ErrorCases(t *testing.T) {
 			bridge.AssertExpectations(mt)
 			rskRpc.AssertExpectations(mt)
 		}, time.Second*3, time.Millisecond*100)
-		assert.True(t, assertNoQuotesLog())
+		assert.Eventually(t, assertNoQuotesLog, time.Second*3, time.Millisecond*100)
 	})
 	t.Run("should handle error in use case", func(t *testing.T) {
 		bridge := &mocks.BridgeMock{}
@@ -270,7 +270,7 @@ func TestBtcReleaseWatcher_Start_ErrorCases(t *testing.T) {
 			bridge.AssertExpectations(mt)
 			rskRpc.AssertExpectations(mt)
 		}, time.Second*3, time.Millisecond*100)
-		assert.True(t, assertNoQuotesLog())
+		assert.Eventually(t, assertNoQuotesLog, time.Second*3, time.Millisecond*100)
 	})
 }
 

--- a/test/mocks/client_adapter_mock.go
+++ b/test/mocks/client_adapter_mock.go
@@ -1138,6 +1138,53 @@ func (_c *ClientAdapterMock_LoadWallet_Call) RunAndReturn(run func(string) (*btc
 	return _c
 }
 
+// LockUnspent provides a mock function with given fields: unlock, ops
+func (_m *ClientAdapterMock) LockUnspent(unlock bool, ops []*wire.OutPoint) error {
+	ret := _m.Called(unlock, ops)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LockUnspent")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bool, []*wire.OutPoint) error); ok {
+		r0 = rf(unlock, ops)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ClientAdapterMock_LockUnspent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LockUnspent'
+type ClientAdapterMock_LockUnspent_Call struct {
+	*mock.Call
+}
+
+// LockUnspent is a helper method to define mock.On call
+//   - unlock bool
+//   - ops []*wire.OutPoint
+func (_e *ClientAdapterMock_Expecter) LockUnspent(unlock interface{}, ops interface{}) *ClientAdapterMock_LockUnspent_Call {
+	return &ClientAdapterMock_LockUnspent_Call{Call: _e.mock.On("LockUnspent", unlock, ops)}
+}
+
+func (_c *ClientAdapterMock_LockUnspent_Call) Run(run func(unlock bool, ops []*wire.OutPoint)) *ClientAdapterMock_LockUnspent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(bool), args[1].([]*wire.OutPoint))
+	})
+	return _c
+}
+
+func (_c *ClientAdapterMock_LockUnspent_Call) Return(_a0 error) *ClientAdapterMock_LockUnspent_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ClientAdapterMock_LockUnspent_Call) RunAndReturn(run func(bool, []*wire.OutPoint) error) *ClientAdapterMock_LockUnspent_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NextID provides a mock function with no fields
 func (_m *ClientAdapterMock) NextID() uint64 {
 	ret := _m.Called()

--- a/test/mocks/rpc_client_mock.go
+++ b/test/mocks/rpc_client_mock.go
@@ -1090,6 +1090,53 @@ func (_c *RpcClientMock_LoadWallet_Call) RunAndReturn(run func(string) (*btcjson
 	return _c
 }
 
+// LockUnspent provides a mock function with given fields: unlock, ops
+func (_m *RpcClientMock) LockUnspent(unlock bool, ops []*wire.OutPoint) error {
+	ret := _m.Called(unlock, ops)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LockUnspent")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bool, []*wire.OutPoint) error); ok {
+		r0 = rf(unlock, ops)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// RpcClientMock_LockUnspent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LockUnspent'
+type RpcClientMock_LockUnspent_Call struct {
+	*mock.Call
+}
+
+// LockUnspent is a helper method to define mock.On call
+//   - unlock bool
+//   - ops []*wire.OutPoint
+func (_e *RpcClientMock_Expecter) LockUnspent(unlock interface{}, ops interface{}) *RpcClientMock_LockUnspent_Call {
+	return &RpcClientMock_LockUnspent_Call{Call: _e.mock.On("LockUnspent", unlock, ops)}
+}
+
+func (_c *RpcClientMock_LockUnspent_Call) Run(run func(unlock bool, ops []*wire.OutPoint)) *RpcClientMock_LockUnspent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(bool), args[1].([]*wire.OutPoint))
+	})
+	return _c
+}
+
+func (_c *RpcClientMock_LockUnspent_Call) Return(_a0 error) *RpcClientMock_LockUnspent_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *RpcClientMock_LockUnspent_Call) RunAndReturn(run func(bool, []*wire.OutPoint) error) *RpcClientMock_LockUnspent_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NextID provides a mock function with no fields
 func (_m *RpcClientMock) NextID() uint64 {
 	ret := _m.Called()


### PR DESCRIPTION
## What
Add functionality to unlock the utxos in derivative wallet in case of failures 

## Why
Right now the wallet locks the utxos to ensure its able to spend them, but if an error during the signing or broadcast happens the utxos will remain locked until they are manually unlocked. This PR tries to unlock them in all the cases, if the UTXOs are locked indeed they become unlocked and if they are not locked then nothing happens

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [x] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2345)
