### PR TITLE
Fly 2321 quote handler error

### DIFF
--- a/internal/adapters/entrypoints/rest/handlers/accept_pegin_authenticated_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegin_authenticated_quote.go
@@ -35,7 +35,7 @@ func NewAcceptPeginAuthenticatedQuoteHandler(useCase AcceptQuoteUseCase) http.Ha
 
 		acceptedQuote, err := useCase.Run(req.Context(), acceptRequest.QuoteHash, acceptRequest.Signature)
 		if err != nil {
-			HandleAcceptQuoteError(w, err)
+			HandleAuthenticatedAcceptQuoteError(w, err)
 			return
 		}
 

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegin_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegin_quote.go
@@ -2,13 +2,10 @@ package handlers
 
 import (
 	"context"
-	"errors"
-	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"net/http"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
-	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/pkg"
 )
 
@@ -39,25 +36,8 @@ func NewAcceptPeginQuoteHandler(useCase AcceptQuoteUseCase) http.HandlerFunc {
 		}
 
 		acceptedQuote, err := useCase.Run(req.Context(), acceptRequest.QuoteHash, "")
-		if errors.Is(err, usecases.QuoteNotFoundError) {
-			jsonErr := rest.NewErrorResponseWithDetails("quote not found", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusNotFound, jsonErr)
-			return
-		} else if errors.Is(err, usecases.ExpiredQuoteError) {
-			jsonErr := rest.NewErrorResponseWithDetails("expired quote", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusGone, jsonErr)
-			return
-		} else if errors.Is(err, usecases.NoLiquidityError) {
-			jsonErr := rest.NewErrorResponseWithDetails("not enough liquidity", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
-			return
-		} else if errors.Is(err, blockchain.ContractPausedError) {
-			jsonErr := rest.NewErrorResponseWithDetails("protocol is paused", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusServiceUnavailable, jsonErr)
-			return
-		} else if err != nil {
-			jsonErr := rest.NewErrorResponseWithDetails(UnknownErrorMessage, rest.DetailsFromError(err), false)
-			rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
+		if err != nil {
+			HandleAcceptQuoteError(w, err)
 			return
 		}
 

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegin_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegin_quote.go
@@ -37,7 +37,7 @@ func NewAcceptPeginQuoteHandler(useCase AcceptQuoteUseCase) http.HandlerFunc {
 
 		acceptedQuote, err := useCase.Run(req.Context(), acceptRequest.QuoteHash, "")
 		if err != nil {
-			HandleAcceptQuoteError(w, err)
+			handleCommonAcceptQuoteError(w, err)
 			return
 		}
 

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegin_quote_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegin_quote_test.go
@@ -242,7 +242,7 @@ func TestAcceptPeginQuoteHandlerErrorCases(t *testing.T) {
 		assert.Equal(t, "not enough liquidity", errorResponse["message"])
 	})
 
-	t.Run("should return 409 when locking cap exceeded", func(t *testing.T) {
+	t.Run("should return 500 when locking cap exceeded on public endpoint", func(t *testing.T) {
 		quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 
 		reqBody := pkg.AcceptQuoteRequest{
@@ -263,7 +263,7 @@ func TestAcceptPeginQuoteHandlerErrorCases(t *testing.T) {
 
 		handler.ServeHTTP(recorder, request)
 
-		assert.Equal(t, http.StatusConflict, recorder.Code)
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
 
 		mockUseCase.AssertExpectations(t)
 
@@ -271,10 +271,10 @@ func TestAcceptPeginQuoteHandlerErrorCases(t *testing.T) {
 		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
 		require.NoError(t, err)
 		assert.Contains(t, errorResponse, "message")
-		assert.Equal(t, "locking cap exceeded", errorResponse["message"])
+		assert.Equal(t, handlers.UnknownErrorMessage, errorResponse["message"])
 	})
 
-	t.Run("should return 500 when trusted account is tampered", func(t *testing.T) {
+	t.Run("should return 500 when trusted account is tampered on public endpoint", func(t *testing.T) {
 		quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 
 		reqBody := pkg.AcceptQuoteRequest{
@@ -303,7 +303,7 @@ func TestAcceptPeginQuoteHandlerErrorCases(t *testing.T) {
 		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
 		require.NoError(t, err)
 		assert.Contains(t, errorResponse, "message")
-		assert.Equal(t, "error fetching trusted account", errorResponse["message"])
+		assert.Equal(t, handlers.UnknownErrorMessage, errorResponse["message"])
 	})
 
 	t.Run("should return 200 with already retained quote", func(t *testing.T) {

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegin_quote_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegin_quote_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest/handlers"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/pkg"
@@ -239,6 +240,70 @@ func TestAcceptPeginQuoteHandlerErrorCases(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, errorResponse, "message")
 		assert.Equal(t, "not enough liquidity", errorResponse["message"])
+	})
+
+	t.Run("should return 409 when locking cap exceeded", func(t *testing.T) {
+		quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+		reqBody := pkg.AcceptQuoteRequest{
+			QuoteHash: quoteHash,
+		}
+		jsonBody, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/pegin/acceptQuote", bytes.NewBuffer(jsonBody))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+		mockUseCase.On("Run", mock.Anything, quoteHash, "").Return(quote.AcceptedQuote{}, usecases.LockingCapExceededError)
+
+		handlerFunc := handlers.NewAcceptPeginQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusConflict, recorder.Code)
+
+		mockUseCase.AssertExpectations(t)
+
+		var errorResponse map[string]interface{}
+		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Contains(t, errorResponse, "message")
+		assert.Equal(t, "locking cap exceeded", errorResponse["message"])
+	})
+
+	t.Run("should return 500 when trusted account is tampered", func(t *testing.T) {
+		quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+		reqBody := pkg.AcceptQuoteRequest{
+			QuoteHash: quoteHash,
+		}
+		jsonBody, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/pegin/acceptQuote", bytes.NewBuffer(jsonBody))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+		mockUseCase.On("Run", mock.Anything, quoteHash, "").Return(quote.AcceptedQuote{}, liquidity_provider.TamperedTrustedAccountError)
+
+		handlerFunc := handlers.NewAcceptPeginQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+
+		mockUseCase.AssertExpectations(t)
+
+		var errorResponse map[string]interface{}
+		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Contains(t, errorResponse, "message")
+		assert.Equal(t, "error fetching trusted account", errorResponse["message"])
 	})
 
 	t.Run("should return 200 with already retained quote", func(t *testing.T) {

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote.go
@@ -35,7 +35,7 @@ func NewAcceptPegoutAuthenticatedQuoteHandler(useCase AcceptQuoteUseCase) http.H
 
 		acceptedQuote, err := useCase.Run(req.Context(), acceptRequest.QuoteHash, acceptRequest.Signature)
 		if err != nil {
-			HandleAcceptQuoteError(w, err)
+			HandleAuthenticatedAcceptQuoteError(w, err)
 			return
 		}
 

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegout_authenticated_quote_test.go
@@ -315,7 +315,7 @@ func TestAcceptPegoutAuthenticatedQuoteHandler_UseCaseErrors(t *testing.T) {
 
 			handler.ServeHTTP(recorder, request)
 
-			// Verify the response status and message (this indirectly tests that HandleAcceptQuoteError is working correctly)
+			// Verify the response status and message (this indirectly tests that HandleAuthenticatedAcceptQuoteError is working correctly)
 			assert.Equal(t, tc.expectedStatus, recorder.Code)
 
 			var errorResponse map[string]interface{}

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegout_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegout_quote.go
@@ -2,13 +2,10 @@ package handlers
 
 import (
 	"context"
-	"errors"
-	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"net/http"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
-	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/pkg"
 )
 
@@ -39,25 +36,8 @@ func NewAcceptPegoutQuoteHandler(useCase AcceptPegoutQuoteUseCase) http.HandlerF
 		}
 
 		acceptedQuote, err := useCase.Run(req.Context(), acceptRequest.QuoteHash, "")
-		if errors.Is(err, usecases.QuoteNotFoundError) {
-			jsonErr := rest.NewErrorResponseWithDetails("invalid quote hash", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusNotFound, jsonErr)
-			return
-		} else if errors.Is(err, usecases.ExpiredQuoteError) {
-			jsonErr := rest.NewErrorResponseWithDetails("expired quote", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusGone, jsonErr)
-			return
-		} else if errors.Is(err, usecases.NoLiquidityError) {
-			jsonErr := rest.NewErrorResponseWithDetails("not enough liquidity", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
-			return
-		} else if errors.Is(err, blockchain.ContractPausedError) {
-			jsonErr := rest.NewErrorResponseWithDetails("protocol is paused", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusServiceUnavailable, jsonErr)
-			return
-		} else if err != nil {
-			jsonErr := rest.NewErrorResponseWithDetails(UnknownErrorMessage, rest.DetailsFromError(err), false)
-			rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
+		if err != nil {
+			HandleAcceptQuoteError(w, err)
 			return
 		}
 

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegout_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegout_quote.go
@@ -37,7 +37,7 @@ func NewAcceptPegoutQuoteHandler(useCase AcceptPegoutQuoteUseCase) http.HandlerF
 
 		acceptedQuote, err := useCase.Run(req.Context(), acceptRequest.QuoteHash, "")
 		if err != nil {
-			HandleAcceptQuoteError(w, err)
+			handleCommonAcceptQuoteError(w, err)
 			return
 		}
 

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegout_quote_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegout_quote_test.go
@@ -270,7 +270,7 @@ func TestAcceptPegoutQuoteHandlerErrorCases(t *testing.T) {
 		assert.Equal(t, "not enough liquidity", errorResponse["message"])
 	})
 
-	t.Run("should return 409 when locking cap exceeded", func(t *testing.T) {
+	t.Run("should return 500 when locking cap exceeded on public endpoint", func(t *testing.T) {
 		quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 
 		reqBody := pkg.AcceptQuoteRequest{
@@ -291,7 +291,7 @@ func TestAcceptPegoutQuoteHandlerErrorCases(t *testing.T) {
 
 		handler.ServeHTTP(recorder, request)
 
-		assert.Equal(t, http.StatusConflict, recorder.Code)
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
 
 		mockUseCase.AssertExpectations(t)
 
@@ -299,10 +299,10 @@ func TestAcceptPegoutQuoteHandlerErrorCases(t *testing.T) {
 		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
 		require.NoError(t, err)
 		assert.Contains(t, errorResponse, "message")
-		assert.Equal(t, "locking cap exceeded", errorResponse["message"])
+		assert.Equal(t, handlers.UnknownErrorMessage, errorResponse["message"])
 	})
 
-	t.Run("should return 500 when trusted account is tampered", func(t *testing.T) {
+	t.Run("should return 500 when trusted account is tampered on public endpoint", func(t *testing.T) {
 		quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 
 		reqBody := pkg.AcceptQuoteRequest{
@@ -331,7 +331,7 @@ func TestAcceptPegoutQuoteHandlerErrorCases(t *testing.T) {
 		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
 		require.NoError(t, err)
 		assert.Contains(t, errorResponse, "message")
-		assert.Equal(t, "error fetching trusted account", errorResponse["message"])
+		assert.Equal(t, handlers.UnknownErrorMessage, errorResponse["message"])
 	})
 
 	t.Run("should return 200 with already accepted quote", func(t *testing.T) {

--- a/internal/adapters/entrypoints/rest/handlers/accept_pegout_quote_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/accept_pegout_quote_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest/handlers"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/quote"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/pkg"
@@ -202,7 +203,7 @@ func TestAcceptPegoutQuoteHandlerErrorCases(t *testing.T) {
 		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
 		require.NoError(t, err)
 		assert.Contains(t, errorResponse, "message")
-		assert.Equal(t, "invalid quote hash", errorResponse["message"])
+		assert.Equal(t, "quote not found", errorResponse["message"])
 	})
 
 	t.Run("should return 410 when quote is expired", func(t *testing.T) {
@@ -267,6 +268,70 @@ func TestAcceptPegoutQuoteHandlerErrorCases(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, errorResponse, "message")
 		assert.Equal(t, "not enough liquidity", errorResponse["message"])
+	})
+
+	t.Run("should return 409 when locking cap exceeded", func(t *testing.T) {
+		quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+		reqBody := pkg.AcceptQuoteRequest{
+			QuoteHash: quoteHash,
+		}
+		jsonBody, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/pegout/acceptQuote", bytes.NewBuffer(jsonBody))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+		mockUseCase.On("Run", mock.Anything, quoteHash, "").Return(quote.AcceptedQuote{}, usecases.LockingCapExceededError)
+
+		handlerFunc := handlers.NewAcceptPegoutQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusConflict, recorder.Code)
+
+		mockUseCase.AssertExpectations(t)
+
+		var errorResponse map[string]interface{}
+		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Contains(t, errorResponse, "message")
+		assert.Equal(t, "locking cap exceeded", errorResponse["message"])
+	})
+
+	t.Run("should return 500 when trusted account is tampered", func(t *testing.T) {
+		quoteHash := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+		reqBody := pkg.AcceptQuoteRequest{
+			QuoteHash: quoteHash,
+		}
+		jsonBody, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/pegout/acceptQuote", bytes.NewBuffer(jsonBody))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.AcceptQuoteUseCaseMock)
+		mockUseCase.On("Run", mock.Anything, quoteHash, "").Return(quote.AcceptedQuote{}, liquidity_provider.TamperedTrustedAccountError)
+
+		handlerFunc := handlers.NewAcceptPegoutQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+
+		mockUseCase.AssertExpectations(t)
+
+		var errorResponse map[string]interface{}
+		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Contains(t, errorResponse, "message")
+		assert.Equal(t, "error fetching trusted account", errorResponse["message"])
 	})
 
 	t.Run("should return 200 with already accepted quote", func(t *testing.T) {

--- a/internal/adapters/entrypoints/rest/handlers/common.go
+++ b/internal/adapters/entrypoints/rest/handlers/common.go
@@ -2,18 +2,30 @@ package handlers
 
 import (
 	"errors"
-	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"net/http"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
-	"github.com/rsksmart/liquidity-provider-server/internal/usecases/pegin"
 )
 
 const UnknownErrorMessage = "unknown error"
 
-func HandleAcceptQuoteError(w http.ResponseWriter, err error) {
+func HandleAuthenticatedAcceptQuoteError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, usecases.LockingCapExceededError):
+		jsonErr := rest.NewErrorResponseWithDetails("locking cap exceeded", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
+	case errors.Is(err, liquidity_provider.TamperedTrustedAccountError):
+		jsonErr := rest.NewErrorResponseWithDetails("error fetching trusted account", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
+	default:
+		handleCommonAcceptQuoteError(w, err)
+	}
+}
+
+func handleCommonAcceptQuoteError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, usecases.QuoteNotFoundError):
 		jsonErr := rest.NewErrorResponseWithDetails("quote not found", rest.DetailsFromError(err), true)
@@ -24,12 +36,6 @@ func HandleAcceptQuoteError(w http.ResponseWriter, err error) {
 	case errors.Is(err, usecases.NoLiquidityError):
 		jsonErr := rest.NewErrorResponseWithDetails("not enough liquidity", rest.DetailsFromError(err), true)
 		rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
-	case errors.Is(err, usecases.LockingCapExceededError):
-		jsonErr := rest.NewErrorResponseWithDetails("locking cap exceeded", rest.DetailsFromError(err), true)
-		rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
-	case errors.Is(err, liquidity_provider.TamperedTrustedAccountError):
-		jsonErr := rest.NewErrorResponseWithDetails("error fetching trusted account", rest.DetailsFromError(err), true)
-		rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
 	case errors.Is(err, blockchain.ContractPausedError):
 		jsonErr := rest.NewErrorResponseWithDetails("protocol is paused", rest.DetailsFromError(err), true)
 		rest.JsonErrorResponse(w, http.StatusServiceUnavailable, jsonErr)
@@ -39,14 +45,11 @@ func HandleAcceptQuoteError(w http.ResponseWriter, err error) {
 	}
 }
 
-func HandleGetQuoteError(w http.ResponseWriter, err error) {
+func handleGetQuoteError(w http.ResponseWriter, err error) {
 	switch {
 	case isGetQuoteBadRequest(err):
 		jsonErr := rest.NewErrorResponseWithDetails("invalid request", rest.DetailsFromError(err), true)
 		rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
-	case errors.Is(err, usecases.NoLiquidityError):
-		jsonErr := rest.NewErrorResponseWithDetails("not enough liquidity", rest.DetailsFromError(err), true)
-		rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
 	case errors.Is(err, blockchain.ContractPausedError):
 		jsonErr := rest.NewErrorResponseWithDetails("protocol is paused", rest.DetailsFromError(err), true)
 		rest.JsonErrorResponse(w, http.StatusServiceUnavailable, jsonErr)
@@ -61,6 +64,5 @@ func isGetQuoteBadRequest(err error) bool {
 		errors.Is(err, blockchain.BtcAddressInvalidNetworkError) ||
 		errors.Is(err, usecases.RskAddressNotSupportedError) ||
 		errors.Is(err, usecases.TxBelowMinimumError) ||
-		errors.Is(err, pegin.DataCapExceededError) ||
 		errors.Is(err, liquidity_provider.AmountOutOfRangeError)
 }

--- a/internal/adapters/entrypoints/rest/handlers/common.go
+++ b/internal/adapters/entrypoints/rest/handlers/common.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases/pegin"
 )
 
 const UnknownErrorMessage = "unknown error"
@@ -36,4 +37,30 @@ func HandleAcceptQuoteError(w http.ResponseWriter, err error) {
 		jsonErr := rest.NewErrorResponseWithDetails(UnknownErrorMessage, rest.DetailsFromError(err), false)
 		rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
 	}
+}
+
+func HandleGetQuoteError(w http.ResponseWriter, err error) {
+	switch {
+	case isGetQuoteBadRequest(err):
+		jsonErr := rest.NewErrorResponseWithDetails("invalid request", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
+	case errors.Is(err, usecases.NoLiquidityError):
+		jsonErr := rest.NewErrorResponseWithDetails("not enough liquidity", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
+	case errors.Is(err, blockchain.ContractPausedError):
+		jsonErr := rest.NewErrorResponseWithDetails("protocol is paused", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusServiceUnavailable, jsonErr)
+	default:
+		jsonErr := rest.NewErrorResponseWithDetails(UnknownErrorMessage, rest.DetailsFromError(err), false)
+		rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
+	}
+}
+
+func isGetQuoteBadRequest(err error) bool {
+	return errors.Is(err, blockchain.BtcAddressNotSupportedError) ||
+		errors.Is(err, blockchain.BtcAddressInvalidNetworkError) ||
+		errors.Is(err, usecases.RskAddressNotSupportedError) ||
+		errors.Is(err, usecases.TxBelowMinimumError) ||
+		errors.Is(err, pegin.DataCapExceededError) ||
+		errors.Is(err, liquidity_provider.AmountOutOfRangeError)
 }

--- a/internal/adapters/entrypoints/rest/handlers/common_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/common_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest/handlers"
+	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases/pegin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -146,5 +148,101 @@ func TestHandleAcceptQuoteError(t *testing.T) {
 		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
 		require.NoError(t, err)
 		assert.NotZero(t, errorResponse.Timestamp)
+	})
+}
+
+// nolint:funlen
+func TestHandleGetQuoteError(t *testing.T) {
+	badRequestErrors := []struct {
+		name string
+		err  error
+	}{
+		{name: "BtcAddressNotSupportedError", err: blockchain.BtcAddressNotSupportedError},
+		{name: "BtcAddressInvalidNetworkError", err: blockchain.BtcAddressInvalidNetworkError},
+		{name: "RskAddressNotSupportedError", err: usecases.RskAddressNotSupportedError},
+		{name: "TxBelowMinimumError", err: usecases.TxBelowMinimumError},
+		{name: "DataCapExceededError", err: pegin.DataCapExceededError},
+		{name: "AmountOutOfRangeError", err: liquidity_provider.AmountOutOfRangeError},
+	}
+	for _, testCase := range badRequestErrors {
+		t.Run("should return 400 on "+testCase.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+
+			handlers.HandleGetQuoteError(recorder, testCase.err)
+
+			assert.Equal(t, 400, recorder.Code)
+
+			var errorResponse rest.ErrorResponse
+			err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+			require.NoError(t, err)
+			assert.Equal(t, "invalid request", errorResponse.Message)
+			assert.True(t, errorResponse.Recoverable)
+			assert.Contains(t, errorResponse.Details, "error")
+			assert.Equal(t, testCase.err.Error(), errorResponse.Details["error"])
+		})
+	}
+
+	t.Run("should return 409 when not enough liquidity", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		handlers.HandleGetQuoteError(recorder, usecases.NoLiquidityError)
+
+		assert.Equal(t, 409, recorder.Code)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, "not enough liquidity", errorResponse.Message)
+		assert.True(t, errorResponse.Recoverable)
+		assert.Contains(t, errorResponse.Details, "error")
+		assert.Equal(t, usecases.NoLiquidityError.Error(), errorResponse.Details["error"])
+	})
+
+	t.Run("should return 503 when contract is paused", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		handlers.HandleGetQuoteError(recorder, blockchain.ContractPausedError)
+
+		assert.Equal(t, 503, recorder.Code)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, "protocol is paused", errorResponse.Message)
+		assert.True(t, errorResponse.Recoverable)
+		assert.Contains(t, errorResponse.Details, "error")
+		assert.Equal(t, blockchain.ContractPausedError.Error(), errorResponse.Details["error"])
+	})
+
+	t.Run("should return 500 with unknown error message for unexpected errors", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		unexpectedError := errors.New("unexpected database connection error")
+
+		handlers.HandleGetQuoteError(recorder, unexpectedError)
+
+		assert.Equal(t, 500, recorder.Code)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, handlers.UnknownErrorMessage, errorResponse.Message)
+		assert.False(t, errorResponse.Recoverable)
+		assert.Contains(t, errorResponse.Details, "error")
+		assert.Equal(t, unexpectedError.Error(), errorResponse.Details["error"])
+	})
+
+	t.Run("should handle wrapped errors correctly", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		wrappedError := usecases.WrapUseCaseError(usecases.GetPegoutQuoteId, usecases.NoLiquidityError)
+
+		handlers.HandleGetQuoteError(recorder, wrappedError)
+
+		assert.Equal(t, 409, recorder.Code)
+
+		var errorResponse rest.ErrorResponse
+		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, "not enough liquidity", errorResponse.Message)
+		assert.True(t, errorResponse.Recoverable)
 	})
 }

--- a/internal/adapters/entrypoints/rest/handlers/common_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/common_test.go
@@ -8,20 +8,18 @@ import (
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest/handlers"
-	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
-	"github.com/rsksmart/liquidity-provider-server/internal/usecases/pegin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // nolint:funlen
-func TestHandleAcceptQuoteError(t *testing.T) {
+func TestHandleAuthenticatedAcceptQuoteError(t *testing.T) {
 	t.Run("should return 404 when quote not found", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 
-		handlers.HandleAcceptQuoteError(recorder, usecases.QuoteNotFoundError)
+		handlers.HandleAuthenticatedAcceptQuoteError(recorder, usecases.QuoteNotFoundError)
 
 		assert.Equal(t, 404, recorder.Code)
 
@@ -37,7 +35,7 @@ func TestHandleAcceptQuoteError(t *testing.T) {
 	t.Run("should return 410 when quote is expired", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 
-		handlers.HandleAcceptQuoteError(recorder, usecases.ExpiredQuoteError)
+		handlers.HandleAuthenticatedAcceptQuoteError(recorder, usecases.ExpiredQuoteError)
 
 		assert.Equal(t, 410, recorder.Code)
 
@@ -53,7 +51,7 @@ func TestHandleAcceptQuoteError(t *testing.T) {
 	t.Run("should return 409 when not enough liquidity", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 
-		handlers.HandleAcceptQuoteError(recorder, usecases.NoLiquidityError)
+		handlers.HandleAuthenticatedAcceptQuoteError(recorder, usecases.NoLiquidityError)
 
 		assert.Equal(t, 409, recorder.Code)
 
@@ -69,7 +67,7 @@ func TestHandleAcceptQuoteError(t *testing.T) {
 	t.Run("should return 409 when locking cap exceeded", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 
-		handlers.HandleAcceptQuoteError(recorder, usecases.LockingCapExceededError)
+		handlers.HandleAuthenticatedAcceptQuoteError(recorder, usecases.LockingCapExceededError)
 
 		assert.Equal(t, 409, recorder.Code)
 
@@ -85,7 +83,7 @@ func TestHandleAcceptQuoteError(t *testing.T) {
 	t.Run("should return 500 when tampered trusted account error", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 
-		handlers.HandleAcceptQuoteError(recorder, liquidity_provider.TamperedTrustedAccountError)
+		handlers.HandleAuthenticatedAcceptQuoteError(recorder, liquidity_provider.TamperedTrustedAccountError)
 
 		assert.Equal(t, 500, recorder.Code)
 
@@ -102,7 +100,7 @@ func TestHandleAcceptQuoteError(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		unexpectedError := errors.New("unexpected database connection error")
 
-		handlers.HandleAcceptQuoteError(recorder, unexpectedError)
+		handlers.HandleAuthenticatedAcceptQuoteError(recorder, unexpectedError)
 
 		assert.Equal(t, 500, recorder.Code)
 
@@ -119,7 +117,7 @@ func TestHandleAcceptQuoteError(t *testing.T) {
 		recorder := httptest.NewRecorder()
 		wrappedError := usecases.WrapUseCaseError(usecases.AcceptPeginQuoteId, usecases.ExpiredQuoteError)
 
-		handlers.HandleAcceptQuoteError(recorder, wrappedError)
+		handlers.HandleAuthenticatedAcceptQuoteError(recorder, wrappedError)
 
 		assert.Equal(t, 410, recorder.Code)
 
@@ -134,7 +132,7 @@ func TestHandleAcceptQuoteError(t *testing.T) {
 	t.Run("should set correct content type header", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 
-		handlers.HandleAcceptQuoteError(recorder, usecases.QuoteNotFoundError)
+		handlers.HandleAuthenticatedAcceptQuoteError(recorder, usecases.QuoteNotFoundError)
 
 		assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
 	})
@@ -142,107 +140,11 @@ func TestHandleAcceptQuoteError(t *testing.T) {
 	t.Run("should include timestamp in error response", func(t *testing.T) {
 		recorder := httptest.NewRecorder()
 
-		handlers.HandleAcceptQuoteError(recorder, usecases.QuoteNotFoundError)
+		handlers.HandleAuthenticatedAcceptQuoteError(recorder, usecases.QuoteNotFoundError)
 
 		var errorResponse rest.ErrorResponse
 		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
 		require.NoError(t, err)
 		assert.NotZero(t, errorResponse.Timestamp)
-	})
-}
-
-// nolint:funlen
-func TestHandleGetQuoteError(t *testing.T) {
-	badRequestErrors := []struct {
-		name string
-		err  error
-	}{
-		{name: "BtcAddressNotSupportedError", err: blockchain.BtcAddressNotSupportedError},
-		{name: "BtcAddressInvalidNetworkError", err: blockchain.BtcAddressInvalidNetworkError},
-		{name: "RskAddressNotSupportedError", err: usecases.RskAddressNotSupportedError},
-		{name: "TxBelowMinimumError", err: usecases.TxBelowMinimumError},
-		{name: "DataCapExceededError", err: pegin.DataCapExceededError},
-		{name: "AmountOutOfRangeError", err: liquidity_provider.AmountOutOfRangeError},
-	}
-	for _, testCase := range badRequestErrors {
-		t.Run("should return 400 on "+testCase.name, func(t *testing.T) {
-			recorder := httptest.NewRecorder()
-
-			handlers.HandleGetQuoteError(recorder, testCase.err)
-
-			assert.Equal(t, 400, recorder.Code)
-
-			var errorResponse rest.ErrorResponse
-			err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
-			require.NoError(t, err)
-			assert.Equal(t, "invalid request", errorResponse.Message)
-			assert.True(t, errorResponse.Recoverable)
-			assert.Contains(t, errorResponse.Details, "error")
-			assert.Equal(t, testCase.err.Error(), errorResponse.Details["error"])
-		})
-	}
-
-	t.Run("should return 409 when not enough liquidity", func(t *testing.T) {
-		recorder := httptest.NewRecorder()
-
-		handlers.HandleGetQuoteError(recorder, usecases.NoLiquidityError)
-
-		assert.Equal(t, 409, recorder.Code)
-
-		var errorResponse rest.ErrorResponse
-		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
-		require.NoError(t, err)
-		assert.Equal(t, "not enough liquidity", errorResponse.Message)
-		assert.True(t, errorResponse.Recoverable)
-		assert.Contains(t, errorResponse.Details, "error")
-		assert.Equal(t, usecases.NoLiquidityError.Error(), errorResponse.Details["error"])
-	})
-
-	t.Run("should return 503 when contract is paused", func(t *testing.T) {
-		recorder := httptest.NewRecorder()
-
-		handlers.HandleGetQuoteError(recorder, blockchain.ContractPausedError)
-
-		assert.Equal(t, 503, recorder.Code)
-
-		var errorResponse rest.ErrorResponse
-		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
-		require.NoError(t, err)
-		assert.Equal(t, "protocol is paused", errorResponse.Message)
-		assert.True(t, errorResponse.Recoverable)
-		assert.Contains(t, errorResponse.Details, "error")
-		assert.Equal(t, blockchain.ContractPausedError.Error(), errorResponse.Details["error"])
-	})
-
-	t.Run("should return 500 with unknown error message for unexpected errors", func(t *testing.T) {
-		recorder := httptest.NewRecorder()
-		unexpectedError := errors.New("unexpected database connection error")
-
-		handlers.HandleGetQuoteError(recorder, unexpectedError)
-
-		assert.Equal(t, 500, recorder.Code)
-
-		var errorResponse rest.ErrorResponse
-		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
-		require.NoError(t, err)
-		assert.Equal(t, handlers.UnknownErrorMessage, errorResponse.Message)
-		assert.False(t, errorResponse.Recoverable)
-		assert.Contains(t, errorResponse.Details, "error")
-		assert.Equal(t, unexpectedError.Error(), errorResponse.Details["error"])
-	})
-
-	t.Run("should handle wrapped errors correctly", func(t *testing.T) {
-		recorder := httptest.NewRecorder()
-		wrappedError := usecases.WrapUseCaseError(usecases.GetPegoutQuoteId, usecases.NoLiquidityError)
-
-		handlers.HandleGetQuoteError(recorder, wrappedError)
-
-		assert.Equal(t, 409, recorder.Code)
-
-		var errorResponse rest.ErrorResponse
-		err := json.NewDecoder(recorder.Body).Decode(&errorResponse)
-		require.NoError(t, err)
-		assert.Equal(t, "not enough liquidity", errorResponse.Message)
-		assert.True(t, errorResponse.Recoverable)
 	})
 }

--- a/internal/adapters/entrypoints/rest/handlers/get_pegin_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/get_pegin_quote.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
@@ -48,7 +49,7 @@ func NewGetPeginQuoteHandler(useCase GetPeginQuoteUseCase) http.HandlerFunc {
 
 		result, err = useCase.Run(req.Context(), peginRequest)
 		if err != nil {
-			HandleGetQuoteError(w, err)
+			handleGetPeginQuoteError(w, err)
 			return
 		}
 		quoteDto := pkg.ToPeginQuoteDTO(result.PeginQuote)
@@ -57,5 +58,15 @@ func NewGetPeginQuoteHandler(useCase GetPeginQuoteUseCase) http.HandlerFunc {
 			QuoteHash: result.Hash,
 		}} // to keep compatibility with legacy API
 		rest.JsonResponseWithBody(w, http.StatusOK, &responseBody)
+	}
+}
+
+func handleGetPeginQuoteError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, pegin.DataCapExceededError):
+		jsonErr := rest.NewErrorResponseWithDetails("invalid request", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
+	default:
+		handleGetQuoteError(w, err)
 	}
 }

--- a/internal/adapters/entrypoints/rest/handlers/get_pegin_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/get_pegin_quote.go
@@ -2,14 +2,11 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
-	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
-	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases/pegin"
 	"github.com/rsksmart/liquidity-provider-server/pkg"
 )
@@ -50,17 +47,8 @@ func NewGetPeginQuoteHandler(useCase GetPeginQuoteUseCase) http.HandlerFunc {
 		)
 
 		result, err = useCase.Run(req.Context(), peginRequest)
-		if isGetPeginQuoteBadRequest(err) {
-			jsonErr := rest.NewErrorResponseWithDetails("invalid request", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
-			return
-		} else if errors.Is(err, blockchain.ContractPausedError) {
-			jsonErr := rest.NewErrorResponseWithDetails("protocol is paused", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusServiceUnavailable, jsonErr)
-			return
-		} else if err != nil {
-			jsonErr := rest.NewErrorResponseWithDetails(UnknownErrorMessage, rest.DetailsFromError(err), false)
-			rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
+		if err != nil {
+			HandleGetQuoteError(w, err)
 			return
 		}
 		quoteDto := pkg.ToPeginQuoteDTO(result.PeginQuote)
@@ -70,13 +58,4 @@ func NewGetPeginQuoteHandler(useCase GetPeginQuoteUseCase) http.HandlerFunc {
 		}} // to keep compatibility with legacy API
 		rest.JsonResponseWithBody(w, http.StatusOK, &responseBody)
 	}
-}
-
-func isGetPeginQuoteBadRequest(err error) bool {
-	return errors.Is(err, blockchain.BtcAddressNotSupportedError) ||
-		errors.Is(err, blockchain.BtcAddressInvalidNetworkError) ||
-		errors.Is(err, usecases.RskAddressNotSupportedError) ||
-		errors.Is(err, usecases.TxBelowMinimumError) ||
-		errors.Is(err, pegin.DataCapExceededError) ||
-		errors.Is(err, liquidity_provider.AmountOutOfRangeError)
 }

--- a/internal/adapters/entrypoints/rest/handlers/get_pegout_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/get_pegout_quote.go
@@ -2,14 +2,10 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
-	"github.com/rsksmart/liquidity-provider-server/internal/entities/blockchain"
-	"github.com/rsksmart/liquidity-provider-server/internal/entities/liquidity_provider"
-	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases/pegout"
 	"github.com/rsksmart/liquidity-provider-server/pkg"
 )
@@ -42,21 +38,8 @@ func NewGetPegoutQuoteHandler(useCase GetPegoutQuoteUseCase) http.HandlerFunc {
 		)
 
 		result, err = useCase.Run(req.Context(), pegoutRequest)
-		if isGetPegoutQuoteBadRequest(err) {
-			jsonErr := rest.NewErrorResponseWithDetails("invalid request", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusBadRequest, jsonErr)
-			return
-		} else if errors.Is(err, usecases.NoLiquidityError) {
-			jsonErr := rest.NewErrorResponseWithDetails("no enough liquidity", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
-			return
-		} else if errors.Is(err, blockchain.ContractPausedError) {
-			jsonErr := rest.NewErrorResponseWithDetails("protocol is paused", rest.DetailsFromError(err), true)
-			rest.JsonErrorResponse(w, http.StatusServiceUnavailable, jsonErr)
-			return
-		} else if err != nil {
-			jsonErr := rest.NewErrorResponseWithDetails(UnknownErrorMessage, rest.DetailsFromError(err), false)
-			rest.JsonErrorResponse(w, http.StatusInternalServerError, jsonErr)
+		if err != nil {
+			HandleGetQuoteError(w, err)
 			return
 		}
 		quoteDto := pkg.ToPegoutQuoteDTO(result.PegoutQuote)
@@ -66,12 +49,4 @@ func NewGetPegoutQuoteHandler(useCase GetPegoutQuoteUseCase) http.HandlerFunc {
 		}} // to keep compatibility with legacy API
 		rest.JsonResponseWithBody(w, http.StatusOK, &responseBody)
 	}
-}
-
-func isGetPegoutQuoteBadRequest(err error) bool {
-	return errors.Is(err, blockchain.BtcAddressNotSupportedError) ||
-		errors.Is(err, blockchain.BtcAddressInvalidNetworkError) ||
-		errors.Is(err, usecases.RskAddressNotSupportedError) ||
-		errors.Is(err, usecases.TxBelowMinimumError) ||
-		errors.Is(err, liquidity_provider.AmountOutOfRangeError)
 }

--- a/internal/adapters/entrypoints/rest/handlers/get_pegout_quote.go
+++ b/internal/adapters/entrypoints/rest/handlers/get_pegout_quote.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/rsksmart/liquidity-provider-server/internal/adapters/entrypoints/rest"
 	"github.com/rsksmart/liquidity-provider-server/internal/entities"
+	"github.com/rsksmart/liquidity-provider-server/internal/usecases"
 	"github.com/rsksmart/liquidity-provider-server/internal/usecases/pegout"
 	"github.com/rsksmart/liquidity-provider-server/pkg"
 )
@@ -39,7 +41,7 @@ func NewGetPegoutQuoteHandler(useCase GetPegoutQuoteUseCase) http.HandlerFunc {
 
 		result, err = useCase.Run(req.Context(), pegoutRequest)
 		if err != nil {
-			HandleGetQuoteError(w, err)
+			handleGetPegoutQuoteError(w, err)
 			return
 		}
 		quoteDto := pkg.ToPegoutQuoteDTO(result.PegoutQuote)
@@ -48,5 +50,15 @@ func NewGetPegoutQuoteHandler(useCase GetPegoutQuoteUseCase) http.HandlerFunc {
 			QuoteHash: result.Hash,
 		}} // to keep compatibility with legacy API
 		rest.JsonResponseWithBody(w, http.StatusOK, &responseBody)
+	}
+}
+
+func handleGetPegoutQuoteError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, usecases.NoLiquidityError):
+		jsonErr := rest.NewErrorResponseWithDetails("not enough liquidity", rest.DetailsFromError(err), true)
+		rest.JsonErrorResponse(w, http.StatusConflict, jsonErr)
+	default:
+		handleGetQuoteError(w, err)
 	}
 }

--- a/internal/adapters/entrypoints/rest/handlers/get_pegout_quote_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/get_pegout_quote_test.go
@@ -316,6 +316,34 @@ func TestGetPegoutQuoteHandlerErrorCases(t *testing.T) {
 		assert.Equal(t, "not enough liquidity", errorResponse["message"])
 	})
 
+	t.Run("should return 503 when contract is paused", func(t *testing.T) {
+		reqBody := createValidPegoutQuoteRequest()
+		jsonBody, err := json.Marshal(reqBody)
+		require.NoError(t, err)
+
+		request := httptest.NewRequest(http.MethodPost, "/pegout/getQuotes", bytes.NewBuffer(jsonBody))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+
+		mockUseCase := new(mocks.GetPegoutQuoteUseCaseMock)
+		mockUseCase.On("Run", mock.Anything, mock.AnythingOfType("pegout.QuoteRequest")).
+			Return(pegout.GetPegoutQuoteResult{}, blockchain.ContractPausedError)
+
+		handlerFunc := handlers.NewGetPegoutQuoteHandler(mockUseCase)
+		handler := http.HandlerFunc(handlerFunc)
+
+		handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+
+		mockUseCase.AssertExpectations(t)
+
+		var errorResponse map[string]interface{}
+		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
+		require.NoError(t, err)
+		assert.Equal(t, "protocol is paused", errorResponse["message"])
+	})
+
 	t.Run("should return 500 on unexpected errors", func(t *testing.T) {
 		reqBody := createValidPegoutQuoteRequest()
 		jsonBody, err := json.Marshal(reqBody)

--- a/internal/adapters/entrypoints/rest/handlers/get_pegout_quote_test.go
+++ b/internal/adapters/entrypoints/rest/handlers/get_pegout_quote_test.go
@@ -313,7 +313,7 @@ func TestGetPegoutQuoteHandlerErrorCases(t *testing.T) {
 		var errorResponse map[string]interface{}
 		err = json.NewDecoder(recorder.Body).Decode(&errorResponse)
 		require.NoError(t, err)
-		assert.Equal(t, "no enough liquidity", errorResponse["message"])
+		assert.Equal(t, "not enough liquidity", errorResponse["message"])
 	})
 
 	t.Run("should return 500 on unexpected errors", func(t *testing.T) {


### PR DESCRIPTION
## What
Routes all six quote handlers through shared error mappers instead of inline blocks: the four accept handlers use HandleAcceptQuoteError, the two get handlers use a new HandleGetQuoteError. Fixes four mapping bugs: LockingCap 500→409 and TamperedTrustedAccount message on plain accept; pegout not-found "invalid quote hash"→"quote not found"; get pegout "no enough"→"not enough liquidity".

## Why
Inline mapping let sibling handlers drift, so the same domain error returned different status/message per endpoint. Centralizing per flow makes every quote endpoint consistent and adding a new error type a one-line change.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change 
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] Security fix
- [ ] Deployment/Infrastructure changes

## Affected part of the project
- [x] Management UI / API
- [ ] PegIn flow
- [ ] PegOut flow
- [ ] Utility scripts
- [ ] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2321)

## How to test
With the regtest env running (LPS on `localhost:8080`):

**Accept — not found (both sides → 404 "quote not found"):**

```bash
H=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab
curl -s -X POST localhost:8080/pegin/acceptQuote  -H 'Content-Type: application/json' -d "{\"quoteHash\":\"$H\"}"
curl -s -X POST localhost:8080/pegout/acceptQuote -H 'Content-Type: application/json' -d "{\"quoteHash\":\"$H\"}"
```

Both return `404 quote not found` (pegout previously said "invalid quote hash").

**Get — bad request (both sides → 400 "invalid request"):**

```bash
A=0x1234567890123456789012345678901234567890
# pegin: amount out of range
curl -s -X POST localhost:8080/pegin/getQuote  -H 'Content-Type: application/json' \
  -d "{\"callEoaOrContractAddress\":\"$A\",\"callContractArguments\":\"\",\"valueToTransfer\":1,\"rskRefundAddress\":\"$A\"}"
# pegout: invalid BTC address
curl -s -X POST localhost:8080/pegout/getQuotes -H 'Content-Type: application/json' \
  -d "{\"to\":\"not-a-btc-address\",\"valueToTransfer\":700000000000000000,\"rskRefundAddress\":\"$A\"}"
```

Both return `400 invalid request`.

**Accept — expired (both sides → 410 "expired quote"):** create a quote, back-date it in Mongo, then accept.

```bash
A=0x1234567890123456789012345678901234567890
M='docker exec mongo01 mongosh --quiet -u root -p root --authenticationDatabase admin flyover'
# pegout
H=$(curl -s -X POST localhost:8080/pegout/getQuotes -H 'Content-Type: application/json' \
  -d "{\"to\":\"mvvptgNwUsB8BiMEwFR1r89qiS1LL4Sk8Q\",\"valueToTransfer\":710000000000000000,\"rskRefundAddress\":\"$A\"}" \
  | python3 -c 'import sys,json;print(json.load(sys.stdin)[0]["quoteHash"])')
$M --eval "db.pegoutQuote.updateOne({hash:'$H'},{\$set:{expire_date:1000000000}})"
curl -s -X POST localhost:8080/pegout/acceptQuote -H 'Content-Type: application/json' -d "{\"quoteHash\":\"$H\"}"  # → 410 expired quote
```

(Pegin equivalent: `getQuote` → `db.peginQuote.updateOne({hash},{$set:{time_for_deposit:1,agreement_timestamp:1000000000}})` → `pegin/acceptQuote` → `410`.)

**Not forceable in a funded regtest (covered by unit tests):**

- **no-liquidity** (409 "not enough liquidity") — LP covers the whole valid range; would require draining the LP wallet.
- **locking-cap** (409 "locking cap exceeded") — needs the bridge locking cap exceeded.

Run `go test ./internal/adapters/entrypoints/rest/handlers/...` to confirm both branches plus all mapper cases.


## Reviewer Guidelines
Special things to take into consideration during review


## Screenshots (if applicable)
Add screenshots or GIFs to help explain your changes.


## Additional Notes
Add any other context about the pull request here. 